### PR TITLE
scripts: extract report-failure library with dedup latch

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -4,6 +4,8 @@
 
 CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
 
+source "${0:A:h}/../scripts/lib/git-sync.sh"
+
 notify() {
   local title="$1"
   local message="$2"
@@ -92,49 +94,18 @@ sync_repo() {
     fi
   fi
 
-  local default_branch
-  default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-  if [[ -z "$default_branch" ]]; then
-    git remote set-head origin --auto 2>/dev/null || true
-    default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-  fi
-  default_branch="${default_branch:-main}"
-
-  local retries=4 delay=2
-  for ((i=1; i<=retries; i++)); do
-    if gum spin --show-error --title "Fetching origin/$default_branch (attempt $i/$retries)" -- \
-      git fetch origin "$default_branch"; then
-      break
-    fi
-    if ((i < retries)); then
-      gum log --level warn "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
-      sleep "$delay"
-      delay=$((delay * 2))
-    else
-      gum log --level error "Failed to fetch after retries"
-      notify "Claude Upgrade" "Failed: network error"
+  local new_rev
+  new_rev=$(git_sync "$CLAUDE_REPO_HOME")
+  case $? in
+    "$GIT_SYNC_UPDATED")
+      gum log --level info "Repository updated to $new_rev"
+      ;;
+    "$GIT_SYNC_CURRENT") ;;
+    *)
+      notify "Claude Upgrade" "Failed: could not sync"
       return 1
-    fi
-  done
-
-  local local_rev remote_rev
-  local_rev=$(git rev-parse HEAD)
-  remote_rev=$(git rev-parse "origin/$default_branch")
-
-  if [[ "$local_rev" == "$remote_rev" ]]; then
-    gum log --level info "Repository already up to date (${local_rev:0:7})"
-    return 0
-  fi
-
-  gum log --level info "Updating repository from ${local_rev:0:7} to ${remote_rev:0:7}..."
-
-  if git pull --ff-only origin "$default_branch"; then
-    gum log --level info "Repository updated to $(git rev-parse --short HEAD)"
-  else
-    gum log --level error "Failed to pull repository"
-    notify "Claude Upgrade" "Failed: could not pull"
-    return 1
-  fi
+      ;;
+  esac
 }
 
 update_marketplaces() {

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -5,17 +5,7 @@
 CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
 
 source "${0:A:h}/../scripts/lib/git-sync.sh"
-
-notify() {
-  local title="$1"
-  local message="$2"
-
-  if [[ "$(uname)" != "Darwin" ]]; then
-    return
-  fi
-
-  osascript -e "display notification \"$message\" with title \"$title\" sound name \"Basso\"" 2>/dev/null || true
-}
+source "${0:A:h}/../scripts/lib/report-failure.sh"
 
 revert_cosmetic_json_changes() {
   local changed_files
@@ -165,38 +155,15 @@ update_plugins() {
   fi
 }
 
-create_things_task() {
+report_upgrade_failure() {
   local output="$1"
 
-  gum log --level info "Creating Things task for upgrade failure..."
-
-  local host time revision version
-  host=$(hostname -s)
-  time=$(date "+%Y-%m-%d %H:%M:%S %Z")
+  local revision version
   revision=$(git -C "$CLAUDE_REPO_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
   version=$(claude --version 2>/dev/null || echo "unknown")
 
-  local notes='- **Host:** '"$host"'
-- **Time:** '"$time"'
-- **Revision:** '"$revision"'
-- **Claude:** '"$version"'
-
-```sh
-claude-upgrade
-```
-
-## Error Output
-```
-'"$output"'
-```'
-
-  local encoded_notes encoded_title
-  encoded_notes=$(echo "$notes" | jq -sRr @uri)
-  encoded_title=$(echo "Claude upgrade failed" | jq -sRr @uri)
-
-  open "things:///add?title=${encoded_title}&notes=${encoded_notes}&when=today"
-
-  notify "Claude Upgrade" "Upgrade failed - see Things task"
+  report_failure "claude-upgrade" "Claude upgrade failed" "claude-upgrade" "$output" \
+    "$revision" "- **Claude:** $version"
 }
 
 main() {
@@ -223,10 +190,11 @@ main() {
   } 2>&1 | tee "$output"
 
   if [[ ${pipestatus[1]} -ne 0 ]]; then
-    create_things_task "$(cat "$output")"
+    report_upgrade_failure "$(cat "$output")"
     exit 1
   fi
 
+  report_success "claude-upgrade"
   gum log --level info "All Claude upgrades completed successfully"
 }
 

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -7,110 +7,47 @@ set -e
 
 DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 
+source "${0:A:h}/../scripts/lib/git-sync.sh"
+
 notify() {
   local title="$1"
   local message="$2"
-  local is_success="$3"
+  local sound="${3:-Basso}"
 
-  if [[ "$(uname)" != "Darwin" ]]; then
-    return
-  fi
-
-  if [[ "$is_success" == "true" ]]; then
-    osascript -e "display notification \"$message\" with title \"$title\" sound name \"Glass\"" 2>/dev/null || true
-  else
-    osascript -e "display notification \"$message\" with title \"$title\" sound name \"Basso\"" 2>/dev/null || true
-  fi
+  [[ "$(uname)" == "Darwin" ]] || return 0
+  osascript -e "display notification \"$message\" with title \"$title\" sound name \"$sound\"" 2>/dev/null || true
 }
 
-if [[ -L "$DOTFILES_HOME" ]]; then
-  gum log --level error "$DOTFILES_HOME is a symlink - run scripts/setup first"
-  notify "Dotfiles Sync" "Failed: ~/.dotfiles is a symlink" "false"
-  exit 1
-fi
-
-if [[ ! -d "$DOTFILES_HOME/.git" ]]; then
-  gum log --level error "$DOTFILES_HOME is not a git repository"
-  notify "Dotfiles Sync" "Failed: not a git repository" "false"
-  exit 1
-fi
-
-cd "$DOTFILES_HOME"
-
-if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+if [[ -d "$DOTFILES_HOME/.git" ]] && { ! git -C "$DOTFILES_HOME" diff --quiet 2>/dev/null || ! git -C "$DOTFILES_HOME" diff --cached --quiet 2>/dev/null; }; then
   gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
   gum log --level error "Run 'git -C $DOTFILES_HOME status' to see changes"
-  notify "Dotfiles Sync" "Skipped: local changes present" "false"
+  notify "Dotfiles Sync" "Skipped: local changes present"
   exit 1
 fi
 
-get_default_branch() {
-  local branch
-  branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-
-  if [[ -z "$branch" ]]; then
-    git remote set-head origin --auto 2>/dev/null || true
-    branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-  fi
-
-  echo "${branch:-main}"
-}
-
-DEFAULT_BRANCH=$(get_default_branch)
-
-fetch_with_retry() {
-  local retries=4
-  local delay=2
-
-  for ((i=1; i<=retries; i++)); do
-    if gum spin --show-error --title "Fetching origin/$DEFAULT_BRANCH (attempt $i/$retries)" -- \
-      git fetch origin "$DEFAULT_BRANCH"; then
-      return 0
-    fi
-
-    if ((i < retries)); then
-      gum log --level warn "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
-      sleep "$delay"
-      delay=$((delay * 2))
-    fi
-  done
-
-  return 1
-}
-
-if ! fetch_with_retry; then
-  gum log --level error "Failed to fetch after retries"
-  notify "Dotfiles Sync" "Failed: network error" "false"
-  exit 1
-fi
-
-LOCAL=$(git rev-parse HEAD)
-REMOTE=$(git rev-parse "origin/$DEFAULT_BRANCH")
-
-if [[ "$LOCAL" == "$REMOTE" ]]; then
-  gum log --level info "Already up to date (${LOCAL:0:7})"
-  exit 0
-fi
-
-gum log --level info "Updating from ${LOCAL:0:7} to ${REMOTE:0:7}..."
-
-if git pull --ff-only origin "$DEFAULT_BRANCH"; then
-  if ! gum spin --show-error --title "Updating submodules" -- git submodule update --init; then
-    gum log --level error "Submodule update failed"
-    notify "Dotfiles Sync" "Failed: submodules" "false"
+new_rev=$(git_sync "$DOTFILES_HOME")
+case $? in
+  "$GIT_SYNC_CURRENT")
+    exit 0
+    ;;
+  "$GIT_SYNC_FAILED")
+    notify "Dotfiles Sync" "Failed: could not sync"
     exit 1
-  fi
+    ;;
+esac
 
-  gum log --level info "Successfully updated to $(git rev-parse --short HEAD)"
-  notify "Dotfiles Sync" "Updated to ${REMOTE:0:7}" "true"
-
-  # Symlink refresh is opt-in; the launchd job skips it.
-  if [[ "$1" == "--bootstrap" ]] && [[ -x "$DOTFILES_HOME/scripts/bootstrap" ]]; then
-    gum log --level info "Running bootstrap..."
-    "$DOTFILES_HOME/scripts/bootstrap" --no-prompt
-  fi
-else
-  gum log --level error "Failed to pull - may need manual intervention"
-  notify "Dotfiles Sync" "Failed: could not pull" "false"
+if ! gum spin --show-error --title "Updating submodules" -- \
+  git -C "$DOTFILES_HOME" submodule update --init; then
+  gum log --level error "Submodule update failed"
+  notify "Dotfiles Sync" "Failed: submodules"
   exit 1
+fi
+
+gum log --level info "Successfully updated to $new_rev"
+notify "Dotfiles Sync" "Updated to $new_rev" "Glass"
+
+# Symlink refresh is opt-in; the launchd job skips it.
+if [[ "$1" == "--bootstrap" ]] && [[ -x "$DOTFILES_HOME/scripts/bootstrap" ]]; then
+  gum log --level info "Running bootstrap..."
+  "$DOTFILES_HOME/scripts/bootstrap" --no-prompt
 fi

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -8,15 +8,7 @@ set -e
 DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 
 source "${0:A:h}/../scripts/lib/git-sync.sh"
-
-notify() {
-  local title="$1"
-  local message="$2"
-  local sound="${3:-Basso}"
-
-  [[ "$(uname)" == "Darwin" ]] || return 0
-  osascript -e "display notification \"$message\" with title \"$title\" sound name \"$sound\"" 2>/dev/null || true
-}
+source "${0:A:h}/../scripts/lib/report-failure.sh"
 
 if [[ -d "$DOTFILES_HOME/.git" ]] && { ! git -C "$DOTFILES_HOME" diff --quiet 2>/dev/null || ! git -C "$DOTFILES_HOME" diff --cached --quiet 2>/dev/null; }; then
   gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"

--- a/bin/dotfiles-upgrade
+++ b/bin/dotfiles-upgrade
@@ -8,43 +8,10 @@ set -o pipefail
 
 DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 
+source "${0:A:h}/../scripts/lib/report-failure.sh"
+
 INSTALL_LOG=$(mktemp)
 trap 'rm -f "$INSTALL_LOG"' EXIT
-
-notify() {
-  [[ "$(uname)" == "Darwin" ]] || return 0
-  osascript -e "display notification \"$2\" with title \"$1\" sound name \"Basso\"" 2>/dev/null || true
-}
-
-create_things_task() {
-  gum log --level info "Creating Things task for install failure"
-
-  local host time revision output
-  host=$(hostname -s)
-  time=$(date "+%Y-%m-%d %H:%M:%S %Z")
-  revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-  output=$(tail -n 100 "$INSTALL_LOG" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')
-
-  local notes='- **Host:** '"$host"'
-- **Time:** '"$time"'
-- **Revision:** '"$revision"'
-
-```sh
-brew bundle
-```
-
-## Error Output (last 100 lines)
-```
-'"$output"'
-```'
-
-  local encoded_notes encoded_title
-  encoded_notes=$(echo "$notes" | jq -sRr @uri)
-  encoded_title=$(echo "Dotfiles install failed" | jq -sRr @uri)
-
-  open "things:///add?title=${encoded_title}&notes=${encoded_notes}&when=today"
-  notify "Dotfiles Upgrade" "Install failed - see Things task"
-}
 
 if ! gum spin --show-output --show-error --title "Syncing dotfiles" -- \
   "$DOTFILES_HOME/bin/dotfiles-sync"; then
@@ -55,7 +22,10 @@ fi
 gum log --level info "Running install"
 if ! "$DOTFILES_HOME/scripts/install" 2>&1 | tee "$INSTALL_LOG"; then
   gum log --level error "install failed"
-  create_things_task
+
+  revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  output=$(tail -n 100 "$INSTALL_LOG" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')
+  report_failure "dotfiles-upgrade" "Dotfiles install failed" "brew bundle" "$output" "$revision"
   exit 1
 fi
 
@@ -63,4 +33,5 @@ if ! gum spin --show-output --show-error --title "Running brew cleanup" -- brew 
   gum log --level warn "brew cleanup had issues"
 fi
 
+report_success "dotfiles-upgrade"
 gum log --level info "All upgrades completed successfully"

--- a/scripts/lib/git-sync.sh
+++ b/scripts/lib/git-sync.sh
@@ -1,0 +1,92 @@
+# shellcheck shell=bash
+# Sourceable helpers for safely fast-forwarding a clone from origin.
+#
+# git_default_branch [repo_dir]
+#   Echo the remote default branch, resolving origin/HEAD with a
+#   set-head retry and falling back to "main".
+#
+# git_sync <repo_dir> [branch]
+#   Guard the target, fetch with retry, and fast-forward only.
+#   Returns:
+#     0  updated   (new short rev echoed to stdout)
+#     2  current   (already up to date)
+#     1  failed    (guard, fetch, or pull failure; reason logged)
+#   Callers own their own notification and post-update side effects.
+
+GIT_SYNC_UPDATED=0
+GIT_SYNC_CURRENT=2
+GIT_SYNC_FAILED=1
+
+git_default_branch() {
+  local repo_dir="${1:-.}"
+  local branch
+  branch=$(git -C "$repo_dir" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+
+  if [[ -z "$branch" ]]; then
+    git -C "$repo_dir" remote set-head origin --auto 2>/dev/null || true
+    branch=$(git -C "$repo_dir" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+  fi
+
+  echo "${branch:-main}"
+}
+
+git_sync_fetch() {
+  local repo_dir="$1" branch="$2"
+  local retries=4 delay=2 i
+
+  for ((i = 1; i <= retries; i++)); do
+    if gum spin --show-error --title "Fetching origin/$branch (attempt $i/$retries)" -- \
+      git -C "$repo_dir" fetch origin "$branch"; then
+      return 0
+    fi
+
+    if ((i < retries)); then
+      gum log --level warn "Fetch failed, retrying in ${delay}s... (attempt $i/$retries)"
+      sleep "$delay"
+      delay=$((delay * 2))
+    fi
+  done
+
+  return 1
+}
+
+git_sync() {
+  local repo_dir="$1"
+  local branch="${2:-}"
+
+  if [[ -L "$repo_dir" ]]; then
+    gum log --level error "$repo_dir is a symlink"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  if [[ ! -d "$repo_dir/.git" ]]; then
+    gum log --level error "$repo_dir is not a git repository"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  [[ -n "$branch" ]] || branch=$(git_default_branch "$repo_dir")
+
+  if ! git_sync_fetch "$repo_dir" "$branch"; then
+    gum log --level error "Failed to fetch after retries"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  local local_rev remote_rev
+  local_rev=$(git -C "$repo_dir" rev-parse HEAD)
+  remote_rev=$(git -C "$repo_dir" rev-parse "origin/$branch")
+
+  if [[ "$local_rev" == "$remote_rev" ]]; then
+    gum log --level info "Already up to date (${local_rev:0:7})"
+    return "$GIT_SYNC_CURRENT"
+  fi
+
+  gum log --level info "Updating from ${local_rev:0:7} to ${remote_rev:0:7}..."
+
+  if ! git -C "$repo_dir" pull --ff-only origin "$branch" 1>&2; then
+    gum log --level error "Failed to pull - may need manual intervention"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  git -C "$repo_dir" rev-parse --short HEAD
+  return "$GIT_SYNC_UPDATED"
+}

--- a/scripts/lib/report-failure.sh
+++ b/scripts/lib/report-failure.sh
@@ -1,0 +1,88 @@
+# shellcheck shell=bash
+# Sourceable failure reporting for unattended jobs.
+#
+# notify <title> <message> [sound]
+#   Darwin-guarded osascript notification (default sound: Basso).
+#
+# report_failure <job> <title> <command> <output> <revision> [extra_meta]
+#   File a Things to-do describing the failure and notify, but only on the
+#   transition into a failed state. A per-job latch under
+#   ${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/<job>.status records ok
+#   or failed; while a job stays broken the latch suppresses duplicate
+#   to-dos. report_success resets it so the next break files a fresh one.
+#   <command> is the shell snippet shown in the to-do for reproduction;
+#   <output> is the captured log; <extra_meta> is optional extra metadata
+#   markdown appended to the host/time/revision header.
+#
+# report_success <job>
+#   Clear the latch.
+
+notify() {
+  local title="$1"
+  local message="$2"
+  local sound="${3:-Basso}"
+
+  [[ "$(uname)" == "Darwin" ]] || return 0
+  osascript -e "display notification \"$message\" with title \"$title\" sound name \"$sound\"" 2>/dev/null || true
+}
+
+report_status_file() {
+  local job="$1"
+  local dir="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles"
+  mkdir -p "$dir"
+  echo "$dir/$job.status"
+}
+
+report_success() {
+  local job="$1"
+  echo ok >"$(report_status_file "$job")"
+}
+
+report_failure() {
+  local job="$1"
+  local title="$2"
+  local command="$3"
+  local output="$4"
+  local revision="$5"
+  local extra_meta="$6"
+
+  local status_file prior
+  status_file=$(report_status_file "$job")
+  prior=$(cat "$status_file" 2>/dev/null)
+  echo failed >"$status_file"
+
+  if [[ "$prior" == "failed" ]]; then
+    gum log --level info "$job still failing - to-do already filed, staying quiet"
+    return 0
+  fi
+
+  gum log --level info "Creating Things to-do for $job failure"
+
+  local host time
+  host=$(hostname -s)
+  time=$(date "+%Y-%m-%d %H:%M:%S %Z")
+
+  local notes='- **Host:** '"$host"'
+- **Time:** '"$time"'
+- **Revision:** '"$revision"
+  [[ -n "$extra_meta" ]] && notes+='
+'"$extra_meta"
+  notes+='
+
+```sh
+'"$command"'
+```
+
+## Error Output
+```
+'"$output"'
+```'
+
+  local encoded_notes encoded_title
+  encoded_notes=$(echo "$notes" | jq -sRr @uri)
+  encoded_title=$(echo "$title" | jq -sRr @uri)
+
+  open "things:///add?title=${encoded_title}&notes=${encoded_notes}&when=today"
+
+  notify "$title" "$job failed - see Things to-do"
+}


### PR DESCRIPTION
notify and create_things_task were copy-pasted across the upgrade jobs,
and a repeatedly-failing background job filed a fresh Things to-do on
every run.

Add a sourceable scripts/lib/report-failure.sh providing notify,
report_failure, and report_success. report_failure builds the Things
to-do (host/time/revision, command snippet, captured log), @uri-encodes
it, opens things://, and notifies - but only on the transition into a
failed state. A per-job latch under
${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/<job>.status suppresses
duplicate to-dos while a job stays broken; report_success resets it so
the next break files a fresh one. Output is not hashed - it carries
timestamps, so the latch is keyed on the ok/failed edge instead.

dotfiles-upgrade and claude-upgrade pass their varying pieces (title,
command snippet, log, revision, and claude-upgrade's extra Claude
version line) and gate success/failure endpoints on the latch.
dotfiles-sync adopts the shared notify; it only notifies and files no
to-dos, so it needs no latch.