### PR TITLE
Brewfile: add linearmouse cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -45,6 +45,7 @@ cask 'google-chrome', args: corporate_cask_args
 cask 'hazel'
 cask 'jordanbaird-ice'
 cask 'istat-menus'
+cask 'linearmouse'
 cask 'logi-options+'
 cask 'monitorcontrol'
 cask 'monodraw'


### PR DESCRIPTION
Adds the `linearmouse` cask to the Brewfile.
