### PR TITLE
worktrunk: configure LLM commit and summary generation

### DIFF
--- a/worktrunk/config.toml
+++ b/worktrunk/config.toml
@@ -3,3 +3,9 @@ claude-trust = "claude-trust-worktree '{{ primary_worktree_path }}' '{{ worktree
 
 [[pre-start]]
 claude-settings = "cp '{{ primary_worktree_path }}/.claude/settings.local.json' '{{ worktree_path }}/.claude/settings.local.json' 2>/dev/null || true"
+
+[list]
+summary = true
+
+[commit.generation]
+command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"


### PR DESCRIPTION
Configures Worktrunk to generate commit messages and branch summaries using Claude Code in print mode with Haiku.

`[commit.generation]` pipes Worktrunk's templated prompt (diff, diffstat, branch name, recent commits) to `claude -p` for `wt step commit`, `wt step squash`, and `wt merge`. `[list] summary = true` enables LLM-generated branch summaries in the `wt switch` picker (tab 5). Both features use the print-mode usage pool, which is currently unused. At Haiku pricing, even heavy usage stays well under $2/month.
