### PR TITLE
scripts: extract git-sync library for safe ff-only pulls

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -4,6 +4,8 @@
 
 CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
 
+source "${0:A:h}/../scripts/lib/git-sync.sh"
+
 notify() {
   local title="$1"
   local message="$2"
@@ -92,49 +94,18 @@ sync_repo() {
     fi
   fi
 
-  local default_branch
-  default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-  if [[ -z "$default_branch" ]]; then
-    git remote set-head origin --auto 2>/dev/null || true
-    default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-  fi
-  default_branch="${default_branch:-main}"
-
-  local retries=4 delay=2
-  for ((i=1; i<=retries; i++)); do
-    if gum spin --show-error --title "Fetching origin/$default_branch (attempt $i/$retries)" -- \
-      git fetch origin "$default_branch"; then
-      break
-    fi
-    if ((i < retries)); then
-      gum log --level warn "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
-      sleep "$delay"
-      delay=$((delay * 2))
-    else
-      gum log --level error "Failed to fetch after retries"
-      notify "Claude Upgrade" "Failed: network error"
+  local new_rev
+  new_rev=$(git_sync "$CLAUDE_REPO_HOME")
+  case $? in
+    "$GIT_SYNC_UPDATED")
+      gum log --level info "Repository updated to $new_rev"
+      ;;
+    "$GIT_SYNC_CURRENT") ;;
+    *)
+      notify "Claude Upgrade" "Failed: could not sync"
       return 1
-    fi
-  done
-
-  local local_rev remote_rev
-  local_rev=$(git rev-parse HEAD)
-  remote_rev=$(git rev-parse "origin/$default_branch")
-
-  if [[ "$local_rev" == "$remote_rev" ]]; then
-    gum log --level info "Repository already up to date (${local_rev:0:7})"
-    return 0
-  fi
-
-  gum log --level info "Updating repository from ${local_rev:0:7} to ${remote_rev:0:7}..."
-
-  if git pull --ff-only origin "$default_branch"; then
-    gum log --level info "Repository updated to $(git rev-parse --short HEAD)"
-  else
-    gum log --level error "Failed to pull repository"
-    notify "Claude Upgrade" "Failed: could not pull"
-    return 1
-  fi
+      ;;
+  esac
 }
 
 update_marketplaces() {

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -7,110 +7,47 @@ set -e
 
 DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 
+source "${0:A:h}/../scripts/lib/git-sync.sh"
+
 notify() {
   local title="$1"
   local message="$2"
-  local is_success="$3"
+  local sound="${3:-Basso}"
 
-  if [[ "$(uname)" != "Darwin" ]]; then
-    return
-  fi
-
-  if [[ "$is_success" == "true" ]]; then
-    osascript -e "display notification \"$message\" with title \"$title\" sound name \"Glass\"" 2>/dev/null || true
-  else
-    osascript -e "display notification \"$message\" with title \"$title\" sound name \"Basso\"" 2>/dev/null || true
-  fi
+  [[ "$(uname)" == "Darwin" ]] || return 0
+  osascript -e "display notification \"$message\" with title \"$title\" sound name \"$sound\"" 2>/dev/null || true
 }
 
-if [[ -L "$DOTFILES_HOME" ]]; then
-  gum log --level error "$DOTFILES_HOME is a symlink - run scripts/setup first"
-  notify "Dotfiles Sync" "Failed: ~/.dotfiles is a symlink" "false"
-  exit 1
-fi
-
-if [[ ! -d "$DOTFILES_HOME/.git" ]]; then
-  gum log --level error "$DOTFILES_HOME is not a git repository"
-  notify "Dotfiles Sync" "Failed: not a git repository" "false"
-  exit 1
-fi
-
-cd "$DOTFILES_HOME"
-
-if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+if [[ -d "$DOTFILES_HOME/.git" ]] && { ! git -C "$DOTFILES_HOME" diff --quiet 2>/dev/null || ! git -C "$DOTFILES_HOME" diff --cached --quiet 2>/dev/null; }; then
   gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
   gum log --level error "Run 'git -C $DOTFILES_HOME status' to see changes"
-  notify "Dotfiles Sync" "Skipped: local changes present" "false"
+  notify "Dotfiles Sync" "Skipped: local changes present"
   exit 1
 fi
 
-get_default_branch() {
-  local branch
-  branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-
-  if [[ -z "$branch" ]]; then
-    git remote set-head origin --auto 2>/dev/null || true
-    branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-  fi
-
-  echo "${branch:-main}"
-}
-
-DEFAULT_BRANCH=$(get_default_branch)
-
-fetch_with_retry() {
-  local retries=4
-  local delay=2
-
-  for ((i=1; i<=retries; i++)); do
-    if gum spin --show-error --title "Fetching origin/$DEFAULT_BRANCH (attempt $i/$retries)" -- \
-      git fetch origin "$DEFAULT_BRANCH"; then
-      return 0
-    fi
-
-    if ((i < retries)); then
-      gum log --level warn "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
-      sleep "$delay"
-      delay=$((delay * 2))
-    fi
-  done
-
-  return 1
-}
-
-if ! fetch_with_retry; then
-  gum log --level error "Failed to fetch after retries"
-  notify "Dotfiles Sync" "Failed: network error" "false"
-  exit 1
-fi
-
-LOCAL=$(git rev-parse HEAD)
-REMOTE=$(git rev-parse "origin/$DEFAULT_BRANCH")
-
-if [[ "$LOCAL" == "$REMOTE" ]]; then
-  gum log --level info "Already up to date (${LOCAL:0:7})"
-  exit 0
-fi
-
-gum log --level info "Updating from ${LOCAL:0:7} to ${REMOTE:0:7}..."
-
-if git pull --ff-only origin "$DEFAULT_BRANCH"; then
-  if ! gum spin --show-error --title "Updating submodules" -- git submodule update --init; then
-    gum log --level error "Submodule update failed"
-    notify "Dotfiles Sync" "Failed: submodules" "false"
+new_rev=$(git_sync "$DOTFILES_HOME")
+case $? in
+  "$GIT_SYNC_CURRENT")
+    exit 0
+    ;;
+  "$GIT_SYNC_FAILED")
+    notify "Dotfiles Sync" "Failed: could not sync"
     exit 1
-  fi
+    ;;
+esac
 
-  gum log --level info "Successfully updated to $(git rev-parse --short HEAD)"
-  notify "Dotfiles Sync" "Updated to ${REMOTE:0:7}" "true"
-
-  # Symlink refresh is opt-in; the launchd job skips it.
-  if [[ "$1" == "--bootstrap" ]] && [[ -x "$DOTFILES_HOME/scripts/bootstrap" ]]; then
-    gum log --level info "Running bootstrap..."
-    "$DOTFILES_HOME/scripts/bootstrap" --no-prompt
-  fi
-else
-  gum log --level error "Failed to pull - may need manual intervention"
-  notify "Dotfiles Sync" "Failed: could not pull" "false"
+if ! gum spin --show-error --title "Updating submodules" -- \
+  git -C "$DOTFILES_HOME" submodule update --init; then
+  gum log --level error "Submodule update failed"
+  notify "Dotfiles Sync" "Failed: submodules"
   exit 1
+fi
+
+gum log --level info "Successfully updated to $new_rev"
+notify "Dotfiles Sync" "Updated to $new_rev" "Glass"
+
+# Symlink refresh is opt-in; the launchd job skips it.
+if [[ "$1" == "--bootstrap" ]] && [[ -x "$DOTFILES_HOME/scripts/bootstrap" ]]; then
+  gum log --level info "Running bootstrap..."
+  "$DOTFILES_HOME/scripts/bootstrap" --no-prompt
 fi

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -18,7 +18,18 @@ notify() {
   osascript -e "display notification \"$message\" with title \"$title\" sound name \"$sound\"" 2>/dev/null || true
 }
 
-if [[ -d "$DOTFILES_HOME/.git" ]] && { ! git -C "$DOTFILES_HOME" diff --quiet 2>/dev/null || ! git -C "$DOTFILES_HOME" diff --cached --quiet 2>/dev/null; }; then
+
+if [[ -d "$DOTFILES_HOME/.git" ]]; then
+  if { git -C "$DOTFILES_HOME" diff --quiet && git -C "$DOTFILES_HOME" diff --cached --quiet; } 2>/dev/null; then
+    : # clean
+  elif git -C "$DOTFILES_HOME" status &>/dev/null; then
+    # git works but tree is dirty
+    gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
+    notify "Dotfiles Sync" "Skipped: local changes present"
+    exit 1
+  fi
+fi
+
   gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
   gum log --level error "Run 'git -C $DOTFILES_HOME status' to see changes"
   notify "Dotfiles Sync" "Skipped: local changes present"

--- a/scripts/lib/git-sync.sh
+++ b/scripts/lib/git-sync.sh
@@ -1,0 +1,92 @@
+# shellcheck shell=bash
+# Sourceable helpers for safely fast-forwarding a clone from origin.
+#
+# git_default_branch [repo_dir]
+#   Echo the remote default branch, resolving origin/HEAD with a
+#   set-head retry and falling back to "main".
+#
+# git_sync <repo_dir> [branch]
+#   Guard the target, fetch with retry, and fast-forward only.
+#   Returns:
+#     0  updated   (new short rev echoed to stdout)
+#     2  current   (already up to date)
+#     1  failed    (guard, fetch, or pull failure; reason logged)
+#   Callers own their own notification and post-update side effects.
+
+GIT_SYNC_UPDATED=0
+GIT_SYNC_CURRENT=2
+GIT_SYNC_FAILED=1
+
+git_default_branch() {
+  local repo_dir="${1:-.}"
+  local branch
+  branch=$(git -C "$repo_dir" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+
+  if [[ -z "$branch" ]]; then
+    git -C "$repo_dir" remote set-head origin --auto 2>/dev/null || true
+    branch=$(git -C "$repo_dir" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+  fi
+
+  echo "${branch:-main}"
+}
+
+git_sync_fetch() {
+  local repo_dir="$1" branch="$2"
+  local retries=4 delay=2 i
+
+  for ((i = 1; i <= retries; i++)); do
+    if gum spin --show-error --title "Fetching origin/$branch (attempt $i/$retries)" -- \
+      git -C "$repo_dir" fetch origin "$branch"; then
+      return 0
+    fi
+
+    if ((i < retries)); then
+      gum log --level warn "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
+      sleep "$delay"
+      delay=$((delay * 2))
+    fi
+  done
+
+  return 1
+}
+
+git_sync() {
+  local repo_dir="$1"
+  local branch="${2:-}"
+
+  if [[ -L "$repo_dir" ]]; then
+    gum log --level error "$repo_dir is a symlink"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  if [[ ! -d "$repo_dir/.git" ]]; then
+    gum log --level error "$repo_dir is not a git repository"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  [[ -n "$branch" ]] || branch=$(git_default_branch "$repo_dir")
+
+  if ! git_sync_fetch "$repo_dir" "$branch"; then
+    gum log --level error "Failed to fetch after retries"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  local local_rev remote_rev
+  local_rev=$(git -C "$repo_dir" rev-parse HEAD)
+  remote_rev=$(git -C "$repo_dir" rev-parse "origin/$branch")
+
+  if [[ "$local_rev" == "$remote_rev" ]]; then
+    gum log --level info "Already up to date (${local_rev:0:7})"
+    return "$GIT_SYNC_CURRENT"
+  fi
+
+  gum log --level info "Updating from ${local_rev:0:7} to ${remote_rev:0:7}..."
+
+  if ! git -C "$repo_dir" pull --ff-only origin "$branch" 1>&2; then
+    gum log --level error "Failed to pull - may need manual intervention"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  git -C "$repo_dir" rev-parse --short HEAD
+  return "$GIT_SYNC_UPDATED"
+}


### PR DESCRIPTION
Both bin/dotfiles-sync and bin/claude-upgrade copied the same ritual:
symlink/.git guards, origin/HEAD default-branch resolution, fetch with
exponential backoff, HEAD-vs-origin comparison, and an ff-only pull.

Move the shared core into a sourceable scripts/lib/git-sync.sh behind
git_default_branch and git_sync, which returns distinct updated/current/
failed outcomes and echoes the new short rev on update. Callers keep
their own behavior: dotfiles-sync still aborts on a dirty tree, updates
submodules, and runs the --bootstrap hook; claude-upgrade keeps its
cosmetic-json revert and the interactive discard-changes prompt.

scripts/setup keeps its own inline sync: it manages the symlink and runs
a clone/checkout state machine across two repos, so the guards and
single-repo assumptions in the library do not fit.