### PR TITLE
tmux: add smug

### DIFF
--- a/tmux/Brewfile
+++ b/tmux/Brewfile
@@ -1,1 +1,2 @@
 brew 'tmux'
+brew 'smug'


### PR DESCRIPTION
Adds [smug](https://github.com/ivaaaan/smug) so declarative tmux sessions can be authored locally in `~/.config/smug/`. No session files are tracked here: they're coupled to personal repo layout and better kept out of the dotfiles repo.

## Changes

- `tmux/Brewfile`: add `brew 'smug'`
