### PR TITLE
tmux: unset stale TMUX_FZF_LAUNCH_KEY from global env

### DIFF
--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -4,6 +4,7 @@ bind % split-window -h -c "#{pane_current_path}"
 
 # tmux-fzf (session/window/pane switcher)
 set -g @plugin 'sainnhe/tmux-fzf'
+set-environment -gu TMUX_FZF_LAUNCH_KEY
 set-environment -g TMUX_FZF_OPTIONS "-p -w 60% -h 60%"
 
 # Prefix-t: switch session, Prefix-w: switch window (via tmux-fzf)


### PR DESCRIPTION
Unsets the stale `TMUX_FZF_LAUNCH_KEY` from the tmux global environment so the plugin falls back to its default `Prefix-F`. Without this, the old `t` value persists across config reloads and the plugin's `main.tmux` clobbers our `Prefix-t` session switch binding.
