### PR TITLE
test: cache tools installed via asdf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         key: asdf-${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
         restore-keys: |
           asdf-${{ runner.os }}-
-        path:
+        path: |
           ~/.asdf/plugins
           ~/.asdf/installs
     - name: Bootstrap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,15 @@ jobs:
       run: ln -s "$PWD" "$HOME/.dotfiles"
     - name: Print Homebrew configuration
       run: brew config
-    - run: brew install asdf
+    - name: Cache asdf installs
+      uses: actions/cache@v4
+      with:
+        key: asdf-${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
+        restore-keys: |
+          asdf-${{ runner.os }}-
+        path:
+          ~/.asdf/plugins
+          ~/.asdf/installs
     - name: Bootstrap
       run: ./scripts/bootstrap
       env:

--- a/asdf/install.sh
+++ b/asdf/install.sh
@@ -45,3 +45,6 @@ asdf plugin update --all
 
 # Install
 asdf install
+
+# Reshim in case any installs were restored from cache
+asdf reshim


### PR DESCRIPTION
Should speed up builds by persisting the plugins and installs. Ruby in particular is especially slow since it's built from source via `ruby-build` (see https://github.com/asdf-vm/asdf-ruby/issues/57), whereas `nodejs` and `golang` install prebuilds and are fast.

The plugins aren't strictly cacheable since there's no lockfile. But given that we're caching the things they install, might as well cache the plugins themselves too, given that their work should be short-circuited by a cache hit.