### PR TITLE
tmux: add adaptive pane labels, drop worktrunk window rename

### DIFF
--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -1,2 +1,13 @@
 set -g status-left "#{E:@catppuccin_status_session}"
 set -g status-right "#{?#{==:#(_tmux-bell-count),0},,#{E:@catppuccin_status_bell}}"
+
+# Pane border labels — hidden when a window has only one pane (shells, editors,
+# and Claude Code already self-identify inside the pane). When split, show just
+# the pane index centered on the top border so prefix+<n> navigation is easy.
+set -g pane-border-format "#[align=centre]─ #P#{?window_zoomed_flag, 󰊓 ,} ─"
+set -g pane-border-style "fg=#{@thm_overlay_0}"
+set -g pane-active-border-style "fg=#{@thm_blue}"
+
+set-hook -g window-layout-changed 'set -w -F pane-border-status "#{?#{>:#{window_panes},1},top,off}"'
+set-hook -g after-split-window    'set -w -F pane-border-status "#{?#{>:#{window_panes},1},top,off}"'
+set-hook -g pane-exited           'set -w -F pane-border-status "#{?#{>:#{window_panes},1},top,off}"'

--- a/worktrunk/config.toml
+++ b/worktrunk/config.toml
@@ -3,9 +3,3 @@ claude-trust = "claude-trust-worktree '{{ primary_worktree_path }}' '{{ worktree
 
 [[pre-start]]
 claude-settings = "cp '{{ primary_worktree_path }}/.claude/settings.local.json' '{{ worktree_path }}/.claude/settings.local.json' 2>/dev/null || true"
-
-[post-switch]
-tmux-rename = '[ -n "$TMUX" ] && tmux rename-window {{ branch | sanitize }}'
-
-[post-remove]
-tmux-kill = 'tmux kill-session -t {{ branch | sanitize }} 2>/dev/null || true'


### PR DESCRIPTION
Panes only get a border label when a window has more than one pane,
since shells, editors, and Claude Code already self-identify.  The
label is just the pane index (plus a zoom indicator) so prefix+<n>
navigation is easy without duplicating cwd/branch info from the
shell prompt.

Worktrunk's post-switch window rename and post-remove session kill
no longer fit the workflow (session = project, pane = task), so
remove both.