### PR TITLE
tmux: restore direct session/window switch keys

### DIFF
--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -4,11 +4,11 @@ bind % split-window -h -c "#{pane_current_path}"
 
 # tmux-fzf (session/window/pane switcher)
 set -g @plugin 'sainnhe/tmux-fzf'
-set-environment -g TMUX_FZF_LAUNCH_KEY "t"
 set-environment -g TMUX_FZF_OPTIONS "-p -w 60% -h 60%"
 
-# Click session name to open tmux-fzf
-bind -n MouseUp1StatusLeft run-shell -b '$TMUX_PLUGIN_MANAGER_PATH/tmux-fzf/main.sh'
+# Prefix-t: switch session, Prefix-w: switch window (via tmux-fzf)
+bind t run-shell -b '$TMUX_PLUGIN_MANAGER_PATH/tmux-fzf/scripts/session.sh switch'
+bind w run-shell -b '$TMUX_PLUGIN_MANAGER_PATH/tmux-fzf/scripts/window.sh switch'
 
 # Copy entire scrollback to system clipboard
 bind g run-shell tmux-grab-scrollback


### PR DESCRIPTION
Restores `Prefix-t` and `Prefix-w` as direct session and window switchers using tmux-fzf's individual scripts instead of routing through the main menu. Removes the `MouseUp1StatusLeft` binding that was triggering tmux-fzf on accidental clicks. The full tmux-fzf menu falls back to the plugin default `Prefix-F`.
