### PR TITLE
renovate: enable git-submodules manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
     "config:recommended"
   ],
   "automerge": true,
+  "git-submodules": {
+    "enabled": true
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Enables Renovate's `git-submodules` manager so submodules tracked in `.gitmodules` (currently `claude/theme-sync`) get update PRs. The manager is disabled by default and must be opted in.
