### PR TITLE
tmux: add smooth-scroll, open-nvim, and mouse-swipe plugins

### DIFF
--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -25,3 +25,12 @@ bind o display-popup -E -w 70% -h 70% -d "#{pane_current_path}" tmux-launch
 
 # Scratch session — toggle attach/detach a persistent workspace.
 bind "\`" display-popup -E -w 80% -h 80% "env -u TMUX tmux new-session -A -s scratch"
+
+# Smooth trackpad/mouse-wheel scrolling in panes
+set -g @plugin 'azorng/tmux-smooth-scroll'
+
+# Open files referenced in pane output in a neovim pane (prefix + e)
+set -g @plugin 'trevarj/tmux-open-nvim'
+
+# Mouse swipe gestures for window/session switching
+set -g @plugin 'jaclu/tmux-mouse-swipe'


### PR DESCRIPTION
Adds three TPM plugins to the tmux navigation config.

## Changes

- [`azorng/tmux-smooth-scroll`](https://github.com/azorng/tmux-smooth-scroll): smooth trackpad and mouse-wheel scrolling in panes
- [`trevarj/tmux-open-nvim`](https://github.com/trevarj/tmux-open-nvim): open files referenced in pane output in a neovim pane (`prefix + e`)
- [`jaclu/tmux-mouse-swipe`](https://github.com/jaclu/tmux-mouse-swipe): swipe gestures for window and session switching

All three use plugin defaults.

## Install

Run `prefix + I` inside tmux on existing machines after sync to have TPM fetch the new plugins. `brew bundle` is unaffected—TPM is not a Homebrew package.
