### PR TITLE
tmux: replace homegrown scratch popup with tmux-floax

### DIFF
--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -23,8 +23,12 @@ bind T display-popup -E -w 80% -h 80% "sesh connect \$(sesh list -i | fzf-tmux -
 # Tool launcher — fzf picker; selection runs inside the popup.
 bind o display-popup -E -w 70% -h 70% -d "#{pane_current_path}" tmux-launch
 
-# Scratch session — toggle attach/detach a persistent workspace.
-bind "\`" display-popup -E -w 80% -h 80% "env -u TMUX tmux new-session -A -s scratch"
+# Floating scratch session
+set -g @plugin 'omerxx/tmux-floax'
+set -g @floax-bind '`'
+set -g @floax-session-name 'scratch'
+set -g @floax-width '80%'
+set -g @floax-height '80%'
 
 # Smooth trackpad/mouse-wheel scrolling in panes
 set -g @plugin 'azorng/tmux-smooth-scroll'


### PR DESCRIPTION
Replaces the homegrown `prefix+`` ` `` scratch session popup with `omerxx/tmux-floax`. The previous binding ran `display-popup -E ... tmux new-session -A -s scratch` and recursed into nested popups when triggered from inside itself, since the inner tmux loaded the same config. Floax handles toggle and nesting correctly and exposes a menu (`prefix+P`) with Fullscreen/Embed actions to promote the floating window into a real session when a task needs deeper investigation.
