### PR TITLE
brew: only install `mas` on macOS

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -20,7 +20,7 @@ brew 'cloc'
 brew 'coreutils'
 brew 'csvkit'
 brew 'jq'
-brew 'mas'
+brew 'mas' if OS.mac?
 brew 'openssl'
 brew 'shellcheck'
 brew 'teamookla/speedtest/speedtest'


### PR DESCRIPTION
Fixes CI errors on Ubuntu:

https://github.com/bendrucker/dotfiles/actions/runs/15618240376/job/43996366760#step:8:52