### PR TITLE
tmux: remove tmux-fingers plugin

### DIFF
--- a/tmux/Brewfile
+++ b/tmux/Brewfile
@@ -1,3 +1,2 @@
 brew 'tmux'
 brew 'sesh'
-brew 'morantron/tmux-fingers/tmux-fingers'

--- a/tmux/core/unbinds.conf
+++ b/tmux/core/unbinds.conf
@@ -8,3 +8,6 @@
 # 2026-04: bindings consolidated; T (was sesh, now t) and o (tool launcher) removed
 unbind T
 unbind o
+
+# 2026-06: removed tmux-fingers plugin in favor of tmux-fzf-links
+unbind F

--- a/tmux/navigation/bin/tmux-keys
+++ b/tmux/navigation/bin/tmux-keys
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Searchable picker over `prefix` bindings. The selected binding is dispatched
 # via `tmux run-shell -b` to a tempfile so this picker's popup closes first —
-# popup-based bindings (sesh, scratch, fingers) would otherwise collide with
+# popup-based bindings (sesh, scratch) would otherwise collide with
 # our still-open popup.
 # shellcheck disable=SC2016  # literal $TMUX_PLUGIN_MANAGER_PATH appears in tmux binding text
 set -euo pipefail

--- a/tmux/search/search.conf
+++ b/tmux/search/search.conf
@@ -6,7 +6,3 @@ set -g @plugin 'roosta/tmux-fuzzback'
 set -g @fuzzback-bind '/'
 set -g @fuzzback-popup 1
 set -g @fuzzback-popup-size '80%'
-
-# Hint-based copy — prefix F overlays labels on visible tokens.
-set -g @plugin 'Morantron/tmux-fingers'
-set -g @fingers-key F


### PR DESCRIPTION
Removes the `Morantron/tmux-fingers` hint-based copy plugin and its brew formula. tmux-fzf-links covers the link-opening use case well enough that I'd rather consolidate on it.

## Changes

- Drop the `@plugin 'Morantron/tmux-fingers'` declaration and `@fingers-key` setting from `tmux/search/search.conf`
- Remove the `morantron/tmux-fingers/tmux-fingers` brew formula from `tmux/Brewfile`
- Tombstone the `prefix F` binding in `tmux/core/unbinds.conf` so reloads pick up the removal
- Drop the stale `fingers` reference from the `tmux-keys` picker comment
