### PR TITLE
Add hunkdiff to default npm packages

### DIFF
--- a/terminal/default-npm-packages
+++ b/terminal/default-npm-packages
@@ -1,0 +1,1 @@
+hunkdiff


### PR DESCRIPTION
## Summary
Added `hunkdiff` to the list of default npm packages that should be installed in the terminal environment.

## Changes
- Added `hunkdiff` package to `terminal/default-npm-packages` configuration file

## Details
This change ensures that `hunkdiff` will be included as a default npm package available in the terminal environment, making it readily accessible for users without requiring manual installation.

https://claude.ai/code/session_0125YsGUcu9TvsFkmAUMYfKT