### PR TITLE
rm tmux-mouse-swipe plugin

### DIFF
--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -32,6 +32,3 @@ set -g @plugin 'azorng/tmux-smooth-scroll'
 
 # Open files referenced in pane output in a neovim pane (prefix + e)
 set -g @plugin 'trevarj/tmux-open-nvim'
-
-# Mouse swipe gestures for window/session switching
-set -g @plugin 'jaclu/tmux-mouse-swipe'


### PR DESCRIPTION
Removes the `jaclu/tmux-mouse-swipe` plugin from the tmux navigation config.
