### PR TITLE
tmux: round the session pill and add a bell module

### DIFF
--- a/tmux/alerts/alerts.conf
+++ b/tmux/alerts/alerts.conf
@@ -1,6 +1,6 @@
 # Bell indicator in status bar
-set -g @catppuccin_bell_icon "󰂞 "
-set -g @catppuccin_bell_color "#{@thm_red}"
+set -g @catppuccin_bell_icon " "
+set -g @catppuccin_bell_color "#{@thm_yellow}"
 set -g @catppuccin_bell_text " #(_tmux-bell-count)"
 
 # Jump to window with bell alert

--- a/tmux/appearance/appearance.conf
+++ b/tmux/appearance/appearance.conf
@@ -2,9 +2,10 @@
 set -g @plugin 'catppuccin/tmux'
 set -goq @catppuccin_flavor 'mocha'
 set -g @catppuccin_window_status_style 'rounded'
-set -g @catppuccin_status_right_separator ''
+set -g @catppuccin_status_right_separator '#[bg=default]'
 set -g @catppuccin_window_flags 'icon'
 set -g @catppuccin_session_icon "󰆍 "
+set -g @catppuccin_session_text "#[bold] #S#[nobold]"
 set -g @catppuccin_window_text " #{?#{==:#{automatic-rename},on},#{=24:pane_title},#W}"
 set -g @catppuccin_window_current_text " #{?#{==:#{automatic-rename},on},#{=24:pane_title},#W}"
 

--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -1,4 +1,12 @@
 set -g status-left "#{E:@catppuccin_status_session}#[bg=default] "
+
+# Catppuccin ships no bell module, so build @catppuccin_status_bell from the
+# @catppuccin_bell_* inputs (set in alerts.conf) with its own module builder.
+# This must run after the plugin loads, so it lives here rather than alongside
+# the inputs.
+%hidden MODULE_NAME="bell"
+source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"
+
 set -g status-right "#{?#{==:#(_tmux-bell-count),0},,#{E:@catppuccin_status_bell}}"
 
 

--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -1,4 +1,4 @@
-set -g status-left "#{E:@catppuccin_status_session}"
+set -g status-left "#{E:@catppuccin_status_session}#[bg=default] "
 set -g status-right "#{?#{==:#(_tmux-bell-count),0},,#{E:@catppuccin_status_bell}}"
 
 


### PR DESCRIPTION
Rounds the session pill on `status-left`, bolds the session name, and adds a bell module for `status-right`.

## Session Pill

#429 set `@catppuccin_status_right_separator` to the rounded glyph to round the session pill, but with `@catppuccin_status_connect_separator` on, the separator inherits the pill's own fill and rendered gray-on-gray, so the right edge looked squared. Prefixing the separator with a `#[bg=default]` reset draws the cap against the bar background instead. I also added one trailing space after the pill so its gap to the first window tab matches the window-to-window spacing, and bolded `#S` to set the session name apart from window names.

## Bell Module

`status-right` references `@catppuccin_status_bell`. Catppuccin builds only its own named modules (`session`, `cpu`, `host`, ...), so the bell is a custom module. I build it from the existing `@catppuccin_bell_*` inputs using catppuccin's module builder (`utils/status_module.conf`), sourced after the plugin loads so the pill matches the session pill, rounded caps included. I switched the fill from red to yellow and swapped the bell glyph to one that centers in its cell (the previous `nf-md-bell` sits left-heavy, and thin-space padding collapses in a monospace font).

## Testing

Verified each change live by reloading the worktree config into a running session and screenshotting the rendered status bar (text introspection strips the styling that's the whole point here). The bell is count-gated, so I confirmed its appearance by force-rendering the built module with a sample count.
