### PR TITLE
worktrunk: migrate pre-start to pipeline form

### DIFF
--- a/worktrunk/config.toml
+++ b/worktrunk/config.toml
@@ -1,5 +1,7 @@
-[pre-start]
+[[pre-start]]
 claude-trust = "claude-trust-worktree '{{ primary_worktree_path }}' '{{ worktree_path }}'"
+
+[[pre-start]]
 claude-settings = "cp '{{ primary_worktree_path }}/.claude/settings.local.json' '{{ worktree_path }}/.claude/settings.local.json' 2>/dev/null || true"
 
 [post-switch]


### PR DESCRIPTION
Migrates `pre-start` hooks from the deprecated table form to the pipeline (array-of-tables) form. Worktrunk is unifying hook config so list form runs serially and table form runs in parallel; this preserves the current serial ordering before the table form is repurposed.
