### PR TITLE
claude: add screenshot-terminal skill

### DIFF
--- a/.claude/skills/screenshot-terminal/SKILL.md
+++ b/.claude/skills/screenshot-terminal/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: screenshot-terminal
+description: Capture screenshots of the user's tmux/terminal setup so the model can see what it actually looks like. Use when the user asks for a visual review of their terminal, tmux status bar, prompt, fonts, or pane chrome, or any case where text introspection (capture-pane, list-panes) loses styling, color, glyph, or layout fidelity.
+---
+
+# screenshot-terminal
+
+This skill is for situations where seeing the rendered terminal matters more than reading its contents. tmux's status bar styling, Catppuccin pills, Nerd Font glyphs, powerline separators, pane chrome, and Ghostty's tab/title bar only render correctly in pixels; `tmux capture-pane` strips all of that.
+
+## Modes
+
+Pick a mode based on what the user is asking for:
+
+- **peek-current** (default for review questions): read-only snapshot of the user's existing tmux session. No `send-keys`, no window switches that disturb the user. Capture the visible Ghostty window, dump structured tmux state (sessions/windows/panes/titles), and read both into context.
+- **drive-current**: send keys to the user's session to set up a specific scene (open fzf, cycle a window, etc.) and capture. Confirm with the user before driving. `tmux/CLAUDE.md` is explicit that you should not send keys to a working pane just to demo.
+- **fresh**: spawn a new detached tmux session, attach it in a new Ghostty window via `open -na Ghostty`, drive it programmatically, capture, and tear down. Use when reproducibility matters or the user's live session would be too noisy.
+
+## Capture pipeline
+
+All modes share the same primitives:
+
+1. `scripts/list-terminal-windows [pattern]`: JXA enumerator over `CGWindowListCopyWindowInfo`. Returns JSON of `{ owner, id, name, bounds }` for Ghostty/iTerm/Terminal/Alacritty/WezTerm/Kitty windows, optionally filtered by a regex against the window name. No focus stealing.
+2. `scripts/find-tmux-window [client-target]`: resolves the CGWindowID hosting the active tmux client. Walks the client's process tree to a terminal app PID; falls back to title scoring (`tmux` / `mosh` / session name) when the chain is broken (mosh, ssh, etc., reparent to PID 1 and break ancestor walking).
+3. `scripts/capture-window <window-id> <out.png>`: wraps `screencapture -x -o -l <id>`. `-x` silences the shutter, `-o` omits window shadow.
+4. `scripts/crop-png <src> <dst> <x> <y> <w> <h>`: crops via `NSBitmapImageRep`. The `sips` CLI fails under Claude Code's sandbox because it writes to a hardcoded `/var/folders` scratch path. Coordinates are in physical pixels (Retina is 2x point coords).
+5. `scripts/tmux-snapshot [out-dir]`: dumps `sessions.tsv`, `windows.tsv`, `panes.tsv`, plus `pane-<id>.txt` per pane. Pairs with the screenshot so the rendered chrome and the textual contents are inspectable side-by-side.
+
+## Gotchas
+
+Always run `scripts/preflight` before capturing. It returns JSON with `ok: true` when capture is viable, or `ok: false` with a `reason` field. Exit codes: 0 ready, 2 locked, 3 no-terminals.
+
+#### Screen lock blocks per-window and per-rect captures
+
+When the screen is locked, Quartz shows `loginwindow` and the `Window Server`'s `Display Shield` topmost in `CGWindowListCopyWindowInfo`. `screencapture -l <id>` and `screencapture -R <rect>` both fail with `could not create image`. Fullscreen `screencapture -x` returns solid black. The only fix is asking the user to unlock. `scripts/preflight` detects this case.
+
+#### Sandbox kills JXA in child scripts
+
+The Claude Code sandbox segfaults JXA's access to AppKit/Quartz when `osascript -l JavaScript` runs from a child shell script, and blocks the tmux unix socket from scripts. Inline JXA (heredoc inside a Bash tool call) works fine. Helper scripts in `scripts/` must be invoked with `dangerouslyDisableSandbox: true` on the Bash call. The sandbox does not cover Write/Edit tool calls, so editing this skill is unaffected. The sandbox also blocks writes to `.claude/skills/` itself; pass the same flag when modifying skill files.
+
+#### `sips` cannot crop under the sandbox
+
+`sips --cropToHeightWidth` writes to a hardcoded `/var/folders` scratch directory the sandbox blocks (`Error 13: an unknown error occurred`). Setting `TMPDIR` does not help. Use `scripts/crop-png` instead, which writes via `NSBitmapImageRep` directly to the destination.
+
+#### Screen Recording permission is on the calling app
+
+`screencapture` requires Screen Recording permission for the *calling* terminal app (Ghostty, iTerm, etc.), not for `screencapture` itself. If captures come back as a uniform color but `scripts/preflight` passes, ask the user to grant Screen Recording in `System Settings → Privacy & Security → Screen Recording`. The terminal app must be relaunched after enabling.
+
+#### JXA does not have `$.exit()`
+
+When writing JXA helpers, do not call `$.exit(N)`; it is undefined and throws. Print JSON to stdout and let the parent shell script translate the result into an exit code (see `scripts/preflight` for the pattern).
+
+#### Don't drive the user's working pane
+
+Per `tmux/CLAUDE.md`: "Don't `send-keys` to their working pane to 'demonstrate'. That defeats the point." Use `fresh` mode for any scene the user shouldn't have to clean up.
+
+#### Permissions JXA does not need
+
+`osascript -l JavaScript` calls into `CGWindowListCopyWindowInfo` do *not* require Accessibility permission as long as enumeration stays read-only. Sending keys via `tmux send-keys` is just a local socket, so no Accessibility needed there either.
+
+## Workflow: peek-current
+
+Default flow when the user asks "what does my setup look like" or "review my status bar" or "why does X look weird":
+
+```sh
+mkdir -p tmp
+.claude/skills/screenshot-terminal/scripts/tmux-snapshot tmp/snapshot
+window_id=$(.claude/skills/screenshot-terminal/scripts/find-tmux-window)
+.claude/skills/screenshot-terminal/scripts/capture-window "$window_id" tmp/snapshot/full.png
+```
+
+`find-tmux-window` is preferred over hand-rolled `jq` against `list-terminal-windows`. Terminal titles do not reliably contain the tmux session name (it depends on `set-titles-string`), and the process-tree walk handles the common case where you are SSHed or moshed into a host running tmux.
+
+Then `Read` the PNG and the TSVs together. The TSVs let you map pane IDs visible in the chrome (`%27`, `%28`) back to current commands and pane titles.
+
+For closer inspection of specific UI regions, status bar at top, prompt at bottom, or a single pane, crop with `scripts/crop-png`. Status bar on this user's setup is approximately the second row of pixels at `y=58, height=50` in a 3870px-wide image (1935 logical px times 2 Retina). Re-measure if the screenshot dimensions differ.
+
+## Workflow: fresh
+
+```sh
+tmux new-session -d -s screenshot-skill -x 120 -y 30 'zsh -i'
+open -na Ghostty --args -e tmux attach -t screenshot-skill
+sleep 1   # wait for the new window to register in CGWindowListCopyWindowInfo
+window_id=$(.claude/skills/screenshot-terminal/scripts/list-terminal-windows | jq -r '
+  [.[] | select(.name | test("screenshot-skill"))] | .[0].id')
+tmux send-keys -t screenshot-skill 'ls -la' Enter
+sleep 0.3
+.claude/skills/screenshot-terminal/scripts/capture-window "$window_id" tmp/fresh.png
+tmux kill-session -t screenshot-skill
+osascript -e 'tell application "Ghostty" to close (every window whose name contains "screenshot-skill")'
+```
+
+`open -na` forces a new app instance; Ghostty's `-e` flag runs a command in the new window. Adjust if the user's terminal is iTerm or Alacritty.
+
+## What this skill does *not* do
+
+- Render terminal output to images headlessly via `freeze` / `termshot` / `silicon`. Those are useful for ANSI-to-PNG but lose tmux chrome and depend on font config, so they don't help with the styling questions this skill exists for.
+- Write reports. The skill produces images and TSVs in `tmp/`. Analysis goes back into the conversation, not into markdown files.
+- Drive the user's working pane without confirmation. See `tmux/CLAUDE.md`.

--- a/.claude/skills/screenshot-terminal/scripts/capture-window
+++ b/.claude/skills/screenshot-terminal/scripts/capture-window
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Capture a single CGWindow by ID into a PNG.
+# Usage: capture-window <window-id> <out.png>
+# Does not steal focus; works on windows that are not topmost.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: capture-window <window-id> <out.png>" >&2
+  exit 64
+fi
+
+window_id="$1"
+out="$2"
+
+mkdir -p "$(dirname "$out")"
+screencapture -x -o -l "$window_id" -t png "$out"
+
+if [[ ! -s "$out" ]]; then
+  echo "capture-window: no output written. The terminal app may lack Screen Recording permission." >&2
+  exit 1
+fi

--- a/.claude/skills/screenshot-terminal/scripts/crop-png
+++ b/.claude/skills/screenshot-terminal/scripts/crop-png
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Crop a PNG via NSBitmapImageRep. Use this instead of `sips` because sips
+# writes to /var/folders scratch which the Claude Code sandbox blocks.
+# Coordinates are in physical pixels, origin top-left.
+# Usage: crop-png <src> <dst> <x> <y> <w> <h>
+
+set -euo pipefail
+
+if [[ $# -ne 6 ]]; then
+  echo "usage: crop-png <src> <dst> <x> <y> <w> <h>  (physical pixels, origin top-left)" >&2
+  exit 64
+fi
+
+SRC="$1" DST="$2" X="$3" Y="$4" W="$5" H="$6"
+mkdir -p "$(dirname "$DST")"
+
+SRC="$SRC" DST="$DST" X="$X" Y="$Y" W="$W" H="$H" osascript -l JavaScript <<'JXA'
+ObjC.import('AppKit');
+ObjC.import('Foundation');
+
+const env = $.NSProcessInfo.processInfo.environment;
+const get = k => ObjC.unwrap(env.objectForKey(k));
+const src = get('SRC'), dst = get('DST');
+const x = parseFloat(get('X')), y = parseFloat(get('Y'));
+const w = parseFloat(get('W')), h = parseFloat(get('H'));
+
+const data = $.NSData.dataWithContentsOfFile(src);
+if (!data.js) throw new Error(`could not read ${src}`);
+const nsimg = $.NSImage.alloc.initWithData(data);
+const cgimg = nsimg.CGImageForProposedRectContextHints($(), $(), $());
+
+const cropped = $.CGImageCreateWithImageInRect(cgimg, $.CGRectMake(x, y, w, h));
+const rep = $.NSBitmapImageRep.alloc.initWithCGImage(cropped);
+// NSBitmapImageFileTypePNG = 4
+const pngData = rep.representationUsingTypeProperties(4, $());
+const ok = pngData.writeToFileAtomically(dst, true);
+if (!ok) throw new Error(`could not write ${dst}`);
+JSON.stringify({ src, dst, src_size: [Number($.CGImageGetWidth(cgimg)), Number($.CGImageGetHeight(cgimg))], crop: [x, y, w, h] });
+JXA

--- a/.claude/skills/screenshot-terminal/scripts/find-tmux-window
+++ b/.claude/skills/screenshot-terminal/scripts/find-tmux-window
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Resolve the CGWindowID of the terminal window hosting a tmux client.
+#
+# Strategy 1 (precise): walk the tmux client's process tree up to a terminal
+# app PID, then match Quartz windows owned by that PID. Falls back when the
+# ancestor chain is broken (e.g. mosh-server detaches and reparents to PID 1).
+#
+# Strategy 2 (heuristic): scan all on-screen terminal windows, prefer ones
+# whose title contains "tmux", "mosh", or the active session name; otherwise
+# take the topmost terminal window.
+#
+# Usage: find-tmux-window [client-target]
+#   find-tmux-window
+#   find-tmux-window /dev/ttys013
+
+set -euo pipefail
+
+target="${1:-}"
+if [[ -n "$target" ]]; then
+  client_pid=$(tmux display-message -p -t "$target" '#{client_pid}' 2>/dev/null)
+  session=$(tmux display-message -p -t "$target" '#S' 2>/dev/null || true)
+else
+  client_pid=$(tmux display-message -p '#{client_pid}' 2>/dev/null)
+  session=$(tmux display-message -p '#S' 2>/dev/null || true)
+fi
+
+if [[ -z "$client_pid" ]]; then
+  echo "find-tmux-window: no tmux client found" >&2
+  exit 1
+fi
+
+TERMS_RE='^(Ghostty|iTerm2|Terminal|Alacritty|WezTerm|kitty)$'
+pid=$client_pid
+terminal_pid=
+for _ in {1..16}; do
+  [[ -z "$pid" || "$pid" == "1" ]] && break
+  comm=$(ps -p "$pid" -o comm= 2>/dev/null | sed 's|.*/||' | xargs)
+  if [[ "$comm" =~ $TERMS_RE ]]; then
+    terminal_pid=$pid
+    break
+  fi
+  pid=$(ps -p "$pid" -o ppid= 2>/dev/null | xargs)
+done
+
+result=$(TERMINAL_PID="${terminal_pid:-0}" SESSION="$session" osascript -l JavaScript <<'JXA'
+ObjC.import('CoreGraphics');
+ObjC.import('Foundation');
+const env = $.NSProcessInfo.processInfo.environment;
+const pid = parseInt(ObjC.unwrap(env.objectForKey('TERMINAL_PID')), 10);
+const session = ObjC.unwrap(env.objectForKey('SESSION')) || '';
+const TERM_RE = /ghostty|iterm|terminal|alacritty|wezterm|kitty/i;
+
+const opts = $.kCGWindowListOptionOnScreenOnly | $.kCGWindowListExcludeDesktopElements;
+const cf = $.CGWindowListCopyWindowInfo(opts, $.kCGNullWindowID);
+const count = $.CFArrayGetCount(cf);
+const all = [];
+for (let i = 0; i < count; i++) {
+  const w = ObjC.deepUnwrap(ObjC.castRefToObject($.CFArrayGetValueAtIndex(cf, i)));
+  if ((w.kCGWindowLayer || 0) !== 0) continue;
+  if (!TERM_RE.test(w.kCGWindowOwnerName || '')) continue;
+  all.push({
+    id: w.kCGWindowNumber,
+    name: w.kCGWindowName || '',
+    pid: w.kCGWindowOwnerPID,
+    zorder: i,
+  });
+}
+
+const candidates = pid ? all.filter(w => w.pid === pid) : all;
+const pool = candidates.length ? candidates : all;
+
+const titleScore = w => {
+  const n = w.name;
+  if (session && n.indexOf(session) !== -1) return 3;
+  if (/tmux/i.test(n)) return 2;
+  if (/mosh|ssh/i.test(n)) return 1;
+  return 0;
+};
+pool.sort((a, b) => titleScore(b) - titleScore(a) || a.zorder - b.zorder);
+pool[0] ? String(pool[0].id) : '';
+JXA
+)
+
+if [[ -z "$result" ]]; then
+  echo "find-tmux-window: no on-screen terminal window found" >&2
+  exit 3
+fi
+
+echo "$result"

--- a/.claude/skills/screenshot-terminal/scripts/list-terminal-windows
+++ b/.claude/skills/screenshot-terminal/scripts/list-terminal-windows
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Enumerate on-screen terminal windows via Quartz. Output JSON.
+# Usage: list-terminal-windows [name-pattern]
+#   name-pattern: optional case-insensitive regex; filters by window name (kCGWindowName)
+
+set -euo pipefail
+
+pattern="${1:-}"
+
+PATTERN="$pattern" osascript -l JavaScript <<'JXA'
+ObjC.import('CoreGraphics');
+ObjC.import('Foundation');
+const env = $.NSProcessInfo.processInfo.environment;
+const patternStr = ObjC.unwrap(env.objectForKey('PATTERN')) || '';
+const opts = $.kCGWindowListOptionOnScreenOnly | $.kCGWindowListExcludeDesktopElements;
+const cf = $.CGWindowListCopyWindowInfo(opts, $.kCGNullWindowID);
+const count = $.CFArrayGetCount(cf);
+const out = [];
+for (let i = 0; i < count; i++) {
+  const dict = $.CFArrayGetValueAtIndex(cf, i);
+  out.push(ObjC.deepUnwrap(ObjC.castRefToObject(dict)));
+}
+const TERMS = /ghostty|iterm|terminal|alacritty|wezterm|kitty/i;
+let terms = out.filter(w => TERMS.test(w.kCGWindowOwnerName || '') && (w.kCGWindowLayer || 0) === 0);
+if (patternStr) {
+  const re = new RegExp(patternStr, 'i');
+  terms = terms.filter(w => re.test(w.kCGWindowName || ''));
+}
+JSON.stringify(terms.map(w => ({
+  owner: w.kCGWindowOwnerName,
+  id: w.kCGWindowNumber,
+  name: w.kCGWindowName || '',
+  bounds: w.kCGWindowBounds
+})), null, 2);
+JXA

--- a/.claude/skills/screenshot-terminal/scripts/preflight
+++ b/.claude/skills/screenshot-terminal/scripts/preflight
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Check whether the host can produce useful screenshots.
+# Prints a single JSON line; exits 0 if ready, non-zero otherwise.
+# Failure modes covered:
+#   screen-locked        loginwindow / Display Shield topmost
+#   no-terminal-windows  nothing to capture
+# Usage: preflight
+
+set -euo pipefail
+
+result=$(osascript -l JavaScript <<'JXA'
+ObjC.import('CoreGraphics');
+ObjC.import('Foundation');
+const onscreen = $.kCGWindowListOptionOnScreenOnly;
+const cf = $.CGWindowListCopyWindowInfo(onscreen, $.kCGNullWindowID);
+const count = $.CFArrayGetCount(cf);
+const wins = [];
+for (let i = 0; i < count; i++) {
+  wins.push(ObjC.deepUnwrap(ObjC.castRefToObject($.CFArrayGetValueAtIndex(cf, i))));
+}
+const locked = wins.some(w =>
+  w.kCGWindowOwnerName === 'loginwindow' ||
+  (w.kCGWindowOwnerName === 'Window Server' && /Shield/.test(w.kCGWindowName || ''))
+);
+const TERMS = /ghostty|iterm|terminal|alacritty|wezterm|kitty/i;
+const terms = wins.filter(w => TERMS.test(w.kCGWindowOwnerName || '') && (w.kCGWindowLayer || 0) === 0);
+const out = { locked, terminal_window_count: terms.length };
+if (locked)            JSON.stringify({ ok: false, reason: 'screen-locked',       detail: out });
+else if (!terms.length) JSON.stringify({ ok: false, reason: 'no-terminal-windows', detail: out });
+else                    JSON.stringify({ ok: true,                                 detail: out });
+JXA
+)
+
+echo "$result"
+case "$result" in
+  *'"ok":true'*)                 exit 0 ;;
+  *'"reason":"screen-locked"'*)  exit 2 ;;
+  *'"reason":"no-terminal-windows"'*) exit 3 ;;
+  *)                             exit 1 ;;
+esac

--- a/.claude/skills/screenshot-terminal/scripts/tmux-snapshot
+++ b/.claude/skills/screenshot-terminal/scripts/tmux-snapshot
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Dump a structured snapshot of the current tmux server: sessions, windows,
+# panes, and per-pane visible buffer. Pairs with capture-window output so the
+# rendered chrome and the textual contents are inspectable side-by-side.
+# Usage: tmux-snapshot [out-dir]   (default: tmp/tmux-snapshot)
+
+set -euo pipefail
+
+out="${1:-tmp/tmux-snapshot}"
+mkdir -p "$out"
+
+tmux list-sessions \
+  -F '#{session_name}|#{session_windows}|#{session_attached}|#{session_created}' \
+  > "$out/sessions.tsv"
+
+tmux list-windows -a \
+  -F '#{session_name}|#{window_index}|#{window_name}|#{window_panes}|#{window_active}|#{window_flags}|#{window_layout}' \
+  > "$out/windows.tsv"
+
+tmux list-panes -a \
+  -F '#{session_name}|#{window_index}|#{window_name}|#{pane_index}|#{pane_id}|#{pane_active}|#{pane_current_command}|#{pane_width}x#{pane_height}|#{pane_title}' \
+  > "$out/panes.tsv"
+
+# Visible buffer per pane (no scrollback).
+mkdir -p "$out/panes"
+while IFS='|' read -r _s _w _wn _p pane_id _; do
+  tmux capture-pane -p -t "$pane_id" > "$out/panes/${pane_id#%}.txt" 2>/dev/null || true
+done < "$out/panes.tsv"
+
+cat <<INFO
+$out/
+  sessions.tsv  $(wc -l < "$out/sessions.tsv" | tr -d ' ') session(s)
+  windows.tsv   $(wc -l < "$out/windows.tsv" | tr -d ' ') window(s)
+  panes.tsv     $(wc -l < "$out/panes.tsv" | tr -d ' ') pane(s)
+  panes/        per-pane visible buffer
+INFO


### PR DESCRIPTION
Adds a project skill that captures pixel-faithful screenshots of the user's tmux/Ghostty setup so the model can review status bar styling, Nerd Font glyphs, pane chrome, and other surfaces that text introspection (`tmux capture-pane`) strips.

## Changes

- `SKILL.md` documents three modes (peek-current, drive-current, fresh) and the failure modes encountered while building it: screen lock blocking per-window captures, JXA segfaulting from child shell scripts under the sandbox, `sips` failing on its hardcoded scratch path, and JXA not exposing `$.exit()`.
- `scripts/preflight` returns JSON and a status code indicating whether capture is viable. Detects `loginwindow` / `Display Shield` topmost (screen locked) and missing terminal windows.
- `scripts/find-tmux-window` resolves the host terminal's `CGWindowID` for the active tmux client. Walks the client's process tree to a terminal app PID; falls back to title-based scoring (`tmux` / `mosh` / session name) when the chain is broken, which happens routinely with mosh and ssh because the server detaches and reparents to PID 1.
- `scripts/list-terminal-windows` enumerates Ghostty/iTerm/Terminal/Alacritty/WezTerm/Kitty windows via `CGWindowListCopyWindowInfo`, with an optional regex name filter.
- `scripts/capture-window` wraps `screencapture -x -o -l <id>`. `scripts/crop-png` crops via `NSBitmapImageRep`, since `sips` writes to a hardcoded `/var/folders` scratch path the sandbox blocks.
- `scripts/tmux-snapshot` dumps `sessions.tsv`, `windows.tsv`, `panes.tsv`, and per-pane visible buffers so the rendered chrome and the textual contents are inspectable side-by-side.
