### PR TITLE
mise: add Python 3.12 and uv

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,4 +1,6 @@
 [tools]
 go = "1.24.4"
 node = "lts"
+python = "3.12"
 terraform = "1.12.1"
+uv = "latest"


### PR DESCRIPTION
Add Python 3.12 and uv to mise tools configuration