### PR TITLE
claude: add SSH keychain wrapper for remote sessions

### DIFF
--- a/bin/with-ssh-keychain
+++ b/bin/with-ssh-keychain
@@ -1,0 +1,36 @@
+#!/bin/sh
+#/ Usage: with-ssh-keychain <command> [<args>...]
+#/ Run a command with macOS keychain unlocked.
+#/ Assumes this is being called from an SSH/Mosh session.
+set -e
+
+# Help text
+test "${1:-}" = "--help" && {
+  grep ^#/ <"$0" | cut -c4-
+  exit 2
+}
+
+# Check if we have a command to run
+if [ $# -eq 0 ]; then
+  echo "Usage: with-ssh-keychain <command> [<args>...]" >&2
+  exit 1
+fi
+
+# Ensure we're in an interactive terminal (not being piped)
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+  # Not interactive - refuse to run to avoid password prompt issues
+  exit 1
+fi
+
+# Check if keychain is already unlocked
+if ! security show-keychain-info ~/Library/Keychains/login.keychain-db >/dev/null 2>&1; then
+  # Keychain is locked, try to unlock it
+  if ! security unlock-keychain ~/Library/Keychains/login.keychain-db; then
+    # If unlock fails (user cancelled or wrong password), exit
+    exit 1
+  fi
+fi
+# If we get here, keychain is unlocked (either was already, or we just unlocked it)
+
+# Execute the command, replacing this process entirely
+exec "$@"

--- a/bin/with-ssh-keychain
+++ b/bin/with-ssh-keychain
@@ -16,15 +16,16 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-# Ensure we're in an interactive terminal (not being piped)
-if [ ! -t 0 ] || [ ! -t 1 ]; then
-  # Not interactive - refuse to run to avoid password prompt issues
-  exit 1
-fi
-
 # Check if keychain is already unlocked
 if ! security show-keychain-info ~/Library/Keychains/login.keychain-db >/dev/null 2>&1; then
-  # Keychain is locked, try to unlock it
+  # Keychain is locked - check if we're in an interactive terminal
+  if [ ! -t 0 ] || [ ! -t 1 ]; then
+    # Not interactive - can't prompt for password
+    echo "Error: Keychain is locked and terminal is not interactive. Cannot prompt for password." >&2
+    exit 1
+  fi
+  
+  # Try to unlock it
   if ! security unlock-keychain ~/Library/Keychains/login.keychain-db; then
     # If unlock fails (user cancelled or wrong password), exit
     exit 1

--- a/claude/aliases.zsh
+++ b/claude/aliases.zsh
@@ -6,8 +6,6 @@ source "$ZSH/ssh/functions.zsh"
 # Conditionally wrap claude with keychain unlock for SSH/Mosh sessions
 if is_remote_session; then
   alias claude='with-ssh-keychain claude'
-else
-  alias claude='claude'
 fi
 
 alias sonnet='claude --model sonnet'

--- a/claude/aliases.zsh
+++ b/claude/aliases.zsh
@@ -1,3 +1,13 @@
 #!/usr/bin/env zsh
 
+# Source SSH detection function
+source "$ZSH/ssh/functions.zsh"
+
+# Conditionally wrap claude with keychain unlock for SSH/Mosh sessions
+if is_remote_session; then
+  alias claude='with-ssh-keychain claude'
+else
+  alias claude='claude'
+fi
+
 alias sonnet='claude --model sonnet'

--- a/ssh/functions.zsh
+++ b/ssh/functions.zsh
@@ -1,0 +1,23 @@
+#!/usr/bin/env zsh
+
+# Check if we're in an SSH or Mosh session
+#
+# SSH environment variables (set by OpenSSH):
+# - SSH_CLIENT: client IP, client port, server port (space-separated)
+# - SSH_CONNECTION: client IP, client port, server IP, server port (space-separated)
+# - SSH_TTY: path to the tty device associated with the current session
+# See: https://linux.die.net/man/1/ssh
+#
+# Mosh detection:
+# - MOSH_SERVER environment variables are used for server configuration
+# - LC_IDENTIFICATION may contain mosh-related information in some configurations
+# - Mosh runs over SSH initially, so SSH variables may also be present
+# See: https://github.com/mobile-shell/mosh/issues/738
+is_remote_session() {
+  # SSH detection - any of these indicate an SSH session
+  [ -n "${SSH_CLIENT:-}" ] || [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_TTY:-}" ] || \
+  # Mosh detection - less standardized, but these are commonly present
+  [ -n "${MOSH:-}" ] || [ -n "${MOSH_SERVER:-}" ] || \
+  # Additional Mosh detection via locale variable
+  [[ "${LC_IDENTIFICATION:-}" == *mosh* ]]
+}

--- a/system/aliases.zsh
+++ b/system/aliases.zsh
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# Unlock the macOS login keychain
+alias unlock-keychain='security unlock-keychain ~/Library/Keychains/login.keychain-db'


### PR DESCRIPTION
Fixes Claude Code keychain access issues in SSH/Mosh sessions by prompting for keychain unlock when needed.

## Changes
- Add `unlock-keychain` alias for manual keychain unlocking
- Create `with-ssh-keychain` wrapper that unlocks keychain only when locked
- Add SSH/Mosh detection function with documented environment variables
- Conditionally wrap `claude` command in remote sessions only

Closes #154