### PR TITLE
terraform: install tflint from 3rd-party tap

### DIFF
--- a/terraform/Brewfile
+++ b/terraform/Brewfile
@@ -1,5 +1,7 @@
 brew 'terraform-docs'
-brew 'tflint'
+
+tap 'terraform-linters/tap'
+cask 'tflint'
 
 tap 'minamijoyo/hcledit'
 brew 'hcledit'


### PR DESCRIPTION
`tflint` was removed from `homebrew-core` and is now distributed as a cask via the official `terraform-linters/tap`.

I switched to `cask 'terraform-linters/tap/tflint'` (with the `tap` declared inline to match the surrounding style in `terraform/Brewfile`). The cask supports both macOS and Linux, and `cask` is already a no-op in CI per the root `Brewfile`.
