### PR TITLE
tmux: cap window-status pane titles at 24 chars

### DIFF
--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -1,6 +1,13 @@
 set -g status-left "#{E:@catppuccin_status_session}"
 set -g status-right "#{?#{==:#(_tmux-bell-count),0},,#{E:@catppuccin_status_bell}}"
 
+# Catppuccin's rounded style bakes #T (pane title) into window-status-format
+# verbatim and ignores @catppuccin_window_current_text. Override after the
+# plugin runs to cap each pill's title at 24 chars so long pane titles stop
+# overflowing the status region (which triggers a left-edge "<" marker).
+set -g window-status-format "#[fg=#dce0e8,bg=#{@thm_overlay_2}] #I #[fg=#4c4f69,bg=#{@thm_surface_0}] #{=24:pane_title} "
+set -g window-status-current-format "#[fg=#dce0e8,bg=#{@thm_mauve}] #I #[fg=#4c4f69,bg=#{@thm_surface_1}] #{=24:pane_title} "
+
 # Pane border labels — hidden when a window has only one pane (shells, editors,
 # and Claude Code already self-identify inside the pane). When split, show just
 # the pane index centered on the top border so prefix+<n> navigation is easy.


### PR DESCRIPTION
Caps each window-status pill's pane title at 24 characters so long titles (e.g. Claude task descriptions) stop pushing the focused pill into the region-overflow `<` marker on the left edge of the status bar.

## Issue

When a window's pane title exceeds the available width in the status-line region, tmux scrolls the window list to keep the focused pill visible and prepends a `<` (or appends `>`) marker to indicate truncation. With Claude Code panes setting titles like `✳ Apply Catppuccin styling to development tools`, the marker fires constantly, leaving labels like `< development tools` that are hard to scan.

## Changes

- Override `window-status-format` and `window-status-current-format` in `tmux/appearance/status.conf` to wrap the title in `#{=24:pane_title}`.
- Override goes in `status.conf` (sourced after TPM) because catppuccin's `rounded` style bakes `#T` directly into the formats and ignores `@catppuccin_window_current_text`.
- Uses the long-form `#{pane_title}` rather than the `#T` shorthand. `#T` does not resolve inside `#{=N:…}` and silently produces an empty string.

## Testing

- Reload via `tmux source-file tmux/appearance/status.conf` and confirmed each pill clamps to 24 chars with no `<` marker on long titles.
- Verified theme-sync continues to re-source `status.conf` last so the override survives flavor flips.
