### PR TITLE
terminal: add yazi file manager

### DIFF
--- a/terminal/Brewfile
+++ b/terminal/Brewfile
@@ -1,3 +1,4 @@
 cask 'iterm2'
 brew 'shellspec'
+brew 'yazi'
 brew 'zoxide'

--- a/terminal/symlinks.conf
+++ b/terminal/symlinks.conf
@@ -1,2 +1,3 @@
 ghostty.config:$XDG_CONFIG_HOME/ghostty/config
 mise.toml:$XDG_CONFIG_HOME/mise/conf.d/terminal.toml
+yazi.toml:$XDG_CONFIG_HOME/yazi/yazi.toml


### PR DESCRIPTION
Install yazi via Homebrew and symlink an empty `terminal/yazi.toml` to `~/.config/yazi/yazi.toml` as a starting point for future config.