### PR TITLE
claude: rework worktree aliases for Claude Code

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -2,20 +2,23 @@
 
 Shell integration for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
-## `ccw` — Claude in a worktree
+## Worktree Aliases
 
-Create a new [worktrunk](https://github.com/nicholasgasior/worktrunk) worktree and launch Claude in it:
+Launch Claude in a [Worktrunk](https://worktrunk.dev) worktree. All variants pass `--name` to Claude, set from the branch name.
+
+| Command | Branch | Permission mode |
+|---------|--------|-----------------|
+| `cw <branch>` | existing | default |
+| `ccw <branch>` | create | default |
+| `cwp <branch>` | create | plan |
+| `cwa <branch>` | existing | auto |
+
+Arguments after `--` are forwarded to `claude`:
 
 ```
-ccw <branch>                      # interactive Claude session
-ccw <branch> -- 'fix the bug'    # Claude with a prompt
+ccw my-feature -- 'fix the bug'
+ccw my-feature --base=@ -- 'stack on current branch'
+cwa pr:123
 ```
 
-Arguments after `--` are forwarded to `claude`.
-
-## Aliases
-
-| Alias | Expands to |
-|-------|-----------|
-| `ccw` | `wt switch --create --execute=claude` |
-| `sonnet` | `claude --model sonnet` |
+`cwp` reads the pasteboard and passes it as Claude's initial prompt — paste an issue URL or Linear prompt, then run `cwp <branch>`.

--- a/claude/aliases.zsh
+++ b/claude/aliases.zsh
@@ -1,9 +1,10 @@
 #!/usr/bin/env zsh
 
-alias sonnet='claude --model sonnet'
-alias ccw='wt switch --create --execute=claude'
+alias cw='wt switch --execute="claude --name={{ branch }}"'
+alias ccw='cw --create'
 
-claude-preset() {
-  local preset="$1"; shift
-  claude --settings "${HOME}/.config/claude-presets/${preset}.json" "$@"
+cwp() {
+  wt switch --create --execute="claude --name={{ branch }} --permission-mode=plan" "$@" -- "$(pbpaste)"
 }
+
+alias cwa='wt switch --execute="claude --name={{ branch }} --permission-mode=auto"'


### PR DESCRIPTION
Replaces the old `ccw` alias and removes dead code (`sonnet`, `claude-preset`) in favor of four focused aliases that cover my actual Worktrunk + Claude Code workflows.

| Command | Branch | Permission mode |
|---------|--------|-----------------|
| `cw` | existing | default |
| `ccw` | create | default |
| `cwp` | create | plan |
| `cwa` | existing | auto |

All variants pass `--name={{ branch }}` so Claude sessions are named after the worktree branch. `cwp` reads the pasteboard for an issue URL or prompt and launches in plan mode.
