### PR TITLE
claude-upgrade: install plugins missing locally before update

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -167,8 +167,23 @@ update_plugins() {
     return 0
   fi
 
+  local installed_json
+  installed_json=$(claude plugin list --json 2>/dev/null || echo '[]')
+
   local failed=0
   while IFS= read -r plugin; do
+    local is_installed
+    is_installed=$(echo "$installed_json" | jq -r --arg p "$plugin" 'any(.id == $p)')
+    if [[ "$is_installed" != "true" ]]; then
+      log "  Installing $plugin (not yet installed)..."
+      if claude plugin install "$plugin" 2>&1; then
+        continue
+      else
+        log "  WARNING: Failed to install $plugin"
+        ((failed++))
+        continue
+      fi
+    fi
     log "  Updating $plugin..."
     if ! claude plugin update "$plugin" 2>&1; then
       log "  WARNING: Failed to update $plugin"


### PR DESCRIPTION
`bin/claude-upgrade` iterates the first-party plugins declared in `enabledPlugins` and runs `claude plugin update` on each. That command fails when the plugin isn't installed locally, which happens after cloning dotfiles onto a new machine or after `marketplace.json` adds a new plugin.

## Changes

- Capture the installed set once via `claude plugin list --json` before the update loop.
- For each configured plugin, check membership with `jq` against the `id` field. If missing, run `claude plugin install` and skip the redundant update; otherwise run `claude plugin update` as before.

`jq` over `grep` because the check runs against the structured `id` field rather than matching substrings in free-form output, and the `list --json` contract is the supported interface.
