### PR TITLE
tmux: pin fzf-links to mise python

### DIFF
--- a/tmux/search/search.conf
+++ b/tmux/search/search.conf
@@ -1,5 +1,8 @@
 # Open links from terminal output via fzf
 set -g @plugin 'alberti42/tmux-fzf-links'
+# Plugin needs python >= 3.10; bare `python3` resolves to Xcode's 3.9 in tmux's
+# PATH. Pin to the mise shim (self-resolves without mise on PATH).
+set -g @fzf-links-python '~/.local/share/mise/shims/python3'
 
 # Fuzzy search scrollback buffer
 set -g @plugin 'roosta/tmux-fuzzback'


### PR DESCRIPTION
Pins `@fzf-links-python` to the mise shim so the `tmux-fzf-links` plugin runs under a modern interpreter.

The plugin requires python >= 3.10 (it uses `match`/`case`, per its README) but defaults to bare `python3`. The plugin resolves that to an absolute path with `command -v` at load time, and tmux's PATH resolved it to Xcode's 3.9 stub at `/usr/bin/python3`, so every link pick crashed with an opaque `SyntaxError: invalid syntax` deep in `__main__.py`.

The mise shim self-resolves to the active mise python (3.14.5) without needing mise on `PATH`, verified from a clean `env -i` environment. I chose the shim over a hardcoded Homebrew path because it tracks the mise-managed version and stays portable to Linux.

I also filed a todo to upstream a version guard to `alberti42/tmux-fzf-links` so a pre-3.10 interpreter produces a clear diagnostic instead of a raw traceback.
