### PR TITLE
tmux: fix window-label glyph filter on bash 3.2

### DIFF
--- a/tmux/appearance/bin/_tmux-window-label
+++ b/tmux/appearance/bin/_tmux-window-label
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
+# Emit ' <glyph>' if the pane title's first character is a non-ASCII glyph
+# (spinner, icon, etc.), so window labels surface Claude's status without
+# leaking ASCII punctuation or directory names.
+#
+# Bash 3.2 (system bash on macOS) does not support [[:ascii:]] inside =~,
+# so detect non-ASCII via byte length: any UTF-8 codepoint outside ASCII
+# encodes to >1 byte.
 title="$1"
 [[ -z "$title" ]] && exit 0
 first="${title::1}"
-[[ "$first" =~ ^[[:ascii:]]$ ]] || printf ' %s' "$first"
+(( $(LC_ALL=C printf %s "$first" | wc -c) > 1 )) && printf ' %s' "$first"


### PR DESCRIPTION
The `[[:ascii:]]` POSIX character class is unsupported inside bash 3.2's `=~` operator (system bash on macOS), so the gate in `_tmux-window-label` always failed and the helper emitted the first character of every pane title. tmux window labels picked up ASCII punctuation, like the leading `(` from a directory-prefixed prompt title, instead of only non-ASCII spinner glyphs.

Switches to a byte-length check: any non-ASCII UTF-8 codepoint encodes to more than one byte under `LC_ALL=C`, so `${title::1}` (one character in the user's UTF-8 locale) reports `>1` byte iff the first character is non-ASCII.
