### PR TITLE
gum: consolidate prompts, spinners, and logging across topics

### DIFF
--- a/.claude/skills/gum/SKILL.md
+++ b/.claude/skills/gum/SKILL.md
@@ -40,7 +40,7 @@ gum spin --show-output --title "install" -- ./scripts/install > "$logfile"
 
 ## Confirm
 
-`gum confirm` exits with status 1 on "no". Under `set -e`, that aborts the script. Always branch on it:
+`gum confirm` exits 1 on "no". Always use it as an `if` condition; don't rely on `set -e` to stop the script.
 
 ```sh
 if gum confirm "Discard local changes?" --default=no; then

--- a/.claude/skills/gum/SKILL.md
+++ b/.claude/skills/gum/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: gum
+description: Add interactive prompts, spinners, and styled logging to shell scripts using gum. Use when adding a prompt, asking for confirmation, showing progress on a long-running command, picking from a list, formatting status output, or making a script interactive. Trigger on "add a prompt", "show progress", "spinner", "make this script interactive", "confirm before", "ask the user".
+---
+
+# gum
+
+[gum](https://github.com/charmbracelet/gum) is the house tool for shell-script UI in this repo. Use its native primitives directly. Do not wrap them in helper functions.
+
+## House style
+
+- Replace ad-hoc `info`/`warn`/`error`/`success`/`log`/`fail` helpers with inline `gum log --level info|warn|error` calls.
+- Drop manual TTY detection (`[[ -t 1 ]]` plus ANSI variables). gum and lipgloss handle terminal capability detection.
+- Drop `logger -t TAG` calls. There is no syslog consumer in this repo.
+- Prefer one gum primitive per call site over a wrapper that hides which primitive runs.
+
+## Logging
+
+```sh
+gum log --level info "syncing dotfiles"
+gum log --level warn "fetch failed, retrying"
+gum log --level error "could not pull"
+```
+
+There is no `success` level. Use `info` for completion messages.
+
+## Spinners
+
+Wrap any command whose output is uninteresting until it fails:
+
+```sh
+gum spin --show-output --show-error --title "brew bundle" -- brew bundle
+```
+
+`--show-output` keeps stdout on success, `--show-error` keeps it on failure. Both stay silent during the spin so the spinner reads cleanly. To capture output to a file, redirect the gum invocation, not the inner command:
+
+```sh
+gum spin --show-output --title "install" -- ./scripts/install > "$logfile"
+```
+
+## Confirm
+
+`gum confirm` exits with status 1 on "no". Under `set -e`, that aborts the script. Always branch on it:
+
+```sh
+if gum confirm "Discard local changes?" --default=no; then
+  git reset --hard HEAD
+fi
+```
+
+## Input
+
+```sh
+name=$(gum input --header "GitHub author name" --placeholder "Jane Doe")
+```
+
+## Choose
+
+Multi-select with no item-count limit:
+
+```sh
+selected=$(printf '%s\n' "${candidates[@]}" | gum choose --no-limit --header "Remove which?")
+```
+
+## Format and table
+
+Use `gum format --type markdown` for headers and bullet summaries, and `gum table --print` for tabular data:
+
+```sh
+gum format --type markdown <<EOF
+# Report
+- **Total:** $total
+EOF
+
+{ echo "Name,Count"; data_csv; } | gum table --print
+```
+
+## Reference
+
+[gum README](https://github.com/charmbracelet/gum#readme) covers every command and its flags.

--- a/.claude/skills/gum/SKILL.md
+++ b/.claude/skills/gum/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gum
-description: Add interactive prompts, spinners, and styled logging to shell scripts using gum. Use when adding a prompt, asking for confirmation, showing progress on a long-running command, picking from a list, formatting status output, or making a script interactive. Trigger on "add a prompt", "show progress", "spinner", "make this script interactive", "confirm before", "ask the user".
+description: Add interactive prompts, spinners, styled logging, and pickers to shell scripts using gum. Use when editing a shell script and adding a prompt, asking for confirmation, wrapping a long-running command in a spinner, picking from a list, logging styled status output, or otherwise making a script interactive. Trigger on "add a prompt", "show progress", "spinner", "make this script interactive", "confirm before", "ask the user", "pick from a list", "menu", "styled logs", "gum log", "gum spin", "gum confirm", "gum choose", "gum input".
+allowed-tools: [Read, Write, Edit, Grep, Glob]
 ---
 
 # gum
@@ -26,7 +27,7 @@ There is no `success` level. Use `info` for completion messages.
 
 ## Spinners
 
-Wrap any command whose output is uninteresting until it fails:
+Wrap commands whose output only matters when something goes wrong:
 
 ```sh
 gum spin --show-output --show-error --title "brew bundle" -- brew bundle
@@ -37,6 +38,8 @@ gum spin --show-output --show-error --title "brew bundle" -- brew bundle
 ```sh
 gum spin --show-output --title "install" -- ./scripts/install > "$logfile"
 ```
+
+For determinate progress (known total), use `gum progress` instead of `gum spin`. The README has the syntax.
 
 ## Confirm
 
@@ -55,6 +58,12 @@ name=$(gum input --header "GitHub author name" --placeholder "Jane Doe")
 ```
 
 ## Choose
+
+Single-select:
+
+```sh
+choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Pick one")
+```
 
 Multi-select with no item-count limit:
 

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -102,7 +102,7 @@ sync_repo() {
 
   local retries=4 delay=2
   for ((i=1; i<=retries; i++)); do
-    if gum spin --title "Fetching origin/$default_branch (attempt $i/$retries)" -- \
+    if gum spin --show-error --title "Fetching origin/$default_branch (attempt $i/$retries)" -- \
       git fetch origin "$default_branch"; then
       break
     fi

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -139,10 +139,7 @@ sync_repo() {
 
 update_marketplaces() {
   gum log --level info "Updating marketplaces..."
-  if ! claude plugin marketplace update; then
-    gum log --level warn "marketplace update had issues"
-    return 1
-  fi
+  claude plugin marketplace update || gum log --level warn "marketplace update had issues, continuing"
 }
 
 update_plugins() {
@@ -250,10 +247,7 @@ main() {
       exit 1
     fi
 
-    if ! update_marketplaces; then
-      gum log --level warn "Marketplace update failed, continuing..."
-    fi
-
+    update_marketplaces
     update_plugins
   } 2>&1 | tee "$output"
 

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -3,13 +3,6 @@
 # Syncs claude repo, updates marketplaces and plugins
 
 CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
-LOG_TAG="claude-upgrade"
-
-log() {
-  local msg="$1"
-  logger -t "$LOG_TAG" "$msg" 2>/dev/null || true
-  echo "$msg"
-}
 
 notify() {
   local title="$1"
@@ -37,7 +30,7 @@ revert_cosmetic_json_changes() {
     head_sorted=$(git show "HEAD:$file" 2>/dev/null | jq -S . 2>/dev/null) || continue
 
     if [[ "$working_sorted" == "$head_sorted" ]]; then
-      log "Reverting cosmetic reorder in $file"
+      gum log --level info "Reverting cosmetic reorder in $file"
       git checkout HEAD -- "$file"
     fi
   done <<< "$changed_files"
@@ -62,16 +55,16 @@ render_diff() {
 }
 
 sync_repo() {
-  log "Syncing Claude repository..."
+  gum log --level info "Syncing Claude repository..."
 
   if [[ -L "$CLAUDE_REPO_HOME" ]]; then
-    log "ERROR: $CLAUDE_REPO_HOME is a symlink"
+    gum log --level error "$CLAUDE_REPO_HOME is a symlink"
     notify "Claude Upgrade" "Failed: ~/.claude-repo is a symlink"
     return 1
   fi
 
   if [[ ! -d "$CLAUDE_REPO_HOME/.git" ]]; then
-    log "ERROR: $CLAUDE_REPO_HOME is not a git repository"
+    gum log --level error "$CLAUDE_REPO_HOME is not a git repository"
     notify "Claude Upgrade" "Failed: not a git repository"
     return 1
   fi
@@ -83,25 +76,17 @@ sync_repo() {
   local git_status
   git_status=$(git status --porcelain 2>/dev/null)
   if [[ -n "$git_status" ]]; then
-    log "Local changes in $CLAUDE_REPO_HOME:"
-    echo "$git_status" | while IFS= read -r line; do log "  $line"; done
-    log "Diff:"
+    gum log --level info "Local changes in $CLAUDE_REPO_HOME:"
+    echo "$git_status"
+    gum log --level info "Diff:"
     render_diff
 
-    if [[ -t 0 && -t 1 ]]; then
-      local response
-      read -q "response?Discard local changes and continue? [y/N] "
-      echo
-      if [[ "$response" == "y" ]]; then
-        log "Discarding local changes..."
-        git reset --hard HEAD
-        git clean -fd
-      else
-        log "ERROR: Local changes present - skipping sync"
-        return 1
-      fi
+    if gum confirm "Discard local changes and continue?" --default=no; then
+      gum log --level info "Discarding local changes..."
+      git reset --hard HEAD
+      git clean -fd
     else
-      log "ERROR: Local changes in $CLAUDE_REPO_HOME - skipping sync"
+      gum log --level error "Local changes present - skipping sync"
       notify "Claude Upgrade" "Skipped: local changes present"
       return 1
     fi
@@ -117,15 +102,16 @@ sync_repo() {
 
   local retries=4 delay=2
   for ((i=1; i<=retries; i++)); do
-    if git fetch origin "$default_branch" 2>&1; then
+    if gum spin --title "Fetching origin/$default_branch (attempt $i/$retries)" -- \
+      git fetch origin "$default_branch"; then
       break
     fi
     if ((i < retries)); then
-      log "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
+      gum log --level warn "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
       sleep "$delay"
       delay=$((delay * 2))
     else
-      log "ERROR: Failed to fetch after retries"
+      gum log --level error "Failed to fetch after retries"
       notify "Claude Upgrade" "Failed: network error"
       return 1
     fi
@@ -136,31 +122,31 @@ sync_repo() {
   remote_rev=$(git rev-parse "origin/$default_branch")
 
   if [[ "$local_rev" == "$remote_rev" ]]; then
-    log "Repository already up to date (${local_rev:0:7})"
+    gum log --level info "Repository already up to date (${local_rev:0:7})"
     return 0
   fi
 
-  log "Updating repository from ${local_rev:0:7} to ${remote_rev:0:7}..."
+  gum log --level info "Updating repository from ${local_rev:0:7} to ${remote_rev:0:7}..."
 
-  if git pull --ff-only origin "$default_branch" 2>&1; then
-    log "Repository updated to $(git rev-parse --short HEAD)"
+  if git pull --ff-only origin "$default_branch"; then
+    gum log --level info "Repository updated to $(git rev-parse --short HEAD)"
   else
-    log "ERROR: Failed to pull repository"
+    gum log --level error "Failed to pull repository"
     notify "Claude Upgrade" "Failed: could not pull"
     return 1
   fi
 }
 
 update_marketplaces() {
-  log "Updating marketplaces..."
-  if ! claude plugin marketplace update 2>&1; then
-    log "WARNING: marketplace update had issues"
+  gum log --level info "Updating marketplaces..."
+  if ! claude plugin marketplace update; then
+    gum log --level warn "marketplace update had issues"
     return 1
   fi
 }
 
 update_plugins() {
-  log "Updating plugins..."
+  gum log --level info "Updating plugins..."
 
   local marketplace_file="$CLAUDE_REPO_HOME/.claude-plugin/marketplace.json"
   local marketplace_name
@@ -168,7 +154,7 @@ update_plugins() {
 
   local settings_file="$HOME/.claude/settings.json"
   if [[ ! -f "$settings_file" ]]; then
-    log "WARNING: settings.json not found at $settings_file"
+    gum log --level warn "settings.json not found at $settings_file"
     return 0
   fi
 
@@ -178,7 +164,7 @@ update_plugins() {
     "$settings_file" 2>/dev/null)
 
   if [[ -z "$plugins" ]]; then
-    log "No first-party plugins found"
+    gum log --level info "No first-party plugins found"
     return 0
   fi
 
@@ -190,31 +176,31 @@ update_plugins() {
     local is_installed
     is_installed=$(echo "$installed_json" | jq -r --arg p "$plugin" 'any(.id == $p)')
     if [[ "$is_installed" != "true" ]]; then
-      log "  Installing $plugin (not yet installed)..."
-      if claude plugin install "$plugin" 2>&1; then
+      gum log --level info "Installing $plugin (not yet installed)..."
+      if claude plugin install "$plugin"; then
         continue
       else
-        log "  WARNING: Failed to install $plugin"
+        gum log --level warn "Failed to install $plugin"
         ((failed++))
         continue
       fi
     fi
-    log "  Updating $plugin..."
-    if ! claude plugin update "$plugin" 2>&1; then
-      log "  WARNING: Failed to update $plugin"
+    gum log --level info "Updating $plugin..."
+    if ! claude plugin update "$plugin"; then
+      gum log --level warn "Failed to update $plugin"
       ((failed++))
     fi
   done <<< "$plugins"
 
   if ((failed > 0)); then
-    log "WARNING: $failed plugin(s) failed to update"
+    gum log --level warn "$failed plugin(s) failed to update"
   fi
 }
 
 create_things_task() {
   local output="$1"
 
-  log "Creating Things task for upgrade failure..."
+  gum log --level info "Creating Things task for upgrade failure..."
 
   local host time revision version
   host=$(hostname -s)
@@ -265,7 +251,7 @@ main() {
     fi
 
     if ! update_marketplaces; then
-      log "WARNING: Marketplace update failed, continuing..."
+      gum log --level warn "Marketplace update failed, continuing..."
     fi
 
     update_plugins
@@ -276,7 +262,7 @@ main() {
     exit 1
   fi
 
-  log "All Claude upgrades completed successfully"
+  gum log --level info "All Claude upgrades completed successfully"
 }
 
 main

--- a/bin/dotf
+++ b/bin/dotf
@@ -9,8 +9,7 @@ export ZSH="$HOME/.dotfiles"
 # Install homebrew
 "$ZSH/scripts/homebrew.sh"
 # Upgrade homebrew
-echo "› brew update"
-brew update
+gum spin --show-output --show-error --title "brew update" -- brew update
 
 # Build default package files
 echo "› building default packages"

--- a/bin/dotf
+++ b/bin/dotf
@@ -1,20 +1,13 @@
 #!/bin/sh
 #
-# dotf
-#
-# `dotf` handles installation, updates, things like that. Run it periodically
-# to make sure you're on the latest and greatest.
+# Install and update dotfiles dependencies; run periodically.
 export ZSH="$HOME/.dotfiles"
 
-# Install homebrew
 "$ZSH/scripts/homebrew.sh"
-# Upgrade homebrew
 gum spin --show-output --show-error --title "brew update" -- brew update
 
-# Build default package files
 echo "› building default packages"
 "$ZSH/bin/build-default-packages"
 
-# Install software
 echo "› $ZSH/scripts/install"
 "$ZSH/scripts/install"

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -7,7 +7,6 @@ set -e
 
 DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 
-# macOS notification helper
 notify() {
   local title="$1"
   local message="$2"
@@ -24,7 +23,6 @@ notify() {
   fi
 }
 
-# Ensure we're working with a real directory, not a symlink
 if [[ -L "$DOTFILES_HOME" ]]; then
   gum log --level error "$DOTFILES_HOME is a symlink - run scripts/setup first"
   notify "Dotfiles Sync" "Failed: ~/.dotfiles is a symlink" "false"
@@ -39,7 +37,6 @@ fi
 
 cd "$DOTFILES_HOME"
 
-# Check for local changes that would prevent pull
 if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
   gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
   gum log --level error "Run 'git -C $DOTFILES_HOME status' to see changes"
@@ -47,7 +44,6 @@ if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; th
   exit 1
 fi
 
-# Get the default branch
 get_default_branch() {
   local branch
   branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
@@ -62,13 +58,12 @@ get_default_branch() {
 
 DEFAULT_BRANCH=$(get_default_branch)
 
-# Fetch with retry logic
 fetch_with_retry() {
   local retries=4
   local delay=2
 
   for ((i=1; i<=retries; i++)); do
-    if gum spin --title "Fetching origin/$DEFAULT_BRANCH (attempt $i/$retries)" -- \
+    if gum spin --show-error --title "Fetching origin/$DEFAULT_BRANCH (attempt $i/$retries)" -- \
       git fetch origin "$DEFAULT_BRANCH"; then
       return 0
     fi
@@ -100,13 +95,16 @@ fi
 gum log --level info "Updating from ${LOCAL:0:7} to ${REMOTE:0:7}..."
 
 if git pull --ff-only origin "$DEFAULT_BRANCH"; then
-  git submodule update --init
+  if ! gum spin --show-error --title "Updating submodules" -- git submodule update --init; then
+    gum log --level error "Submodule update failed"
+    notify "Dotfiles Sync" "Failed: submodules" "false"
+    exit 1
+  fi
 
   gum log --level info "Successfully updated to $(git rev-parse --short HEAD)"
   notify "Dotfiles Sync" "Updated to ${REMOTE:0:7}" "true"
 
-  # Optionally run bootstrap to update symlinks
-  # Only if --bootstrap flag is passed (not by default for launchd)
+  # Symlink refresh is opt-in; the launchd job skips it.
   if [[ "$1" == "--bootstrap" ]] && [[ -x "$DOTFILES_HOME/scripts/bootstrap" ]]; then
     gum log --level info "Running bootstrap..."
     "$DOTFILES_HOME/scripts/bootstrap" --no-prompt

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -6,13 +6,6 @@
 set -e
 
 DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
-LOG_TAG="dotfiles-sync"
-
-log() {
-  local msg="$1"
-  logger -t "$LOG_TAG" "$msg" 2>/dev/null || true
-  echo "$msg"
-}
 
 # macOS notification helper
 notify() {
@@ -33,13 +26,13 @@ notify() {
 
 # Ensure we're working with a real directory, not a symlink
 if [[ -L "$DOTFILES_HOME" ]]; then
-  log "ERROR: $DOTFILES_HOME is a symlink - run scripts/setup first"
+  gum log --level error "$DOTFILES_HOME is a symlink - run scripts/setup first"
   notify "Dotfiles Sync" "Failed: ~/.dotfiles is a symlink" "false"
   exit 1
 fi
 
 if [[ ! -d "$DOTFILES_HOME/.git" ]]; then
-  log "ERROR: $DOTFILES_HOME is not a git repository"
+  gum log --level error "$DOTFILES_HOME is not a git repository"
   notify "Dotfiles Sync" "Failed: not a git repository" "false"
   exit 1
 fi
@@ -48,8 +41,8 @@ cd "$DOTFILES_HOME"
 
 # Check for local changes that would prevent pull
 if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-  log "ERROR: Local changes in $DOTFILES_HOME - skipping sync"
-  log "  Run 'git -C $DOTFILES_HOME status' to see changes"
+  gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
+  gum log --level error "  Run 'git -C $DOTFILES_HOME status' to see changes"
   notify "Dotfiles Sync" "Skipped: local changes present" "false"
   exit 1
 fi
@@ -75,12 +68,13 @@ fetch_with_retry() {
   local delay=2
 
   for ((i=1; i<=retries; i++)); do
-    if git fetch origin "$DEFAULT_BRANCH" 2>&1; then
+    if gum spin --title "Fetching origin/$DEFAULT_BRANCH (attempt $i/$retries)" -- \
+      git fetch origin "$DEFAULT_BRANCH"; then
       return 0
     fi
 
     if ((i < retries)); then
-      log "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
+      gum log --level warn "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
       sleep "$delay"
       delay=$((delay * 2))
     fi
@@ -89,9 +83,8 @@ fetch_with_retry() {
   return 1
 }
 
-log "Fetching updates from origin/$DEFAULT_BRANCH..."
 if ! fetch_with_retry; then
-  log "ERROR: Failed to fetch after retries"
+  gum log --level error "Failed to fetch after retries"
   notify "Dotfiles Sync" "Failed: network error" "false"
   exit 1
 fi
@@ -100,30 +93,26 @@ LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse "origin/$DEFAULT_BRANCH")
 
 if [[ "$LOCAL" == "$REMOTE" ]]; then
-  log "Already up to date (${LOCAL:0:7})"
+  gum log --level info "Already up to date (${LOCAL:0:7})"
   exit 0
 fi
 
-log "Updating from ${LOCAL:0:7} to ${REMOTE:0:7}..."
+gum log --level info "Updating from ${LOCAL:0:7} to ${REMOTE:0:7}..."
 
-if git pull --ff-only origin "$DEFAULT_BRANCH" 2>&1; then
-  git submodule update --init 2>&1 | while read -r line; do
-    log "  $line"
-  done
+if git pull --ff-only origin "$DEFAULT_BRANCH"; then
+  git submodule update --init
 
-  log "Successfully updated to $(git rev-parse --short HEAD)"
+  gum log --level info "Successfully updated to $(git rev-parse --short HEAD)"
   notify "Dotfiles Sync" "Updated to ${REMOTE:0:7}" "true"
 
   # Optionally run bootstrap to update symlinks
   # Only if --bootstrap flag is passed (not by default for launchd)
   if [[ "$1" == "--bootstrap" ]] && [[ -x "$DOTFILES_HOME/scripts/bootstrap" ]]; then
-    log "Running bootstrap..."
-    "$DOTFILES_HOME/scripts/bootstrap" --no-prompt 2>&1 | while read -r line; do
-      log "  $line"
-    done
+    gum log --level info "Running bootstrap..."
+    "$DOTFILES_HOME/scripts/bootstrap" --no-prompt
   fi
 else
-  log "ERROR: Failed to pull - may need manual intervention"
+  gum log --level error "Failed to pull - may need manual intervention"
   notify "Dotfiles Sync" "Failed: could not pull" "false"
   exit 1
 fi

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -42,7 +42,7 @@ cd "$DOTFILES_HOME"
 # Check for local changes that would prevent pull
 if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
   gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
-  gum log --level error "  Run 'git -C $DOTFILES_HOME status' to see changes"
+  gum log --level error "Run 'git -C $DOTFILES_HOME status' to see changes"
   notify "Dotfiles Sync" "Skipped: local changes present" "false"
   exit 1
 fi

--- a/bin/dotfiles-upgrade
+++ b/bin/dotfiles-upgrade
@@ -22,7 +22,7 @@ create_things_task() {
   host=$(hostname -s)
   time=$(date "+%Y-%m-%d %H:%M:%S %Z")
   revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-  output=$(tail -n 100 "$INSTALL_LOG")
+  output=$(tail -n 100 "$INSTALL_LOG" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')
 
   local notes='- **Host:** '"$host"'
 - **Time:** '"$time"'
@@ -52,7 +52,7 @@ if ! gum spin --show-output --show-error --title "Syncing dotfiles" -- \
 fi
 
 if ! gum spin --show-output --show-error --title "Running install" -- \
-  "$DOTFILES_HOME/scripts/install" > "$INSTALL_LOG"; then
+  "$DOTFILES_HOME/scripts/install" > "$INSTALL_LOG" 2>&1; then
   gum log --level error "install failed"
   create_things_task
   exit 1

--- a/bin/dotfiles-upgrade
+++ b/bin/dotfiles-upgrade
@@ -6,68 +6,17 @@
 set -e
 
 DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
-LOG_TAG="dotfiles-upgrade"
 
-LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles-upgrade"
-mkdir -p "$LOG_DIR"
-SYNC_LOG="$LOG_DIR/sync.log"
-INSTALL_LOG="$LOG_DIR/install.log"
-CLEANUP_LOG="$LOG_DIR/cleanup.log"
-for f in "$SYNC_LOG" "$INSTALL_LOG" "$CLEANUP_LOG"; do : > "$f"; done
-
-if [[ -t 1 ]]; then
-  C_BOLD=$'\033[1m'
-  C_DIM=$'\033[2m'
-  C_RED=$'\033[31m'
-  C_YELLOW=$'\033[33m'
-  C_BLUE=$'\033[34m'
-  C_RESET=$'\033[0m'
-else
-  C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_BLUE='' C_RESET=''
-fi
-
-info() {
-  logger -t "$LOG_TAG" "$1" 2>/dev/null || true
-  printf '%s==>%s %s%s%s\n' "$C_BLUE" "$C_RESET" "$C_BOLD" "$1" "$C_RESET"
-}
-
-warn() {
-  logger -t "$LOG_TAG" "WARN: $1" 2>/dev/null || true
-  printf '%s !!%s %s\n' "$C_YELLOW" "$C_RESET" "$1"
-}
-
-error() {
-  logger -t "$LOG_TAG" "ERROR: $1" 2>/dev/null || true
-  printf '%s xx%s %s\n' "$C_RED" "$C_RESET" "$1"
-}
+INSTALL_LOG=$(mktemp)
+trap 'rm -f "$INSTALL_LOG"' EXIT
 
 notify() {
   [[ "$(uname)" == "Darwin" ]] || return 0
   osascript -e "display notification \"$2\" with title \"$1\" sound name \"Basso\"" 2>/dev/null || true
 }
 
-# Run a command, capturing all output to logfile. With gum on a TTY, show a
-# live spinner; otherwise stream raw output. gum writes the captured output
-# to its stdout post-run (--show-output on success, --show-error on failure),
-# which we redirect to the logfile. Stderr stays on the terminal so the
-# spinner remains visible.
-stream() {
-  local logfile="$1" title="$2"; shift 2
-
-  if [[ -t 2 ]] && command -v gum >/dev/null 2>&1; then
-    logger -t "$LOG_TAG" "$title" 2>/dev/null || true
-    gum spin --show-output --show-error --title "$title" -- "$@" > "$logfile"
-    return $?
-  fi
-
-  info "$title"
-  "$@" 2>&1 | tee -a "$logfile"
-  # shellcheck disable=SC2154  # zsh: $pipestatus is the zsh equivalent of $PIPESTATUS
-  return "${pipestatus[1]}"
-}
-
 create_things_task() {
-  info "Creating Things task for install failure"
+  gum log --level info "Creating Things task for install failure"
 
   local host time revision output
   host=$(hostname -s)
@@ -78,7 +27,6 @@ create_things_task() {
   local notes='- **Host:** '"$host"'
 - **Time:** '"$time"'
 - **Revision:** '"$revision"'
-- **Log:** `'"$INSTALL_LOG"'`
 
 ```sh
 brew bundle
@@ -97,23 +45,21 @@ brew bundle
   notify "Dotfiles Upgrade" "Install failed - see Things task"
 }
 
-if ! stream "$SYNC_LOG" "Syncing dotfiles" "$DOTFILES_HOME/bin/dotfiles-sync"; then
-  error "sync failed"
-  printf '%s--- last 50 lines of %s ---%s\n' "$C_DIM" "$SYNC_LOG" "$C_RESET"
-  tail -n 50 "$SYNC_LOG"
+if ! gum spin --show-output --show-error --title "Syncing dotfiles" -- \
+  "$DOTFILES_HOME/bin/dotfiles-sync"; then
+  gum log --level error "sync failed"
   exit 1
 fi
 
-if ! stream "$INSTALL_LOG" "Running install" "$DOTFILES_HOME/scripts/install"; then
-  error "install failed"
-  printf '%s--- last 50 lines of %s ---%s\n' "$C_DIM" "$INSTALL_LOG" "$C_RESET"
-  tail -n 50 "$INSTALL_LOG"
+if ! gum spin --show-output --show-error --title "Running install" -- \
+  "$DOTFILES_HOME/scripts/install" > "$INSTALL_LOG"; then
+  gum log --level error "install failed"
   create_things_task
   exit 1
 fi
 
-if ! stream "$CLEANUP_LOG" "Running brew cleanup" brew cleanup; then
-  warn "brew cleanup had issues (see $CLEANUP_LOG)"
+if ! gum spin --show-output --show-error --title "Running brew cleanup" -- brew cleanup; then
+  gum log --level warn "brew cleanup had issues"
 fi
 
-info "All upgrades completed successfully"
+gum log --level info "All upgrades completed successfully"

--- a/bin/tmux-usage-report
+++ b/bin/tmux-usage-report
@@ -37,13 +37,17 @@ total=$(echo "$recent" | wc -l | tr -d ' ')
 first=$(echo "$recent" | head -1 | jq -r .ts)
 last=$(echo "$recent" | tail -1 | jq -r .ts)
 
-echo "=== tmux usage report (last $days days) ==="
-echo "Period: $first → $last"
-echo "Total events: $total"
+gum format --type markdown <<EOF
+# tmux usage report (last $days days)
+- **Period:** $first to $last
+- **Total events:** $total
+EOF
 echo
 
-echo "--- Event frequency ---"
-echo "$recent" | jq -r .event | sort | uniq -c | sort -rn
+{ echo "Event,Count"
+  echo "$recent" | jq -r .event | sort | uniq -c | sort -rn | \
+    awk '{ printf "%s,%s\n", $2, $1 }'
+} | gum table --print
 echo
 
 sessions=$(count session-created)

--- a/github/install.sh
+++ b/github/install.sh
@@ -69,12 +69,16 @@ if [[ "$force" != true && ( -n "${NONINTERACTIVE-}" || ! -t 0 ) ]]; then
   exit 0
 fi
 
-for repo in "${undeclared[@]}"; do
+if [[ "$force" == true ]]; then
+  to_remove=$(printf '%s\n' "${undeclared[@]}")
+else
+  to_remove=$(printf '%s\n' "${undeclared[@]}" | \
+    gum choose --no-limit \
+      --header "Undeclared gh extensions — Tab to select, Enter to confirm")
+fi
+
+while IFS= read -r repo; do
+  [[ -z "$repo" ]] && continue
   name=${${repo##*/}#gh-}
-  if [[ "$force" == true ]]; then
-    gh extension remove "$name"
-  else
-    read -r "reply?Remove gh-$name? [y/N] " || break
-    [[ "$reply" == [Yy]* ]] && gh extension remove "$name"
-  fi
-done
+  gum spin --title "Removing gh-$name" -- gh extension remove "$name"
+done <<< "$to_remove"

--- a/github/install.sh
+++ b/github/install.sh
@@ -74,7 +74,7 @@ if [[ "$force" == true ]]; then
 else
   to_remove=$(printf '%s\n' "${undeclared[@]}" | \
     gum choose --no-limit \
-      --header "Undeclared gh extensions — Tab to select, Enter to confirm")
+      --header "Undeclared gh extensions: Tab to select, Enter to confirm")
 fi
 
 while IFS= read -r repo; do

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -12,6 +12,8 @@ for arg in "$@"; do
   esac
 done
 
+"$DOTFILES_ROOT/scripts/homebrew.sh"
+
 setup_gitconfig () {
   [ -f git/config.local ] && return
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2059
 #
 # bootstrap installs things.
 
 cd "$(dirname "$0")/.." || exit 1
 DOTFILES_ROOT=$(pwd -P)
 
-# Parse arguments
 NO_PROMPT=false
 for arg in "$@"; do
   case $arg in
@@ -14,80 +12,48 @@ for arg in "$@"; do
   esac
 done
 
-echo ''
-
-info () {
-  printf "\r  [ \033[00;34m..\033[0m ] $1\n"
-}
-
-user () {
-  printf "\r  [ \033[0;33m??\033[0m ] $1\n"
-}
-
-success () {
-  printf "\r\033[2K  [ \033[00;32mOK\033[0m ] $1\n"
-}
-
-fail () {
-  printf "\r\033[2K  [\033[0;31mFAIL\033[0m] $1\n"
-  echo ''
-  exit 1
-}
-
 setup_gitconfig () {
-  if ! [ -f git/config.local ]
-  then
-    # Skip gitconfig setup in no-prompt mode
-    if [ "$NO_PROMPT" == "true" ]; then
-      info 'skipping gitconfig setup (no-prompt mode)'
-      return
-    fi
+  [ -f git/config.local ] && return
 
-    info 'setup gitconfig'
-
-    git_credential='cache'
-    if [ "$(uname -s)" == "Darwin" ]
-    then
-      git_credential='osxkeychain'
-    fi
-
-    user ' - What is your github author name?'
-    read -r -e git_authorname
-    user ' - What is your github author email?'
-    read -r -e git_authoremail
-
-    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" git/config.local.example > git/config.local
-
-    success 'gitconfig'
+  if [ "$NO_PROMPT" == "true" ]; then
+    gum log --level info 'skipping gitconfig setup (no-prompt mode)'
+    return
   fi
+
+  gum log --level info 'setup gitconfig'
+
+  git_credential='cache'
+  if [ "$(uname -s)" == "Darwin" ]; then
+    git_credential='osxkeychain'
+  fi
+
+  git_authorname=$(gum input --header "GitHub author name" --placeholder "Jane Doe")
+  git_authoremail=$(gum input --header "GitHub author email" --placeholder "jane@example.com")
+
+  sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" git/config.local.example > git/config.local
 }
 
 init_submodules () {
-  info 'initializing submodules'
+  gum log --level info 'initializing submodules'
   git -C "$DOTFILES_ROOT" submodule update --init --recursive
-  success 'submodules initialized'
 }
 
 install_dotfiles () {
-  info 'installing dotfiles'
+  gum log --level info 'installing dotfiles'
   "$DOTFILES_ROOT/scripts/install-symlinks" "$DOTFILES_ROOT"
-  success "symlinks installed"
 }
 
 setup_gitconfig
 init_submodules
 install_dotfiles
 
-info 'building default packages'
+gum log --level info 'building default packages'
 ./bin/build-default-packages
 
 # shellcheck disable=SC1091
-if source ./bin/dotf
-then
-  success "dependencies installed"
-else
-  fail "error installing dependencies"
+if ! source ./bin/dotf; then
+  gum log --level error 'error installing dependencies'
+  exit 1
 fi
 
-echo ''
-echo '  All installed!'
+gum log --level info 'all installed'

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -18,4 +18,10 @@ then
 
 fi
 
+# install gum early so dotfiles-bootstrap helpers can use it before scripts/install runs brew bundle
+if test ! "$(command -v gum)"
+then
+  brew install gum
+fi
+
 exit 0

--- a/scripts/install
+++ b/scripts/install
@@ -11,8 +11,7 @@ if [[ -z "${NONINTERACTIVE-}" ]] && [[ ! -t 0 ]]; then
   export NONINTERACTIVE=1
 fi
 
-echo "› brew bundle"
-brew bundle
+gum spin --show-output --show-error --title "brew bundle" -- brew bundle
 
 # Expose brew configuration to installers
 eval "$(brew shellenv)"

--- a/scripts/install
+++ b/scripts/install
@@ -11,15 +11,13 @@ if [[ -z "${NONINTERACTIVE-}" ]] && [[ ! -t 0 ]]; then
   export NONINTERACTIVE=1
 fi
 
-gum spin --show-output --show-error --title "brew bundle" -- brew bundle
+brew bundle
 
 # Expose brew configuration to installers
 eval "$(brew shellenv)"
 
-# Install mise tools and activate shims
 source mise/install.sh
 
-# Install declarative symlinks
 ./scripts/install-symlinks
 
 # Build exclusions for mise and any git submodules
@@ -28,5 +26,4 @@ for sm_path in ${(f)"$(git submodule foreach --quiet 'echo $sm_path' 2>/dev/null
   excludes+=("!" "-path" "./$sm_path/*")
 done
 
-# Find and run topic installers
 find . -name install.sh "${excludes[@]}" | while read -r installer; do "${installer}"; done

--- a/scripts/setup
+++ b/scripts/setup
@@ -56,6 +56,8 @@ get_default_branch() {
 
 # Main setup logic
 main() {
+  "$SCRIPT_DIR/homebrew.sh"
+
   gum log --level info "Setting up dotfiles with separate installed and development directories"
   echo "  Repo URL: $REPO_URL"
   echo "  Installed: $DOTFILES_HOME"
@@ -66,7 +68,6 @@ main() {
   state=$(detect_state)
   gum log --level info "Current dotfiles state: $state"
 
-  # Handle DOTFILES_HOME based on current state
   case $state in
     symlink)
       local target
@@ -131,7 +132,6 @@ main() {
       ;;
   esac
 
-  # Handle DOTFILES_DEV
   gum log --level info "Checking development directory..."
   if [[ -d "$DOTFILES_DEV/.git" ]]; then
     gum log --level info "Development directory already exists at $DOTFILES_DEV"
@@ -171,7 +171,6 @@ main() {
 
   gum log --level info "Separate directories verified"
 
-  # Run bootstrap from installed version
   gum log --level info "Running bootstrap from installed dotfiles..."
   "$DOTFILES_HOME/scripts/bootstrap"
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -62,10 +62,9 @@ main() {
   echo "  Development: $DOTFILES_DEV"
   echo ""
 
-  gum log --level info "Detecting current dotfiles state..."
   local state
   state=$(detect_state)
-  echo "  Current state: $state"
+  gum log --level info "Current dotfiles state: $state"
 
   # Handle DOTFILES_HOME based on current state
   case $state in

--- a/scripts/setup
+++ b/scripts/setup
@@ -24,11 +24,6 @@ else
   exit 1
 fi
 
-info()    { printf "\033[0;34m==>\033[0m %s\n" "$1"; }
-warn()    { printf "\033[0;33mWarning:\033[0m %s\n" "$1"; }
-error()   { printf "\033[0;31mError:\033[0m %s\n" "$1" >&2; }
-success() { printf "\033[0;32m✓\033[0m %s\n" "$1"; }
-
 # Detect current state of ~/.dotfiles
 detect_state() {
   if [[ -L "$DOTFILES_HOME" ]]; then
@@ -61,13 +56,13 @@ get_default_branch() {
 
 # Main setup logic
 main() {
-  info "Setting up dotfiles with separate installed and development directories"
+  gum log --level info "Setting up dotfiles with separate installed and development directories"
   echo "  Repo URL: $REPO_URL"
   echo "  Installed: $DOTFILES_HOME"
   echo "  Development: $DOTFILES_DEV"
   echo ""
 
-  info "Detecting current dotfiles state..."
+  gum log --level info "Detecting current dotfiles state..."
   local state
   state=$(detect_state)
   echo "  Current state: $state"
@@ -78,27 +73,27 @@ main() {
       local target
       target=$(readlink "$DOTFILES_HOME")
       # shellcheck disable=SC2088 # tilde is intentional display text
-      info "~/.dotfiles is a symlink to: $target"
+      gum log --level info "~/.dotfiles is a symlink to: $target"
 
       if [[ "$target" == "$DOTFILES_DEV" ]] || [[ "$target" == "$DOTFILES_DEV/" ]]; then
-        info "Symlink points to dev directory - will replace with independent clone"
+        gum log --level info "Symlink points to dev directory - will replace with independent clone"
       fi
 
-      info "Removing symlink..."
+      gum log --level info "Removing symlink..."
       rm "$DOTFILES_HOME"
 
-      info "Cloning fresh copy to $DOTFILES_HOME..."
+      gum log --level info "Cloning fresh copy to $DOTFILES_HOME..."
       git clone "$REPO_URL" "$DOTFILES_HOME"
 
       # Set up remote HEAD for default branch detection
       git -C "$DOTFILES_HOME" remote set-head origin --auto 2>/dev/null || true
 
-      success "Installed dotfiles cloned"
+      gum log --level info "Installed dotfiles cloned"
       ;;
 
     clone)
       # shellcheck disable=SC2088 # tilde is intentional display text
-      info "~/.dotfiles is already a git clone"
+      gum log --level info "~/.dotfiles is already a git clone"
 
       local current_remote
       current_remote=$(git -C "$DOTFILES_HOME" remote get-url origin 2>/dev/null)
@@ -111,55 +106,54 @@ main() {
       local default_branch
       default_branch=$(get_default_branch "$DOTFILES_HOME")
 
-      info "Updating to latest ($default_branch)..."
+      gum log --level info "Updating to latest ($default_branch)..."
       git -C "$DOTFILES_HOME" fetch origin "$default_branch"
       git -C "$DOTFILES_HOME" checkout "$default_branch" 2>/dev/null || true
       git -C "$DOTFILES_HOME" pull --ff-only origin "$default_branch" || {
-        warn "Could not fast-forward - you may have local changes"
+        gum log --level warn "Could not fast-forward - you may have local changes"
       }
-      success "Installed dotfiles updated"
+      gum log --level info "Installed dotfiles updated"
       ;;
 
     missing)
-      info "No ~/.dotfiles found - fresh install"
-      info "Cloning to $DOTFILES_HOME..."
+      gum log --level info "No ~/.dotfiles found - fresh install"
+      gum log --level info "Cloning to $DOTFILES_HOME..."
       git clone "$REPO_URL" "$DOTFILES_HOME"
 
       # Set up remote HEAD for default branch detection
       git -C "$DOTFILES_HOME" remote set-head origin --auto 2>/dev/null || true
 
-      success "Installed dotfiles cloned"
+      gum log --level info "Installed dotfiles cloned"
       ;;
 
     *)
-      error "Unknown state at $DOTFILES_HOME - please investigate manually"
+      gum log --level error "Unknown state at $DOTFILES_HOME - please investigate manually"
       exit 1
       ;;
   esac
 
   # Handle DOTFILES_DEV
-  info "Checking development directory..."
+  gum log --level info "Checking development directory..."
   if [[ -d "$DOTFILES_DEV/.git" ]]; then
-    info "Development directory already exists at $DOTFILES_DEV"
-    success "Development dotfiles ready"
+    gum log --level info "Development directory already exists at $DOTFILES_DEV"
   elif [[ -e "$DOTFILES_DEV" ]]; then
-    warn "$DOTFILES_DEV exists but is not a git repo"
-    warn "Please move or remove it, then re-run this script"
+    gum log --level warn "$DOTFILES_DEV exists but is not a git repo"
+    gum log --level warn "Please move or remove it, then re-run this script"
   else
-    info "Creating development directory..."
+    gum log --level info "Creating development directory..."
     mkdir -p "$(dirname "$DOTFILES_DEV")"
     git clone "$REPO_URL" "$DOTFILES_DEV"
 
     # Set up remote HEAD for default branch detection
     git -C "$DOTFILES_DEV" remote set-head origin --auto 2>/dev/null || true
 
-    success "Development dotfiles cloned"
+    gum log --level info "Development dotfiles cloned"
   fi
 
   # Verify we now have two separate directories
   if [[ -L "$DOTFILES_HOME" ]]; then
     # shellcheck disable=SC2088 # tilde is intentional display text
-    error "~/.dotfiles is still a symlink - something went wrong"
+    gum log --level error "~/.dotfiles is still a symlink - something went wrong"
     exit 1
   fi
 
@@ -172,24 +166,24 @@ main() {
   dev_git=$(cd "$DOTFILES_DEV" && pwd -P)/.git
 
   if [[ "$home_git" == "$dev_git" ]]; then
-    error "Both directories share the same .git - this shouldn't happen"
+    gum log --level error "Both directories share the same .git - this shouldn't happen"
     exit 1
   fi
 
-  success "Separate directories verified"
+  gum log --level info "Separate directories verified"
 
   # Run bootstrap from installed version
-  info "Running bootstrap from installed dotfiles..."
+  gum log --level info "Running bootstrap from installed dotfiles..."
   "$DOTFILES_HOME/scripts/bootstrap"
 
   # Run macOS setup (includes launchd job)
   if [[ "$(uname)" == "Darwin" ]] && [[ -x "$DOTFILES_HOME/macos/install.sh" ]]; then
-    info "Running macOS setup..."
+    gum log --level info "Running macOS setup..."
     ZSH="$DOTFILES_HOME" "$DOTFILES_HOME/macos/install.sh"
   fi
 
   echo ""
-  success "Setup complete!"
+  gum log --level info "Setup complete"
   echo ""
   echo "  Installed dotfiles: $DOTFILES_HOME (auto-syncs daily)"
   echo "  Development dotfiles: $DOTFILES_DEV (for making changes)"


### PR DESCRIPTION
Replaces ad-hoc ANSI helpers, bare `read` prompts, and silent long-running commands across the repo with gum's native primitives. Drops divergent `info`/`warn`/`error`/`log` wrappers in favor of inline `gum log --level X`, removes dead `logger -t TAG` syslog routing, and trims the TTY-detected `stream()` helper added in #400 down to direct `gum spin` calls.

## Changes

- `bin/dotfiles-upgrade`: drop the `stream()` helper, ANSI color block, and per-phase log files. Use `gum spin --show-output --show-error` directly. Only the install phase's stdout is captured to a tempfile, since that is all `create_things_task` consumes.
- `bin/dotfiles-sync`: drop `log()` and `LOG_TAG`. Inline `gum log --level X` and wrap the fetch retry loop in `gum spin`.
- `bin/claude-upgrade`: same cleanup as `dotfiles-sync`. The `gum confirm` discard prompt was already in place earlier in the branch.
- `bin/tmux-usage-report`: replace the `===`/`---` echo headers with `gum format --type markdown` and the event-frequency block with `gum table --print`.
- `bin/dotf`: wrap `brew update` in `gum spin --show-output --show-error`.
- `scripts/setup`: drop the four ANSI `info`/`warn`/`error`/`success` helpers and inline `gum log --level X`. Indented data `echo` lines stay as-is.
- `scripts/install`: wrap `brew bundle` in `gum spin --show-output --show-error`.
- `scripts/bootstrap`: replace `info`/`user`/`success`/`fail` helpers with inline `gum log`; replace `read` prompts with `gum input`.
- `github/install.sh`: replace the per-prompt remove loop with `gum choose --no-limit` plus a `gum spin` per removal.
- `.claude/skills/gum/SKILL.md` (new): document the house style so future scripts adopt the same idioms. Covers `gum log`, `gum spin`, `gum confirm` under `set -e`, `gum input`, `gum choose`, and `gum format`/`gum table`. Links the upstream gum README.
