### PR TITLE
zsh: add .local/bin to PATH

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -4,7 +4,7 @@ if [[ -n "$ZPROF" ]]; then
   zmodload zsh/zprof
 fi
 
-export PATH="/usr/local/bin:/usr/local/sbin:$ZSH/bin:$PATH"
+export PATH="$HOME/.local/bin:/usr/local/bin:/usr/local/sbin:$ZSH/bin:$PATH"
 
 export ZSH="$HOME/.dotfiles"
 export PROJECTS="$HOME/src"


### PR DESCRIPTION
Claude Code wants `$HOME/.local/bin` in $PATH and auto-adds to ~/.zshrc if not found.

This consolidates the PATH export to the top of the file and uses `$HOME` instead of hardcoding the path.