### PR TITLE
ci: disable brew upgrade to keep cached bottles stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,9 @@ jobs:
     - name: Cache Homebrew packages
       uses: actions/cache@v5
       with:
-        key: homebrew-${{ runner.os }}-${{ hashFiles('**/Brewfile') }}
+        key: homebrew-v2-${{ runner.os }}-${{ hashFiles('**/Brewfile') }}
         restore-keys: |
-          homebrew-${{ runner.os }}-
+          homebrew-v2-${{ runner.os }}-
         path: |
           ~/Library/Caches/Homebrew
           /home/linuxbrew/.linuxbrew

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,7 @@ jobs:
       run: sudo apt-get install -y zsh
     - name: Overwrite conflicting formulae
       if: ${{ runner.os == 'macOS' }}
-      run: |
-        brew update
-        brew upgrade openssl@3 || brew link --overwrite openssl@3
+      run: brew link --overwrite openssl@3 || true
     - name: Print Homebrew configuration
       run: brew config
     - name: Cache mise installs
@@ -57,7 +55,10 @@ jobs:
     - name: Bootstrap
       run: ./scripts/bootstrap
       env:
-        # skip updates/upgrades to speed up install
+        # skip updates/upgrades to speed up install and keep cached bottles
+        # stable. Upgrades relink against host libs that may be missing on
+        # later runs (e.g. bat against libllhttp.so on Linux).
+        HOMEBREW_NO_AUTO_UPDATE: '1'
         HOMEBREW_NO_INSTALL_UPGRADE: '1'
         # remove stale packages from cache
         HOMEBREW_BUNDLE_INSTALL_CLEANUP: '1'


### PR DESCRIPTION
CI was failing on Linux because `bat/install.sh` calls `bat cache --build`, and the cached `/home/linuxbrew/.linuxbrew` had `bat` linked against `libllhttp.so.9.3`, which no longer exists on the runner image. Each `brew upgrade` re-pulls bottles that may link against host libraries unavailable on the next run, so the simplest fix is to stop upgrading entirely and let the cached bottles stay put.

## Changes

- Added `HOMEBREW_NO_AUTO_UPDATE: '1'` to the bootstrap env. `HOMEBREW_NO_INSTALL_UPGRADE: '1'` was already set, but without `NO_AUTO_UPDATE` a `brew install` (e.g. `brew install gum` in `scripts/homebrew.sh`) still kicks off an update that can cascade into upgrades.
- Dropped the macOS `brew update` + `brew upgrade openssl@3` from the "Overwrite conflicting formulae" step. The `brew link --overwrite openssl@3` fallback already resolves the conflict without rebuilding.
