### PR TITLE
rm herdr

### DIFF
--- a/claude/install.sh
+++ b/claude/install.sh
@@ -47,24 +47,5 @@ install_claude_symlinks() {
   done
 }
 
-install_herdr_claude_hook() {
-  local hook_dir="$HOME/.claude/hooks"
-  local hook_path="$hook_dir/herdr-agent-state.sh"
-  local temp_home
-  temp_home="$(mktemp -d)"
-
-  # herdr's installer also adds hook entries to ~/.claude/settings.json,
-  # which the bendrucker/herdr plugin already provides via hooks.json.
-  # Route the installer at a throwaway HOME and copy out only the script.
-  mkdir -p "$temp_home/.claude"
-  HOME="$temp_home" herdr integration install claude >/dev/null
-  mkdir -p "$hook_dir"
-  cp -p "$temp_home/.claude/hooks/herdr-agent-state.sh" "$hook_path"
-  rm -rf "$temp_home"
-
-  echo "  ✓ ~/.claude/hooks/herdr-agent-state.sh"
-}
-
 setup_claude_repo
 install_claude_symlinks
-install_herdr_claude_hook

--- a/tmux/core/unbinds.conf
+++ b/tmux/core/unbinds.conf
@@ -8,3 +8,6 @@
 # 2026-04: bindings consolidated; T (was sesh, now t) and o (tool launcher) removed
 unbind T
 unbind o
+
+# 2026-06: removed herdr agent multiplexer
+unbind H

--- a/tmux/herdr.toml
+++ b/tmux/herdr.toml
@@ -1,1 +1,0 @@
-onboarding = false

--- a/tmux/mise.toml
+++ b/tmux/mise.toml
@@ -1,2 +1,0 @@
-[tools]
-"github:ogulcancelik/herdr" = "0.5.9"

--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -14,8 +14,6 @@ set-environment -g TMUX_FZF_OPTIONS "-p -w 60% -h 60%"
 bind -N "Switch session" t display-popup -E -w 80% -h 80% "sesh connect \$(sesh list -i | fzf --no-sort --ansi --border --border-label ' sesh ' --prompt '  ')"
 bind -N "Switch window" w run-shell -b '$TMUX_PLUGIN_MANAGER_PATH/tmux-fzf/scripts/window.sh switch'
 
-bind -N "Open herdr agent multiplexer" H display-popup -E -w 90% -h 90% herdr
-
 bind -N "Grab scrollback to clipboard" g run-shell tmux-grab-scrollback
 
 bind -N "Open linked session for window browsing" X run-shell 'tmux new-session -d -t "#{session_name}" -s "#{session_name}-linked" 2>/dev/null; tmux switch-client -t "#{session_name}-linked"'

--- a/tmux/symlinks.conf
+++ b/tmux/symlinks.conf
@@ -1,3 +1,1 @@
 .:$XDG_CONFIG_HOME/tmux
-mise.toml:$XDG_CONFIG_HOME/mise/conf.d/tmux.toml
-herdr.toml:$XDG_CONFIG_HOME/herdr/config.toml


### PR DESCRIPTION
Removes herdr, the tmux agent multiplexer. I wasn't using it.

## Changes

- Delete the `github:ogulcancelik/herdr` mise tool (the `tmux/mise.toml` that pinned it held nothing else)
- Drop the `herdr.toml` config and its symlink, plus the `mise.toml` symlink
- Remove the prefix `H` popup binding from `tmux/navigation/navigation.conf` and tombstone it in `tmux/core/unbinds.conf`
- Remove `install_herdr_claude_hook` from `claude/install.sh`
