### PR TITLE
claude-upgrade: force HTTPS for github.com

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -205,6 +205,12 @@ claude-upgrade
 }
 
 main() {
+  # Force HTTPS for github.com: SSH agents (Secretive, 1Password, etc.)
+  # can't sign while the Mac is locked, breaking unattended runs.
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0='url.https://github.com/.insteadOf'
+  export GIT_CONFIG_VALUE_0='git@github.com:'
+
   local output
   output=$(mktemp)
   # shellcheck disable=SC2064


### PR DESCRIPTION
Rewrites `github.com` URLs to HTTPS inside `claude-upgrade` via `GIT_CONFIG_*` env vars so the script fetches anonymously.

## Issue

SSH agents like Secretive and 1Password can't sign while the Mac is locked. Their keys live in the Secure Enclave with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, so signing fails regardless of whether the key requires Touch ID or just notifies. The nightly `com.user.claude-upgrade` launchd job was failing with `agent refused operation` every time the screen was locked.

## Changes

- Export `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` at the top of `main()` to inject `url.https://github.com/.insteadOf=git@github.com:` for all child `git` processes
- Scoped to the script's process only. `~/.claude-repo`'s remote is untouched, and interactive SSH keeps working normally
- Applies to `sync_repo`, `update_marketplaces`, and `update_plugins` since they all shell out to git against public repos that need no auth

## Testing

Ran `bin/claude-upgrade` with the Mac locked. Fetch went over HTTPS (`From https://github.com/bendrucker/claude`) and all 27 plugins updated successfully.
