### PR TITLE
corp: detect MDMs

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,7 +9,7 @@ if ENV['CI']
   end
 end
 
-corporate = File.exist?(File.join(__dir__, '.corporate'))
+corporate = Dir.exist?('/Library/Managed Preferences') && !Dir.empty?('/Library/Managed Preferences')
 
 cask_args appdir: '/Applications'
 


### PR DESCRIPTION
Rather than require `touch ~/.corporate` to mark a computer as corporate to skip personal-only apps, detect the presence of an MDM via its managed preferences.