### PR TITLE
theme: qualify dark-notify with its tap in Brewfile

### DIFF
--- a/theme/Brewfile
+++ b/theme/Brewfile
@@ -1,2 +1,2 @@
 tap 'cormacrelf/tap'
-brew 'dark-notify'
+brew 'cormacrelf/tap/dark-notify'


### PR DESCRIPTION
Qualifies the `dark-notify` formula with its tap (`cormacrelf/tap/dark-notify`) in `theme/Brewfile`. The bare name made `brew bundle` search `homebrew/core`, which has no such formula, so the install failed with "No available formula with the name dark-notify."

This is a follow-up to #431, which added the formula without the tap prefix.
