### PR TITLE
hunk: add diff viewer as git pager with catppuccin theme-sync

### DIFF
--- a/git/config
+++ b/git/config
@@ -19,7 +19,7 @@
 
 [core]
   excludesfile = ~/.config/git/ignore
-  pager = "diff-so-fancy | less --tabs=4 -RF"
+  pager = "hunk pager"
   compression = 9
 
 [interactive]
@@ -27,6 +27,10 @@
 
 [diff]
   algorithm = "histogram"
+  tool = hunk
+
+[difftool "hunk"]
+  cmd = hunk difftool "$LOCAL" "$REMOTE"
 
 [commit]
   verbose = true

--- a/hunk/config.toml
+++ b/hunk/config.toml
@@ -1,0 +1,4 @@
+theme = "catppuccin-mocha"
+mode = "auto"
+agent_notes = true
+line_numbers = true

--- a/hunk/install.sh
+++ b/hunk/install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Install hunk's config as a real file at ~/.config/hunk/config.toml rather than
+# a symlink. The theme sync scripts rewrite the `theme` line on light/dark
+# switches; if this were symlinked, every switch would dirty the tracked copy.
+set -euo pipefail
+
+topic_dir="$(cd "$(dirname "$0")" && pwd)"
+dotfiles_root="$(cd "$topic_dir/.." && pwd)"
+
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/hunk"
+mkdir -p "$config_dir"
+cp "$topic_dir/config.toml" "$config_dir/config.toml"
+
+# Reconcile the freshly copied default flavor with the active appearance.
+"$dotfiles_root/theme/bin/theme-sync-hunk"

--- a/hunk/mise.toml
+++ b/hunk/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"npm:hunkdiff" = "0.14.1"

--- a/theme/bin/theme-sync-hunk
+++ b/theme/bin/theme-sync-hunk
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Apply the active catppuccin flavor to hunk by setting `theme` in config.toml.
+# hunk reads its config at launch (both the git pager and a direct `hunk diff`),
+# so there's no running process to signal.
+set -euo pipefail
+
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
+flavor="$("$bin_dir/theme-flavor")"
+want="catppuccin-${flavor}"
+
+conf="${XDG_CONFIG_HOME:-$HOME/.config}/hunk/config.toml"
+[[ -f "$conf" ]] || exit 0
+
+current="$(yq -p toml -oy '.theme' "$conf")"
+[[ "$current" == "$want" ]] && exit 0
+
+yq -i -p toml -o toml ".theme = \"$want\"" "$conf"

--- a/tmux/core/core.conf
+++ b/tmux/core/core.conf
@@ -1,6 +1,7 @@
 # Prefix
 set -g prefix C-s
 unbind C-b
+bind -N "Send a literal C-s to the focused app (e.g. hunk save-note)" C-s send-prefix
 
 unbind r
 bind -N "Reload tmux config" r source-file ~/.config/tmux/tmux.conf

--- a/tmux/session/session.conf
+++ b/tmux/session/session.conf
@@ -2,3 +2,7 @@
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @continuum-restore 'on'
+
+# Manual save on prefix S. C-s is the tmux prefix and passes through to apps
+# (prefix C-s), so resurrect's default C-s save would collide with it.
+set -g @resurrect-save 'S'


### PR DESCRIPTION
Adds a `hunk/` topic that installs [hunk](https://github.com/modem-dev/hunk), a terminal diff viewer, and sets it as the git pager. Wires its catppuccin flavor into the existing `theme-sync` system and works around the `C-s` tmux prefix collision.

## Changes

- **Install**: `hunk/mise.toml` pins `npm:hunkdiff` through the mise npm backend, matching how `terminal/mise.toml` manages non-registry tools (exact version, Renovate-tracked).
- **Git pager**: sets `core.pager = "hunk pager"` plus a `hunk difftool`. `hunk pager` detects non-diff input and passes it through, so `git log`/`git branch` paging is unchanged and only diffs open the TUI. I kept `diff-so-fancy` for `interactive.diffFilter` (`git add -p`) since hunk is a TUI and can't act as a stdin/stdout filter.
- **Theme**: `theme/bin/theme-sync-hunk` patches the `theme` line in `config.toml` on light/dark switches, alongside the existing `theme-sync-btop`/`-fzf`/`-tmux` scripts that the orchestrator globs. hunk reads its config at launch, so there's no running process to signal.
- **Config**: `hunk/install.sh` copies `config.toml` to `~/.config/hunk/` rather than symlinking it. A symlink would route `theme-sync` rewrites back into the tracked copy and dirty the repo on every appearance change, the same reason btop isn't symlinked.
- **tmux**: binds `prefix C-s` to `send-prefix`. hunk uses `C-s` to save a review note, which the tmux prefix swallows; `C-s C-s` now sends a literal `C-s` to the focused app.

## Testing

- `mise install npm:hunkdiff@0.14.1` resolves and installs the `hunk` binary.
- `hunk/install.sh` generates `~/.config/hunk/config.toml`; `theme-sync-hunk` flips `catppuccin-latte` to `catppuccin-mocha` to match the active appearance.
- `git log | hunk pager` passes the log through unchanged (no TUI).
- `prefix C-s` registers as `send-prefix` on the running server.

## References

Extends the same `theme-sync` mechanism as #456. The two are independent (no shared files), so they merge in any order.
