### PR TITLE
zsh: own the active dotfiles root in one module

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -2,20 +2,12 @@
 
 export DOTFILES_HOME="$HOME/.dotfiles"
 
-# Select dotfiles source:
-#   DOTFILES_USE_DEV=/path - use specified dev directory (for dotfiles test)
-#   ~/.dotfiles-dev-mode   - persistent dev mode (file contains path)
-#   default                - use installed directory
-if [[ -n "$DOTFILES_USE_DEV" ]]; then
-  export ZSH="$DOTFILES_USE_DEV"
-elif [[ -f "$HOME/.dotfiles-dev-mode" ]]; then
-  export ZSH="$(<"$HOME/.dotfiles-dev-mode")"
-else
-  export ZSH="$DOTFILES_HOME"
-fi
-
-# Fallback if selected directory doesn't exist
-[[ ! -d "$ZSH" ]] && export ZSH="$DOTFILES_HOME"
+# Resolve which dotfiles root is active. The module lives next to this file;
+# ${(%):-%N} resolves through the ~/.zshenv symlink to the active root's copy,
+# so it is available before $ZSH is known. dev.zsh reuses the same functions.
+source "${${(%):-%N}:A:h}/active-root.zsh"
+_dotfiles_resolve_root
+export ZSH="$REPLY"
 
 export DOTFILES_TMUX="$ZSH/tmux"
 

--- a/zsh/active-root.zsh
+++ b/zsh/active-root.zsh
@@ -1,0 +1,42 @@
+# shellcheck shell=bash
+# Owns "which dotfiles root is active, and how to switch to one".
+#
+# Sourced two ways:
+#   - early from .zshenv, before $ZSH is known, to route shell startup
+#   - again via the zshrc topic loop, so dev.zsh can reuse switch/resolve
+#
+# Must stay fork-free: .zshenv runs on every shell and startup is CI-gated.
+# $(<file) is a builtin redirect, not a subshell, so it is allowed here.
+
+DOTFILES_DEV_FLAG="$HOME/.dotfiles-dev-mode"
+
+# Resolve the active root into REPLY, applying precedence:
+#   DOTFILES_USE_DEV (test subshell) > persistent flag file > $DOTFILES_HOME
+# Falls back to $DOTFILES_HOME when the selected directory is missing.
+# Assigns REPLY rather than printing so .zshenv can route startup without a
+# subshell fork.
+_dotfiles_resolve_root() {
+  if [[ -n "$DOTFILES_USE_DEV" ]]; then
+    REPLY="$DOTFILES_USE_DEV"
+  elif [[ -f "$DOTFILES_DEV_FLAG" ]]; then
+    REPLY="$(<"$DOTFILES_DEV_FLAG")"
+  else
+    REPLY="$DOTFILES_HOME"
+  fi
+
+  [[ -d "$REPLY" ]] || REPLY="$DOTFILES_HOME"
+}
+
+# Persist the active root and relink in one step, so the flag file and the
+# installed symlinks can't disagree. An empty root clears persistent dev mode
+# and relinks to the installed home.
+_dotfiles_switch_root() {
+  local root="$1"
+  if [[ -n "$root" ]]; then
+    print -r -- "$root" > "$DOTFILES_DEV_FLAG"
+  else
+    rm -f "$DOTFILES_DEV_FLAG"
+    root="$DOTFILES_HOME"
+  fi
+  "$root/scripts/install-symlinks" "$root"
+}

--- a/zsh/dev.zsh
+++ b/zsh/dev.zsh
@@ -91,9 +91,9 @@ _dotfiles_status() {
     fi
   fi
 
-  if [[ -f "$HOME/.dotfiles-dev-mode" ]]; then
+  if [[ -f "$DOTFILES_DEV_FLAG" ]]; then
     echo ""
-    echo "Persistent dev mode: $(<"$HOME/.dotfiles-dev-mode")"
+    echo "Persistent dev mode: $(<"$DOTFILES_DEV_FLAG")"
   fi
 }
 
@@ -111,8 +111,6 @@ _dotfiles_test() {
 }
 
 _dotfiles_dev() {
-  local flag="$HOME/.dotfiles-dev-mode"
-
   case "$1" in
     enable)
       local dev_dir
@@ -120,19 +118,17 @@ _dotfiles_dev() {
         echo "Not inside a dotfiles repository or worktree."
         return 1
       }
-      echo "$dev_dir" > "$flag"
-      "$dev_dir/scripts/install-symlinks" "$dev_dir"
+      _dotfiles_switch_root "$dev_dir"
       echo "Dev mode enabled: $dev_dir"
       echo "Restart shell to apply."
       ;;
     disable)
-      rm -f "$flag"
-      "$DOTFILES_HOME/scripts/install-symlinks" "$DOTFILES_HOME"
+      _dotfiles_switch_root ""
       echo "Dev mode disabled."
       echo "Restart shell to apply."
       ;;
     "")
-      if [[ -f "$flag" ]]; then
+      if [[ -f "$DOTFILES_DEV_FLAG" ]]; then
         _dotfiles_dev disable
       else
         _dotfiles_dev enable


### PR DESCRIPTION
The knowledge of which dotfiles root is active and how to switch to one
was re-derived in three places: .zshenv resolved it at startup, dev.zsh's
enable/disable wrote the flag and relinked as two steps that could drift,
and status re-read the flag path.

Add zsh/active-root.zsh with _dotfiles_resolve_root (precedence:
DOTFILES_USE_DEV > flag file > installed home) and _dotfiles_switch_root
(write/clear flag and relink together). .zshenv sources it early via the
symlink-resolved path so it routes startup before $ZSH is known, and
dev.zsh reuses both functions. resolve assigns REPLY rather than printing
to keep startup fork-free.