### PR TITLE
neovim: migrate treesitter to main-branch API and add startup test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,17 @@ Config and `.zsh` files are loaded from `~/.dotfiles` by default. Edits in a dev
 - **Source directly from the worktree** — for configs like tmux that support runtime reload, source the worktree file explicitly (e.g., `tmux source-file /path/to/worktree/tmux/tmux.conf`). Do **not** suggest `prefix+r` or `tmux source-file ~/.config/tmux/tmux.conf` — those follow the symlink to `~/.dotfiles`, not the worktree.
 - Test dependencies: `bin/dotf` installs/updates packages
 
+### Topic Integration Tests
+
+Topics can ship a shellspec integration test that runs in CI after bootstrap (so symlinks are installed and packages are available). The bootstrap job iterates `*/.shellspec` and runs `shellspec` in each matching directory.
+
+To add tests to a topic:
+
+1. Create `<topic>/.shellspec` with shellspec options (e.g., `--shell bash`)
+2. Create `<topic>/spec/<name>_spec.sh` with `Describe`/`It` blocks
+
+Existing examples: `git/spec/`, `neovim/spec/`. Tests run against the installed config (symlinks from `~/.dotfiles`), so they verify the real post-bootstrap state.
+
 ### Version Updates
 
 Recent patterns show dependency updates via PRs:

--- a/neovim/.shellspec
+++ b/neovim/.shellspec
@@ -1,0 +1,1 @@
+--shell bash

--- a/neovim/config/lua/config/treesitter.lua
+++ b/neovim/config/lua/config/treesitter.lua
@@ -1,9 +1,25 @@
-require("nvim-treesitter.configs").setup({
-  ensure_installed = {
-    "bash", "dockerfile", "go", "gomod",
-    "hcl", "javascript", "json", "lua",
-    "python", "rust", "terraform", "toml",
-    "typescript", "tsx", "yaml",
+require("nvim-treesitter").install({
+  "bash", "dockerfile", "go", "gomod",
+  "hcl", "javascript", "json", "lua",
+  "python", "rust", "terraform", "toml",
+  "typescript", "tsx", "yaml",
+})
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = {
+    "bash", "sh",
+    "dockerfile",
+    "go", "gomod",
+    "hcl",
+    "javascript", "javascriptreact",
+    "json",
+    "lua",
+    "python",
+    "rust",
+    "terraform",
+    "toml",
+    "typescript", "typescriptreact",
+    "yaml",
   },
-  highlight = { enable = true },
+  callback = function() vim.treesitter.start() end,
 })

--- a/neovim/spec/neovim_spec.sh
+++ b/neovim/spec/neovim_spec.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "neovim"
+  It "starts without errors"
+    start_nvim() {
+      local output
+      output=$(nvim --headless +qa 2>&1) || return $?
+      if echo "$output" | grep -qE 'E[0-9]+:|stack traceback'; then
+        echo "$output"
+        return 1
+      fi
+    }
+    When call start_nvim
+    The status should be success
+  End
+End


### PR DESCRIPTION
Fixes an `E5113` crash on nvim startup caused by `nvim-treesitter`'s 1.0 rewrite. The plugin's `main` branch dropped `require("nvim-treesitter.configs").setup({...})`, so the existing `treesitter.lua` stopped loading.

## Changes

- Rewrite `neovim/config/lua/config/treesitter.lua` to the main-branch API: `require("nvim-treesitter").install({...})` for parsers, plus a `FileType` autocmd that calls `vim.treesitter.start()` for highlighting.
- Add a shellspec integration test (`neovim/.shellspec`, `neovim/spec/neovim_spec.sh`) that runs `nvim --headless +qa` and fails on any `E<digits>:` error or Lua `stack traceback`. It's picked up automatically by the existing "Run topic tests" CI step — no workflow changes needed.
- Document the per-topic integration test pattern in `CLAUDE.md`.

## Testing

- Ran `nvim --headless +qa` locally against the fixed config — exits 0 with no errors; plugins install cleanly via `vim.pack` and parser downloads kick off.
- Verified the test fails against a reproduction of the original broken config (caught the `E5113` + stack traceback).
