### PR TITLE
theme: sync fzf flavor with macOS appearance

### DIFF
--- a/system/fzf.zsh
+++ b/system/fzf.zsh
@@ -4,8 +4,10 @@
 # system appearance changes. Falls back to mocha on first install before
 # the cache exists.
 _fzf_opts_cache="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/fzf-default-opts"
-if [[ -r "$_fzf_opts_cache" ]]; then
-  export FZF_DEFAULT_OPTS="$(<$_fzf_opts_cache)"
+# -s (non-empty) guards against a truncated/zero-byte cache from an interrupted
+# write; -r alone would let an empty cache blank out FZF_DEFAULT_OPTS entirely.
+if [[ -s "$_fzf_opts_cache" ]]; then
+  export FZF_DEFAULT_OPTS="$(<"$_fzf_opts_cache")"
 else
   export FZF_DEFAULT_OPTS=" \
 --color=bg+:#313244,bg:#1e1e2e,spinner:#f5e0dc,hl:#f38ba8 \

--- a/system/fzf.zsh
+++ b/system/fzf.zsh
@@ -1,9 +1,17 @@
 #!/usr/bin/env zsh
-# Catppuccin Mocha colors for fzf. Pinned: fzf reads FZF_DEFAULT_OPTS at
-# invocation, so an in-shell flip would still leave running shells stale.
-export FZF_DEFAULT_OPTS=" \
+# Catppuccin colors for fzf, flavored to the active macOS appearance.
+# Reads from a cache file (no subshell on startup) populated whenever the
+# system appearance changes. Falls back to mocha on first install before
+# the cache exists.
+_fzf_opts_cache="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/fzf-default-opts"
+if [[ -r "$_fzf_opts_cache" ]]; then
+  export FZF_DEFAULT_OPTS="$(<$_fzf_opts_cache)"
+else
+  export FZF_DEFAULT_OPTS=" \
 --color=bg+:#313244,bg:#1e1e2e,spinner:#f5e0dc,hl:#f38ba8 \
 --color=fg:#cdd6f4,header:#f38ba8,info:#cba6f7,pointer:#f5e0dc \
 --color=marker:#b4befe,fg+:#cdd6f4,prompt:#cba6f7,hl+:#f38ba8 \
 --color=selected-bg:#45475a \
 --color=border:#6c7086,label:#cdd6f4"
+fi
+unset _fzf_opts_cache

--- a/system/install.sh
+++ b/system/install.sh
@@ -12,3 +12,4 @@ if [ ! -f "$btop_conf" ]; then
   btop --default-config > "$btop_conf"
 fi
 "$script_dir/../theme/bin/theme-sync-btop"
+"$script_dir/../theme/bin/theme-sync-fzf"

--- a/theme/bin/theme-fzf-opts
+++ b/theme/bin/theme-fzf-opts
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Print FZF_DEFAULT_OPTS color flags for the active catppuccin flavor.
+set -euo pipefail
+
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
+flavor="$("$bin_dir/theme-flavor")"
+
+if [[ "$flavor" == "latte" ]]; then
+  cat <<'EOF'
+--color=bg+:#ccd0da,bg:#eff1f5,spinner:#dc8a78,hl:#d20f39 --color=fg:#4c4f69,header:#d20f39,info:#8839ef,pointer:#dc8a78 --color=marker:#7287fd,fg+:#4c4f69,prompt:#8839ef,hl+:#d20f39 --color=selected-bg:#bcc0cc --color=border:#9ca0b0,label:#4c4f69
+EOF
+else
+  cat <<'EOF'
+--color=bg+:#313244,bg:#1e1e2e,spinner:#f5e0dc,hl:#f38ba8 --color=fg:#cdd6f4,header:#f38ba8,info:#cba6f7,pointer:#f5e0dc --color=marker:#b4befe,fg+:#cdd6f4,prompt:#cba6f7,hl+:#f38ba8 --color=selected-bg:#45475a --color=border:#6c7086,label:#cdd6f4
+EOF
+fi

--- a/theme/bin/theme-sync-fzf
+++ b/theme/bin/theme-sync-fzf
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Apply the active catppuccin flavor to fzf.
+# Writes the opts cache for new shells; also pushes the value into tmux's
+# global env so popup commands (which run sh -c, not zsh) get the right palette.
+set -euo pipefail
+
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
+want="$("$bin_dir/theme-fzf-opts")"
+
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles"
+cache="$cache_dir/fzf-default-opts"
+
+mkdir -p "$cache_dir"
+if [[ ! -f "$cache" ]] || [[ "$(<"$cache")" != "$want" ]]; then
+  tmp="$cache.tmp.$$"
+  printf '%s\n' "$want" > "$tmp"
+  mv "$tmp" "$cache"
+fi
+
+if tmux list-sessions >/dev/null 2>&1; then
+  current=$(tmux show-environment -g FZF_DEFAULT_OPTS 2>/dev/null | sed 's/^FZF_DEFAULT_OPTS=//')
+  if [[ "$current" != "$want" ]]; then
+    tmux set-environment -g FZF_DEFAULT_OPTS "$want"
+  fi
+fi

--- a/theme/bin/theme-sync-fzf
+++ b/theme/bin/theme-sync-fzf
@@ -18,7 +18,9 @@ if [[ ! -f "$cache" ]] || [[ "$(<"$cache")" != "$want" ]]; then
 fi
 
 if tmux list-sessions >/dev/null 2>&1; then
-  current=$(tmux show-environment -g FZF_DEFAULT_OPTS 2>/dev/null | sed 's/^FZF_DEFAULT_OPTS=//')
+  # tmux show-environment exits 1 with "unknown variable" on stderr when the
+  # var isn't set; the || keeps set -euo pipefail from aborting first-run.
+  current=$(tmux show-environment -g FZF_DEFAULT_OPTS 2>/dev/null | sed 's/^FZF_DEFAULT_OPTS=//') || current=""
   if [[ "$current" != "$want" ]]; then
     tmux set-environment -g FZF_DEFAULT_OPTS "$want"
   fi


### PR DESCRIPTION
Tmux popups (sesh switcher, `tmux-fzf` window switch, `tmux-fingers`) showed mocha fzf colors even after the system flipped to light mode. They run via `display-popup -E <cmd>`, which executes `sh -c <cmd>` and bypasses `.zshrc`, so they only see `FZF_DEFAULT_OPTS` from the tmux server's global env. That value was pinned to mocha in `system/fzf.zsh` and never resynced.

## Changes

- `theme/bin/theme-fzf-opts` is the single source of truth for the catppuccin fzf palette, switching between mocha and latte based on `theme-flavor`.
- `theme/bin/theme-sync-fzf` writes the current palette to `$XDG_CACHE_HOME/dotfiles/fzf-default-opts` and, when a tmux server is running, also pushes it into the global env with `tmux set-environment -g`. Gated on both sides so reruns are no-ops. Hooks into the existing `theme-sync` loop, so the macOS appearance watcher already triggers it.
- `system/fzf.zsh` reads the cache via `$(<file)` (no fork on shell startup, per the repo's startup budget) and falls back to mocha for first-install before the cache is written.
- `system/install.sh` calls `theme-sync-fzf` after btop so the cache exists immediately after bootstrap.

## Review fixes

A high-effort review surfaced two real bugs, fixed in the second commit:

- `theme-sync-fzf`: `set -euo pipefail` aborted the script when `tmux show-environment -g FZF_DEFAULT_OPTS` exited 1 on the first run (variable not yet present in tmux's global env), so the `set-environment` write never happened. Added `|| current=""` to the pipeline.
- `system/fzf.zsh`: `[[ -r ]]` accepts a zero-byte file. An interrupted atomic write would leave `FZF_DEFAULT_OPTS=""`, which disables all fzf colors, worse than the old mocha-only behavior. Switched to `[[ -s ]]` and quoted the file path.

## Testing

- Verified `theme-fzf-opts` returns the correct palette for both flavors.
- Ran `theme-sync-fzf` twice and confirmed the second run is a no-op (gating on both cache file and tmux env).
- Confirmed the cache file is written and `tmux show-environment -g FZF_DEFAULT_OPTS` reflects the active flavor.
- Sourced `system/fzf.zsh` directly from the worktree and confirmed it picks up the cached value.
- Reproduced the pipefail abort in a sandbox, then verified the fix lets the script complete and seed the tmux env from scratch.
- Verified `[[ -s ]]` correctly falls back to mocha on an empty cache file.
