### PR TITLE
tmux: use absolute path for theme-sync invocations

### DIFF
--- a/tmux/appearance/appearance.conf
+++ b/tmux/appearance/appearance.conf
@@ -9,7 +9,7 @@ set -g @catppuccin_window_current_text " #W#(_tmux-window-label '#{pane_title}')
 
 # Sync catppuccin flavor with macOS appearance (fallback for watch-theme-change daemon).
 # theme-sync-tmux self-gates, so it's safe to call unconditionally on every focus event.
-set-hook -g client-focus-in 'run-shell -b theme-sync-tmux'
+set-hook -g client-focus-in 'run-shell -b "$ZSH/theme/bin/theme-sync-tmux"'
 
 # Status bar
 set -g status-position top

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -21,8 +21,8 @@ set -g @plugin 'tmux-plugins/tpm'
 run '${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins/tpm/tpm'
 
 # Post-TPM: apply theme and start watcher
-run 'theme-sync-tmux'
-run-shell -b 'pgrep -f "_watch-theme-change[.]swift" >/dev/null || watch-theme-change'
+run '$ZSH/theme/bin/theme-sync-tmux'
+run-shell -b 'pgrep -f "_watch-theme-change[.]swift" >/dev/null || $ZSH/theme/bin/watch-theme-change'
 
 # Status modules (must load after TPM processes catppuccin)
 source-file ~/.config/tmux/appearance/status.conf


### PR DESCRIPTION
Fixes exit 127 on `client-focus-in` when calling `theme-sync-tmux` and `watch-theme-change` by bare name. The running tmux server pre-dates `theme/path.zsh` (added in #397), so its inherited `PATH` lacks `~/.dotfiles/theme/bin` and the hook can't resolve the script.

## Changes

- `tmux/appearance/appearance.conf`: `client-focus-in` hook calls `$ZSH/theme/bin/theme-sync-tmux` directly.
- `tmux/tmux.conf`: same fix for the post-TPM `theme-sync-tmux` and `watch-theme-change` invocations.

`$ZSH` is already in tmux's global environment (set by `zshenv`) and resolves to the worktree under dev mode, so the absolute path stays consistent across installs.

## Testing

- `tmux source-file appearance.conf` in the running server, then verified `client-focus-in[0]` resolves to `/Users/ben/.dotfiles/theme/bin/theme-sync-tmux`.
- `tmux run-shell '$ZSH/theme/bin/theme-sync-tmux'` exits 0.
