### PR TITLE
upgrade: prepend metadata to Things task notes on failure

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -186,7 +186,18 @@ create_things_task() {
 
   log "Creating Things task for upgrade failure..."
 
-  local notes='```sh
+  local host time revision version
+  host=$(hostname -s)
+  time=$(date "+%Y-%m-%d %H:%M:%S %Z")
+  revision=$(git -C "$CLAUDE_REPO_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  version=$(claude --version 2>/dev/null || echo "unknown")
+
+  local notes='- **Host:** '"$host"'
+- **Time:** '"$time"'
+- **Revision:** '"$revision"'
+- **Claude:** '"$version"'
+
+```sh
 claude-upgrade
 ```
 

--- a/bin/dotfiles-upgrade
+++ b/bin/dotfiles-upgrade
@@ -52,7 +52,16 @@ create_things_task() {
 
   log "Creating Things task for install failure..."
 
-  local notes='```sh
+  local host time revision
+  host=$(hostname -s)
+  time=$(date "+%Y-%m-%d %H:%M:%S %Z")
+  revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+  local notes='- **Host:** '"$host"'
+- **Time:** '"$time"'
+- **Revision:** '"$revision"'
+
+```sh
 brew bundle
 ```
 


### PR DESCRIPTION
Prepends a metadata bullet list to the Things task body when `claude-upgrade` or `dotfiles-upgrade` fails. Helps disambiguate which machine a failure came from and pins the repo state at the time of failure.

## Changes

- `bin/claude-upgrade`: adds **Host**, **Time**, **Revision** (short SHA of `$CLAUDE_REPO_HOME`), and **Claude** (output of `claude --version`) to the task notes.
- `bin/dotfiles-upgrade`: adds **Host**, **Time**, and **Revision** (short SHA of `$DOTFILES_HOME`) to the task notes.

Each field falls back to `unknown` if its command fails.
