### PR TITLE
upgrade: stream install output live

### DIFF
--- a/bin/dotfiles-upgrade
+++ b/bin/dotfiles-upgrade
@@ -4,6 +4,7 @@
 # Syncs dotfiles, runs scripts/install, creates Things task on failure
 
 set -e
+set -o pipefail
 
 DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 
@@ -51,8 +52,8 @@ if ! gum spin --show-output --show-error --title "Syncing dotfiles" -- \
   exit 1
 fi
 
-if ! gum spin --show-output --show-error --title "Running install" -- \
-  "$DOTFILES_HOME/scripts/install" > "$INSTALL_LOG" 2>&1; then
+gum log --level info "Running install"
+if ! "$DOTFILES_HOME/scripts/install" 2>&1 | tee "$INSTALL_LOG"; then
   gum log --level error "install failed"
   create_things_task
   exit 1


### PR DESCRIPTION
Streams `scripts/install` output live to the terminal instead of hiding it behind `gum spin` and a log redirect. The previous wrapper was the wrong shape for a multi-minute job that runs `brew bundle`, `mise install`, symlinks, and every topic installer: output only escaped the redirect when sudo wrote to `/dev/tty`, leaving long silent gaps.

## Changes

- Drop `gum spin` around install; announce with `gum log` and run the script directly
- `tee` to `$INSTALL_LOG` so the Things task fallback still has the last 100 lines on failure
- Add `set -o pipefail` so install failures propagate through the `tee` pipe
