### PR TITLE
terminal: switch to Monaspace Neon (Nerd Font)

### DIFF
--- a/terminal/Brewfile
+++ b/terminal/Brewfile
@@ -1,4 +1,5 @@
 cask 'iterm2'
+cask 'font-monaspice-nerd-font'
 brew 'shellspec'
 brew 'yazi'
 brew 'zoxide'

--- a/terminal/com.googlecode.iterm2.plist
+++ b/terminal/com.googlecode.iterm2.plist
@@ -759,11 +759,11 @@
 			<key>Name</key>
 			<string>Default</string>
 			<key>Non Ascii Font</key>
-			<string>HackNerdFontCompleteM-Regular 12</string>
+			<string>MonaspiceNeNFM-Regular 12</string>
 			<key>Non-ASCII Anti Aliased</key>
 			<true/>
 			<key>Normal Font</key>
-			<string>HackNerdFontCompleteM-Regular 12</string>
+			<string>MonaspiceNeNFM-Regular 12</string>
 			<key>Option Key Sends</key>
 			<integer>0</integer>
 			<key>Prompt Before Closing 2</key>

--- a/terminal/ghostty.config
+++ b/terminal/ghostty.config
@@ -1,3 +1,5 @@
+font-family = MonaspiceNe NFM
+
 theme = dark:Catppuccin Mocha,light:Catppuccin Latte
 
 # Match tmux copy-mode selection rendering (which inverts via mode-style) so


### PR DESCRIPTION
Switches the terminal font from JetBrains Mono / Hack Nerd Font to [Monaspace](https://github.com/githubnext/monaspace) Neon across both terminal emulators. I picked Neon (GitHub's neo-grotesque default) as the closest match to Hack, so this is a drop-in look change rather than a restyle. I used the Nerd Font–patched build (`font-monaspice-nerd-font`, named "Monaspice" upstream to avoid the trademark) and specifically the Mono (`NFM`) variant, matching the single-width "M" flavor the Hack config already used so icon glyphs stay one cell wide.

## Changes

- `terminal/Brewfile`: add `cask 'font-monaspice-nerd-font'` so the font installs via `brew bundle` (previously the Hack Nerd Font was not managed here at all).
- `terminal/ghostty.config`: set `font-family = MonaspiceNe NFM`. Ghostty previously rendered with its default font. Texture healing and ligatures come for free since Ghostty enables `calt`/`liga` by default.
- `terminal/com.googlecode.iterm2.plist`: replace both `Normal Font` and `Non Ascii Font` (`HackNerdFontCompleteM-Regular 12` → `MonaspiceNeNFM-Regular 12`).

## Testing

- `ghostty +validate-config` passes and `ghostty +list-fonts` resolves `MonaspiceNe NFM` with bold/italic faces.
- Confirmed the installed face's family name (`MonaspiceNe NFM`) and PostScript name (`MonaspiceNeNFM-Regular`) directly from the font's `name` table so the Ghostty family string and iTerm2 PostScript string are exact.