### PR TITLE
ssh: require public key authentication

### DIFF
--- a/ssh/200-require-key-auth.conf
+++ b/ssh/200-require-key-auth.conf
@@ -3,4 +3,3 @@ PasswordAuthentication no
 PubkeyAuthentication yes
 AuthenticationMethods publickey
 ChallengeResponseAuthentication no
-UsePAM yes

--- a/ssh/200-require-key-auth.conf
+++ b/ssh/200-require-key-auth.conf
@@ -1,0 +1,6 @@
+# Require public key authentication and disable password authentication
+PasswordAuthentication no
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+ChallengeResponseAuthentication no
+UsePAM yes

--- a/ssh/install.sh
+++ b/ssh/install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Copy SSH daemon configuration to system directory
+sudo cp "$(dirname "$0")/200-require-key-auth.conf" /etc/ssh/sshd_config.d/
+
+# Reload SSH daemon
+sudo launchctl kickstart -k system/com.openssh.sshd
+
+echo "SSH configuration updated to require public key authentication"

--- a/ssh/install.sh
+++ b/ssh/install.sh
@@ -5,7 +5,11 @@ set -e
 # Copy SSH daemon configuration to system directory
 sudo cp "$(dirname "$0")/200-require-key-auth.conf" /etc/ssh/sshd_config.d/
 
-# Reload SSH daemon
-sudo launchctl kickstart -k system/com.openssh.sshd
+# Reload SSH daemon based on OS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sudo launchctl kickstart -k system/com.openssh.sshd
+else
+    sudo systemctl reload sshd
+fi
 
 echo "SSH configuration updated to require public key authentication"


### PR DESCRIPTION
Adds SSH daemon configuration to disable password authentication and require public key authentication only.

## Changes

- Adds `ssh/200-require-key-auth.conf` with SSH daemon security settings
- Adds `ssh/install.sh` script to apply configuration system-wide
- Disables `PasswordAuthentication` and `ChallengeResponseAuthentication`
- Requires `AuthenticationMethods publickey` only