### PR TITLE
claude-upgrade: also rewrite ssh:// github URLs to HTTPS

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -207,9 +207,11 @@ claude-upgrade
 main() {
   # Force HTTPS for github.com: SSH agents (Secretive, 1Password, etc.)
   # can't sign while the Mac is locked, breaking unattended runs.
-  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_COUNT=2
   export GIT_CONFIG_KEY_0='url.https://github.com/.insteadOf'
   export GIT_CONFIG_VALUE_0='git@github.com:'
+  export GIT_CONFIG_KEY_1='url.https://github.com/.insteadOf'
+  export GIT_CONFIG_VALUE_1='ssh://git@github.com/'
 
   local output
   output=$(mktemp)


### PR DESCRIPTION
Extends the HTTPS rewrite from #364 to also cover the explicit `ssh://git@github.com/` URL format. The previous `insteadOf` only matched the SCP-style `git@github.com:` URLs, so remotes using `ssh://` (like my MBP's `~/.claude-repo`) still attempted SSH and failed when the agent was locked.
