### PR TITLE
neovim: add lualine, gitsigns, and visual polish

### DIFF
--- a/neovim/config/init.lua
+++ b/neovim/config/init.lua
@@ -6,9 +6,14 @@ vim.pack.add({
   "https://github.com/nvim-lua/plenary.nvim",
   "https://github.com/nvim-treesitter/nvim-treesitter",
   "https://github.com/christoomey/vim-tmux-navigator",
+  "https://github.com/nvim-lualine/lualine.nvim",
+  "https://github.com/lewis6991/gitsigns.nvim",
 })
 
+require("config.options")
 require("config.colorscheme")
+require("config.statusline")
+require("config.gitsigns")
 require("config.keymaps")
 require("config.treesitter")
 require("config.lsp")

--- a/neovim/config/lua/config/colorscheme.lua
+++ b/neovim/config/lua/config/colorscheme.lua
@@ -1,10 +1,26 @@
 require("catppuccin").setup({
   flavour = "auto",
   background = { light = "latte", dark = "mocha" },
+  styles = {
+    comments = { "italic" },
+    conditionals = { "italic" },
+    keywords = { "italic" },
+  },
   integrations = {
     treesitter = true,
     telescope = { enabled = true },
-    native_lsp = { enabled = true },
+    native_lsp = {
+      enabled = true,
+      underlines = {
+        errors = { "undercurl" },
+        hints = { "undercurl" },
+        warnings = { "undercurl" },
+        information = { "undercurl" },
+      },
+    },
+    gitsigns = true,
+    cmp = true,
+    mini = { enabled = true },
   },
 })
 

--- a/neovim/config/lua/config/diagnostics.lua
+++ b/neovim/config/lua/config/diagnostics.lua
@@ -1,12 +1,12 @@
 vim.diagnostic.config({
   severity_sort = true,
-  virtual_text = { spacing = 2 },
+  virtual_text = { spacing = 2, prefix = "●" },
   signs = {
     text = {
-      [vim.diagnostic.severity.ERROR] = "E",
-      [vim.diagnostic.severity.WARN] = "W",
-      [vim.diagnostic.severity.INFO] = "I",
-      [vim.diagnostic.severity.HINT] = "H",
+      [vim.diagnostic.severity.ERROR] = "",
+      [vim.diagnostic.severity.WARN] = "",
+      [vim.diagnostic.severity.INFO] = "",
+      [vim.diagnostic.severity.HINT] = "",
     },
   },
 })

--- a/neovim/config/lua/config/gitsigns.lua
+++ b/neovim/config/lua/config/gitsigns.lua
@@ -1,0 +1,10 @@
+require("gitsigns").setup({
+  signs = {
+    add          = { text = "▎" },
+    change       = { text = "▎" },
+    delete       = { text = "" },
+    topdelete    = { text = "" },
+    changedelete = { text = "▎" },
+    untracked    = { text = "▎" },
+  },
+})

--- a/neovim/config/lua/config/options.lua
+++ b/neovim/config/lua/config/options.lua
@@ -1,0 +1,8 @@
+vim.o.number = true
+vim.o.relativenumber = true
+vim.o.cursorline = true
+vim.o.signcolumn = "yes"
+vim.o.scrolloff = 8
+vim.o.termguicolors = true
+vim.o.showmode = false
+vim.o.laststatus = 3

--- a/neovim/config/lua/config/statusline.lua
+++ b/neovim/config/lua/config/statusline.lua
@@ -1,0 +1,16 @@
+require("lualine").setup({
+  options = {
+    theme = "catppuccin",
+    component_separators = { left = "│", right = "│" },
+    section_separators = { left = "", right = "" },
+    globalstatus = true,
+  },
+  sections = {
+    lualine_a = { "mode" },
+    lualine_b = { "branch", "diff", "diagnostics" },
+    lualine_c = { { "filename", path = 1 } },
+    lualine_x = { "encoding", "fileformat", "filetype" },
+    lualine_y = { "progress" },
+    lualine_z = { "location" },
+  },
+})


### PR DESCRIPTION
Levels up the neovim visual style with a lualine status bar, gitsigns gutter markers, expanded catppuccin integrations, and Nerd Font diagnostic icons.

## Changes

- Add `lualine.nvim` and `gitsigns.nvim` to `vim.pack.add`
- New `config.options` for visual UI: `number`, `relativenumber`, `cursorline`, `signcolumn=yes`, `scrolloff=8`, `laststatus=3`, `showmode=false`
- New `config.statusline` configures lualine with the `catppuccin` theme, powerline section separators, and a global statusline with branch/diff/diagnostics/file/progress sections
- New `config.gitsigns` with thin block-character signs
- Catppuccin gains italic comments/conditionals/keywords, undercurl LSP underlines, and integrations for `gitsigns`, `cmp`, and `mini`
- Diagnostic signs swap ASCII `E`/`W`/`I`/`H` for Nerd Font glyphs, virtual text gets a `●` prefix

## Testing

- `shellspec` passes (existing headless-startup test)
- Verified the worktree config loads cleanly via `XDG_CONFIG_HOME` override pointing at `neovim/config/`
