### PR TITLE
fix: add GITHUB_TOKEN to mise workflow to avoid rate limiting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
           python
           python@3.11
           python@3.12
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   shellcheck:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Added `GITHUB_TOKEN` environment variable to the Bootstrap step in GitHub Actions workflow
- This resolves the GitHub API rate limiting issue when `mise` installs packages from GitHub releases

## Problem
The workflow was failing with:
```
mise WARN  GitHub rate limit exceeded. Resets at 2025-06-25 19:26:15
mise ERROR failed to install aqua:hashicorp/terraform@1.12.2
mise ERROR HTTP status client error (403 rate limit exceeded)
```

## Solution
`mise` automatically uses the `GITHUB_TOKEN` environment variable when available, providing authenticated requests with higher rate limits.

🤖 Generated with [Claude Code](https://claude.ai/code)