### PR TITLE
tmux: restore sesh for zoxide-aware session picker

### DIFF
--- a/tmux/Brewfile
+++ b/tmux/Brewfile
@@ -1,2 +1,3 @@
 brew 'tmux'
+brew 'sesh'
 brew 'smug'

--- a/tmux/completion.zsh
+++ b/tmux/completion.zsh
@@ -1,6 +1,11 @@
 #!/usr/bin/env zsh
 
 if [[ -n "$TMUX" ]]; then
+  if command -v sesh >/dev/null 2>&1; then
+    eval "$(sesh completion zsh)"
+    compdef _sesh sesh
+  fi
+
   __tmux_fzf_autocomplete() {
     local selected
     selected=$(tmux capture-pane -pS -10000 \

--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -16,3 +16,6 @@ bind g run-shell tmux-grab-scrollback
 
 # Linked session for independent window browsing in a second terminal
 bind X run-shell 'tmux new-session -d -t "#{session_name}" -s "#{session_name}-linked" 2>/dev/null; tmux switch-client -t "#{session_name}-linked"'
+
+# Session picker — sesh merges tmux sessions with zoxide directories.
+bind T display-popup -E -w 80% -h 80% "sesh connect \$(sesh list -i | fzf-tmux -p 80%,80% --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ')"


### PR DESCRIPTION
Restores [`sesh`](https://github.com/joshmedeski/sesh) (removed in `8a613c4`) as a complement to tmux-fzf. `sesh list -i` merges tmux sessions with zoxide directories, so `prefix T` jumps to any recently-visited project without first `cd`'ing there. `prefix t` continues to open tmux-fzf for session switching among existing sessions.

## Changes

- `tmux/Brewfile`: re-add `brew 'sesh'`
- `tmux/completion.zsh`: register sesh zsh completions behind a `command -v sesh` guard
- `tmux/navigation/navigation.conf`: bind `prefix T` to a `display-popup` running `sesh connect` through `fzf-tmux`

Intentionally skips the previously-removed helper scripts (`tmux-sessions`, `tmux-windows`, `_fzf-colors`, `_tmux-session-list`) — tmux-fzf covers that territory now.

## Testing

- [ ] `brew bundle --file=tmux/Brewfile` installs `sesh`
- [ ] `prefix T` opens the sesh popup; selecting a zoxide dir creates/attaches a session named after it
- [ ] `prefix t` still opens tmux-fzf session picker (regression check)
- [ ] `bench-startup` — shell startup remains under the 1s CI gate (completion is deferred)
