### PR TITLE
gitignore: move .claude/scheduled_tasks.lock to user ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 Brewfile.lock.json
 .corporate
 *.local
-.claude/scheduled_tasks.lock

--- a/git/ignore
+++ b/git/ignore
@@ -13,6 +13,7 @@ coverage
 
 # Local settings for Claude Code
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 CLAUDE.local.md
 
 # Temporary files


### PR DESCRIPTION
Moves `.claude/scheduled_tasks.lock` from this repo's `.gitignore` to `git/ignore`, which is symlinked to `~/.config/git/ignore` as the global excludes file. The lockfile is a Claude Code runtime artifact that can show up in any repo, so ignoring it locally here didn't cover the general case. `#351` put it in the wrong place.
