### PR TITLE
scripts: feed remove_stale from stdin to share the removal rule

### DIFF
--- a/scripts/.shellspec
+++ b/scripts/.shellspec
@@ -1,0 +1,1 @@
+--shell bash

--- a/scripts/install-symlinks
+++ b/scripts/install-symlinks
@@ -33,8 +33,10 @@ is_desired() {
   printf '%s\n' "$desired_targets" | grep -qFx "$1"
 }
 
+# Read candidate link paths from stdin (one per line) and remove those that
+# point into DOTFILES_ROOT but are no longer declared.
 remove_stale() {
-  for link in "$@"; do
+  while IFS= read -r link; do
     [ -L "$link" ] || continue
     target="$(readlink "$link" 2>/dev/null)" || continue
     case "$target" in
@@ -48,21 +50,12 @@ remove_stale() {
   done
 }
 
-# Scan directories that could contain managed symlinks
-remove_stale "$HOME"/.[!.]*
-[ -d "$HOME/.ssh" ] && remove_stale "$HOME/.ssh"/*
+# Scan directories that could contain managed symlinks. The HOME glob enumerates
+# dotfiles directly under $HOME (and ~/.ssh); the XDG scan recurses to find nested
+# links. Both feed the same removal rule.
+{
+  printf '%s\n' "$HOME"/.[!.]*
+  [ -d "$HOME/.ssh" ] && printf '%s\n' "$HOME/.ssh"/*
+} | remove_stale
 
-stale_links="${TMPDIR:-/tmp}/install-symlinks.$$"
-find "$XDG_CONFIG_HOME" -type l > "$stale_links" 2>/dev/null || true
-while read -r link; do
-  target="$(readlink "$link" 2>/dev/null)" || continue
-  case "$target" in
-    "$DOTFILES_ROOT"/*) ;;
-    *) continue ;;
-  esac
-  is_desired "$link" || {
-    echo "install-symlinks: removing stale symlink $link -> $target"
-    rm "$link"
-  }
-done < "$stale_links"
-rm -f "$stale_links"
+find "$XDG_CONFIG_HOME" -type l 2>/dev/null | remove_stale

--- a/scripts/spec/install_symlinks_spec.sh
+++ b/scripts/spec/install_symlinks_spec.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "install-symlinks remove_stale"
+  install_symlinks="$SHELLSPEC_PROJECT_ROOT/install-symlinks"
+
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/remove-stale"
+    root="$sandbox/root"
+    other_root="$sandbox/other-root"
+    home="$sandbox/home"
+    xdg="$home/.config"
+    rm -rf "$sandbox"
+
+    # Declared source for one desired link, under a fake dotfiles root.
+    mkdir -p "$root/topic" "$other_root" "$home" "$xdg"
+    printf 'kept\n' > "$root/topic/kept.conf"
+    printf 'kept.conf:~/.kept\n' > "$root/topic/symlinks.conf"
+
+    # Stale link directly under HOME: points into root but not declared.
+    printf 'stale\n' > "$root/stale-source"
+    ln -sfn "$root/stale-source" "$home/.stale"
+
+    # Stale link nested under XDG: points into root but not declared.
+    mkdir -p "$xdg/nested"
+    ln -sfn "$root/stale-source" "$xdg/nested/stale"
+
+    # Unrelated link under HOME: points outside root, must be left alone.
+    printf 'unrelated\n' > "$other_root/unrelated-source"
+    ln -sfn "$other_root/unrelated-source" "$home/.unrelated"
+  }
+
+  run_install() {
+    HOME="$home" XDG_CONFIG_HOME="$xdg" "$install_symlinks" "$root"
+  }
+
+  BeforeEach 'setup'
+
+  It "creates declared links, removes stale links into root, and preserves the rest"
+    When call run_install
+    The status should be success
+    The output should include "removing stale symlink $home/.stale"
+    The output should include "removing stale symlink $xdg/nested/stale"
+    # Declared link created.
+    The path "$home/.kept" should be symlink
+    # Stale links into root removed.
+    The path "$home/.stale" should not be exist
+    The path "$xdg/nested/stale" should not be exist
+    # Link pointing outside root left untouched.
+    The path "$home/.unrelated" should be symlink
+  End
+End


### PR DESCRIPTION
The XDG scan re-inlined the stale-link removal body to use a recursive
find instead of a glob. Make remove_stale read candidate link paths from
stdin so the HOME glob and XDG find both feed one removal rule.

Add a shellspec spec that builds a sandbox tree and asserts only stale
links pointing into the dotfiles root are removed.