### PR TITLE
tmux: add repeatable resize and quick-toggle keys

### DIFF
--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -16,3 +16,14 @@ bind g run-shell tmux-grab-scrollback
 
 # Linked session for independent window browsing in a second terminal
 bind X run-shell 'tmux new-session -d -t "#{session_name}" -s "#{session_name}-linked" 2>/dev/null; tmux switch-client -t "#{session_name}-linked"'
+
+# Repeatable resize — hold the letter instead of re-pressing prefix.
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Quick toggles
+bind Tab last-window
+bind \; last-pane
+bind =   select-layout tiled


### PR DESCRIPTION
Adds repeatable `H`/`J`/`K`/`L` resize bindings (hold the letter rather than re-entering prefix) and three single-key toggles — `Tab` for last window, `;` for last pane, and `=` to reset the current window to `tiled`. The tiled reset in particular unbreaks mobile re-attaches where pane sizes end up wedged.

## Changes

- `tmux/navigation/navigation.conf`: add `bind -r H/J/K/L` resize, `bind Tab last-window`, `bind \; last-pane`, `bind = select-layout tiled`

## Testing

- [ ] `prefix HHHH` shrinks pane left in 5-col increments without re-pressing prefix
- [ ] `prefix Tab` toggles between the two most recent windows
- [ ] `prefix ;` toggles between the two most recent panes
- [ ] `prefix =` resets the window to a tiled layout (useful after mobile re-attach)
