### PR TITLE
Enable selection color inversion in Ghostty to match tmux

### DIFF
--- a/terminal/ghostty.config
+++ b/terminal/ghostty.config
@@ -1,5 +1,9 @@
 theme = dark:catppuccin-mocha,light:catppuccin-latte
 
+# Match tmux copy-mode selection rendering (which inverts via mode-style) so
+# selections look the same whether tmux is intercepting them or not.
+selection-invert-fg-bg = true
+
 shell-integration-features = sudo,ssh-terminfo,ssh-env
 
 # Hyper+A → tmux prefix (Ctrl+B)


### PR DESCRIPTION
## Summary
Updated Ghostty terminal configuration to enable selection color inversion, ensuring consistent visual rendering of text selections whether they are handled by Ghostty or intercepted by tmux.

## Changes
- Added `selection-invert-fg-bg = true` configuration option to match tmux's copy-mode selection rendering behavior
- Added explanatory comment documenting the rationale: tmux uses mode-style to invert selection colors, so this setting ensures selections appear identical regardless of whether tmux is intercepting them

## Details
This change addresses a visual inconsistency where selections would render differently depending on whether tmux was actively intercepting the selection. By enabling foreground/background color inversion for selections in Ghostty, the appearance is now unified across both scenarios.

https://claude.ai/code/session_016Q6UXvwUZepQkMYP6PU412