### PR TITLE
tmux: add tmux-fingers for hint-based copy

### DIFF
--- a/tmux/Brewfile
+++ b/tmux/Brewfile
@@ -1,3 +1,3 @@
 brew 'tmux'
 brew 'smug'
-brew 'fcsonline/tmux-thumbs/tmux-thumbs'
+brew 'morantron/tmux-fingers/tmux-fingers'

--- a/tmux/Brewfile
+++ b/tmux/Brewfile
@@ -1,2 +1,3 @@
 brew 'tmux'
 brew 'smug'
+brew 'fcsonline/tmux-thumbs/tmux-thumbs'

--- a/tmux/search/search.conf
+++ b/tmux/search/search.conf
@@ -7,7 +7,5 @@ set -g @fuzzback-popup 1
 set -g @fuzzback-popup-size '80%'
 
 # Hint-based copy — prefix F overlays labels on visible tokens.
-set -g @plugin 'fcsonline/tmux-thumbs'
-set -g @thumbs-key F
-set -g @thumbs-command 'printf "%s" {} | pbcopy'
-set -g @thumbs-upcase-command 'printf "%s" {} | pbcopy && tmux display-message "copied"'
+set -g @plugin 'Morantron/tmux-fingers'
+set -g @fingers-key F

--- a/tmux/search/search.conf
+++ b/tmux/search/search.conf
@@ -5,3 +5,9 @@ set -g @plugin 'alberti42/tmux-fzf-links'
 set -g @plugin 'roosta/tmux-fuzzback'
 set -g @fuzzback-popup 1
 set -g @fuzzback-popup-size '80%'
+
+# Hint-based copy — prefix F overlays labels on visible tokens.
+set -g @plugin 'fcsonline/tmux-thumbs'
+set -g @thumbs-key F
+set -g @thumbs-command 'printf "%s" {} | pbcopy'
+set -g @thumbs-upcase-command 'printf "%s" {} | pbcopy && tmux display-message "copied"'


### PR DESCRIPTION
Adds [tmux-fingers](https://github.com/Morantron/tmux-fingers) so URLs, hashes, paths, and other tokens on-screen can be copied by typing a short hint label instead of entering copy-mode. Installed from the `morantron/tmux-fingers` Homebrew tap.

Originally proposed with [tmux-thumbs](https://github.com/fcsonline/tmux-thumbs), but its tap is failing to install and upstream activity has stalled. tmux-fingers covers the same workflow and copies to the system clipboard by default (`@fingers-use-system-clipboard=1`), so no `pbcopy` wiring is needed.

## Changes

- `tmux/search/search.conf`: register `Morantron/tmux-fingers` plugin, bind `prefix F`
- `tmux/Brewfile`: add `brew 'morantron/tmux-fingers/tmux-fingers'`

## Testing

- [ ] `brew bundle --file=tmux/Brewfile` installs the binary
- [ ] `prefix I` (TPM install) pulls the plugin into `~/.local/share/tmux/plugins/`
- [ ] `prefix F` overlays hint labels on visible tokens; typing one copies to the system clipboard
- [ ] `ctrl+<label>` opens the token (default `@fingers-ctrl-action = :open:`)