### PR TITLE
claude-upgrade: prompt to discard local changes when run interactively

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -83,13 +83,28 @@ sync_repo() {
   local git_status
   git_status=$(git status --porcelain 2>/dev/null)
   if [[ -n "$git_status" ]]; then
-    log "ERROR: Local changes in $CLAUDE_REPO_HOME - skipping sync"
-    log "Changed files:"
+    log "Local changes in $CLAUDE_REPO_HOME:"
     echo "$git_status" | while IFS= read -r line; do log "  $line"; done
     log "Diff:"
     render_diff
-    notify "Claude Upgrade" "Skipped: local changes present"
-    return 1
+
+    if [[ -t 0 && -t 1 ]]; then
+      local response
+      read -q "response?Discard local changes and continue? [y/N] "
+      echo
+      if [[ "$response" == "y" ]]; then
+        log "Discarding local changes..."
+        git reset --hard HEAD
+        git clean -fd
+      else
+        log "ERROR: Local changes present - skipping sync"
+        return 1
+      fi
+    else
+      log "ERROR: Local changes in $CLAUDE_REPO_HOME - skipping sync"
+      notify "Claude Upgrade" "Skipped: local changes present"
+      return 1
+    fi
   fi
 
   local default_branch


### PR DESCRIPTION
Hand-running `claude-upgrade` bails on any local diff in `~/.claude-repo`, which forces a manual cleanup in another terminal before the sync can proceed.

## Changes

On a TTY, `sync_repo` now prints the changed files and diff, then prompts `Discard local changes and continue? [y/N]`. A `y` answer runs `git reset --hard HEAD && git clean -fd` and falls through to the normal fetch/pull path. Any other answer bails with the existing error.

Non-TTY runs (launchd) keep the old behavior: log the diff, send a notification, and return 1 so the nightly job creates a Things task.

## Testing

Covered by a `zsh -n` syntax check. The destructive reset runs only after an explicit `y`, and TTY detection via `[[ -t 0 && -t 1 ]]` gates the prompt so unattended runs cannot hit it.
