### PR TITLE
tmux: add F12 toggle for nested sessions

### DIFF
--- a/tmux/core/core.conf
+++ b/tmux/core/core.conf
@@ -23,3 +23,16 @@ set -g focus-events on                     # apps detect pane/window focus chang
 
 # Only break words on spaces and @ so double-click selects full URLs and ticket IDs
 setw -g word-separators ' @'
+
+# F12 suspends the outer prefix so inner (SSH'd) tmux can take keys.
+# Status bar dims while suspended so you know which tmux is listening.
+bind -T root F12 \
+  set prefix None \;\
+  set key-table off \;\
+  set status-style "fg=#{@thm_overlay_0},bg=#{@thm_mantle}" \;\
+  refresh-client -S
+bind -T off F12 \
+  set -u prefix \;\
+  set -u key-table \;\
+  set -u status-style \;\
+  refresh-client -S


### PR DESCRIPTION
Adds an F12 toggle that suspends the outer tmux prefix so a nested (SSH'd) tmux can take keys. The status bar dims while suspended so it's clear which tmux is listening.

## Changes

- `tmux/core/core.conf`: bind `F12` in the `root` and `off` key tables to flip `prefix`, `key-table`, and `status-style`

## Testing

- [ ] SSH into a host running tmux, attach, press `F12`; keys pass to the inner tmux and the outer status dims
- [ ] Press `F12` again — outer tmux resumes, status restores
- [ ] Detach/reattach — state is per-client (other clients unaffected)
