### PR TITLE
tmux: add herdr popup binding

### DIFF
--- a/claude/install.sh
+++ b/claude/install.sh
@@ -47,5 +47,23 @@ install_claude_symlinks() {
   done
 }
 
+install_herdr_claude_hook() {
+  local hook_dir="$HOME/.claude/hooks"
+  local hook_path="$hook_dir/herdr-agent-state.sh"
+  local temp_home
+  temp_home="$(mktemp -d)"
+
+  # herdr's installer also adds hook entries to ~/.claude/settings.json,
+  # which the bendrucker/herdr plugin already provides via hooks.json.
+  # Route the installer at a throwaway HOME and copy out only the script.
+  HOME="$temp_home" herdr integration install claude >/dev/null
+  mkdir -p "$hook_dir"
+  cp -p "$temp_home/.claude/hooks/herdr-agent-state.sh" "$hook_path"
+  rm -rf "$temp_home"
+
+  echo "  ✓ ~/.claude/hooks/herdr-agent-state.sh"
+}
+
 setup_claude_repo
 install_claude_symlinks
+install_herdr_claude_hook

--- a/claude/install.sh
+++ b/claude/install.sh
@@ -56,6 +56,7 @@ install_herdr_claude_hook() {
   # herdr's installer also adds hook entries to ~/.claude/settings.json,
   # which the bendrucker/herdr plugin already provides via hooks.json.
   # Route the installer at a throwaway HOME and copy out only the script.
+  mkdir -p "$temp_home/.claude"
   HOME="$temp_home" herdr integration install claude >/dev/null
   mkdir -p "$hook_dir"
   cp -p "$temp_home/.claude/hooks/herdr-agent-state.sh" "$hook_path"

--- a/tmux/herdr.toml
+++ b/tmux/herdr.toml
@@ -1,0 +1,1 @@
+onboarding = false

--- a/tmux/mise.toml
+++ b/tmux/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"github:ogulcancelik/herdr" = "0.5.5"

--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -11,6 +11,8 @@ set-environment -g TMUX_FZF_OPTIONS "-p -w 60% -h 60%"
 bind -N "Switch session" t display-popup -E -w 80% -h 80% "sesh connect \$(sesh list -i | fzf --no-sort --ansi --border --border-label ' sesh ' --prompt '  ')"
 bind -N "Switch window" w run-shell -b '$TMUX_PLUGIN_MANAGER_PATH/tmux-fzf/scripts/window.sh switch'
 
+bind -N "Open herdr agent multiplexer" H display-popup -E -w 90% -h 90% herdr
+
 bind -N "Grab scrollback to clipboard" g run-shell tmux-grab-scrollback
 
 bind -N "Open linked session for window browsing" X run-shell 'tmux new-session -d -t "#{session_name}" -s "#{session_name}-linked" 2>/dev/null; tmux switch-client -t "#{session_name}-linked"'

--- a/tmux/symlinks.conf
+++ b/tmux/symlinks.conf
@@ -1,1 +1,3 @@
 .:$XDG_CONFIG_HOME/tmux
+mise.toml:$XDG_CONFIG_HOME/mise/conf.d/tmux.toml
+herdr.toml:$XDG_CONFIG_HOME/herdr/config.toml


### PR DESCRIPTION
Adds `prefix + H` to launch [herdr](https://github.com/ogulcancelik/herdr), an agent multiplexer, in a centered 90% x 90% tmux popup. Closing the popup detaches the client. Herdr's own background server keeps agents running.

## Changes

- `tmux/navigation/navigation.conf`: new binding `bind H display-popup -E -w 90% -h 90% herdr`
- `tmux/mise.toml`: pin `github:ogulcancelik/herdr` to `0.5.5` (no Homebrew formula yet, so using mise's GitHub backend)
- `tmux/herdr.toml`: ship `onboarding = false` so fresh machines skip the first-run flow
- `tmux/symlinks.conf`: install `mise.toml` to `mise/conf.d/tmux.toml` and `herdr.toml` to `herdr/config.toml`

Kept herdr's default `ctrl+b` prefix since the tmux prefix is `C-s`, so no collision.
