### PR TITLE
lint: Brewfiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,16 @@
 name: tests
 on: [push]
 jobs:
+  lint-brewfiles:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rubocop
+      run: gem install rubocop
+    - name: Lint Brewfiles
+      run: rubocop **/Brewfile
   bootstrap:
+    needs: lint-brewfiles
     strategy:
       matrix:
         os:


### PR DESCRIPTION
This pull request introduces a new CI job to lint Brewfiles using Rubocop before proceeding with the bootstrap process.

- **Adds a `lint-brewfiles` job** in the `.github/workflows/test.yml` file.
- Lints all Brewfiles in the repository using `rubocop **/Brewfile`.
- **Modifies the `bootstrap` job** to ensure it runs after the `lint-brewfiles` job has successfully completed, enhancing the CI pipeline by ensuring code quality checks are passed before the bootstrap process begins.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bendrucker/dotfiles?shareId=68da9c42-1286-4a1e-989a-0716b46ec590).