### PR TITLE
copyq: install cask and add tmux history binding

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -34,6 +34,7 @@ cask 'adobe-creative-cloud' unless corporate
 cask 'android-file-transfer' unless corporate
 cask 'backblaze' unless corporate
 cask 'charles'
+cask 'copyq'
 cask 'disk-drill'
 cask 'dash'
 cask 'figma'

--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -14,5 +14,8 @@ bind w run-shell -b tmux-windows
 # Copy entire scrollback to system clipboard
 bind g run-shell tmux-grab-scrollback
 
+# Clipboard history via CopyQ
+bind C-y run-shell -b "/Applications/CopyQ.app/Contents/MacOS/CopyQ menu"
+
 # Linked session for independent window browsing in a second terminal
 bind X run-shell 'tmux new-session -d -t "#{session_name}" -s "#{session_name}-linked" 2>/dev/null; tmux switch-client -t "#{session_name}-linked"'


### PR DESCRIPTION
Installs CopyQ via Homebrew cask and adds a tmux keybinding to open its clipboard history menu.

## Changes

- Add `cask 'copyq'` to root `Brewfile`
- Bind `prefix + C-y` in `tmux/navigation/navigation.conf` to invoke `CopyQ menu`

Tmux selections already flow to the system pasteboard via `set-clipboard on` (OSC 52), which CopyQ monitors automatically, so no additional integration is needed.

## Testing

- [ ] `brew bundle` installs CopyQ
- [ ] Launch CopyQ and enable autostart in its preferences
- [ ] Copy text in a tmux copy-mode selection; confirm it appears in CopyQ history
- [ ] `prefix + C-y` opens the CopyQ menu
