### PR TITLE
claude: rm theme-sync submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "claude/theme-sync"]
-	path = claude/theme-sync
-	url = https://github.com/alfredomtx/claude-theme-sync
 [submodule "bat/catppuccin"]
 	path = bat/catppuccin
 	url = https://github.com/catppuccin/bat.git

--- a/claude/install.sh
+++ b/claude/install.sh
@@ -3,11 +3,6 @@ set -e
 
 [[ "$(uname -s)" == "Darwin" ]] || exit 0
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-# Install theme-sync daemon
-"$SCRIPT_DIR/theme-sync/install.sh"
-
 CLAUDE_REPO_URL="https://github.com/bendrucker/claude.git"
 CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
 


### PR DESCRIPTION
Removes the `alfredomtx/claude-theme-sync` submodule and its `claude/install.sh` hook. Claude Code's native `theme: auto` setting now follows the terminal's appearance, so the third-party daemon is redundant.

The matching settings change lives in [bendrucker/claude#611](https://github.com/bendrucker/claude/pull/611).

## Changes

- Deinit and remove the `claude/theme-sync` submodule
- Drop the submodule entry from `.gitmodules`
- Remove the `theme-sync/install.sh` invocation from `claude/install.sh`

The repo-root `theme/` directory (`theme-sync-tmux`, `theme-sync-btop`, etc.) is unrelated and stays.
