### PR TITLE
lib: add git_sync_notify and drop duplicated guards

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -6,6 +6,7 @@ CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
 
 source "${0:A:h}/../scripts/lib/git-sync.sh"
 source "${0:A:h}/../scripts/lib/report-failure.sh"
+source "${0:A:h}/../scripts/lib/sync-notify.sh"
 
 revert_cosmetic_json_changes() {
   local changed_files
@@ -49,18 +50,6 @@ render_diff() {
 sync_repo() {
   gum log --level info "Syncing Claude repository..."
 
-  if [[ -L "$CLAUDE_REPO_HOME" ]]; then
-    gum log --level error "$CLAUDE_REPO_HOME is a symlink"
-    notify "Claude Upgrade" "Failed: ~/.claude-repo is a symlink"
-    return 1
-  fi
-
-  if [[ ! -d "$CLAUDE_REPO_HOME/.git" ]]; then
-    gum log --level error "$CLAUDE_REPO_HOME is not a git repository"
-    notify "Claude Upgrade" "Failed: not a git repository"
-    return 1
-  fi
-
   cd "$CLAUDE_REPO_HOME" || return 1
 
   revert_cosmetic_json_changes
@@ -85,14 +74,13 @@ sync_repo() {
   fi
 
   local new_rev
-  new_rev=$(git_sync "$CLAUDE_REPO_HOME")
+  new_rev=$(git_sync_notify "$CLAUDE_REPO_HOME" "Claude Upgrade")
   case $? in
     "$GIT_SYNC_UPDATED")
       gum log --level info "Repository updated to $new_rev"
       ;;
     "$GIT_SYNC_CURRENT") ;;
     *)
-      notify "Claude Upgrade" "Failed: could not sync"
       return 1
       ;;
   esac

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -9,6 +9,7 @@ DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 
 source "${0:A:h}/../scripts/lib/git-sync.sh"
 source "${0:A:h}/../scripts/lib/report-failure.sh"
+source "${0:A:h}/../scripts/lib/sync-notify.sh"
 
 if [[ -d "$DOTFILES_HOME/.git" ]] && { ! git -C "$DOTFILES_HOME" diff --quiet 2>/dev/null || ! git -C "$DOTFILES_HOME" diff --cached --quiet 2>/dev/null; }; then
   gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
@@ -17,13 +18,12 @@ if [[ -d "$DOTFILES_HOME/.git" ]] && { ! git -C "$DOTFILES_HOME" diff --quiet 2>
   exit 1
 fi
 
-new_rev=$(git_sync "$DOTFILES_HOME")
+new_rev=$(git_sync_notify "$DOTFILES_HOME" "Dotfiles Sync")
 case $? in
   "$GIT_SYNC_CURRENT")
     exit 0
     ;;
   "$GIT_SYNC_FAILED")
-    notify "Dotfiles Sync" "Failed: could not sync"
     exit 1
     ;;
 esac

--- a/scripts/lib/sync-notify.sh
+++ b/scripts/lib/sync-notify.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=bash
+# Sourceable bridge from git_sync's return codes to a failure notification.
+# Requires git-sync.sh and report-failure.sh to be sourced first.
+#
+# git_sync_notify <repo_dir> <title> [branch]
+#   Run git_sync and map its result:
+#     updated  echo the new short rev, return GIT_SYNC_UPDATED
+#     current  return GIT_SYNC_CURRENT
+#     failed   notify "<title>" "Failed: could not sync", return GIT_SYNC_FAILED
+#   Callers own success messages and post-update side effects. Capture with
+#   command substitution to keep the rev and status: rev=$(git_sync_notify …); status=$?
+
+git_sync_notify() {
+  local repo_dir="$1" title="$2" branch="${3:-}"
+
+  local rev status
+  rev=$(git_sync "$repo_dir" "$branch")
+  status=$?
+
+  if [[ "$status" == "$GIT_SYNC_FAILED" ]]; then
+    notify "$title" "Failed: could not sync"
+  elif [[ "$status" == "$GIT_SYNC_UPDATED" ]]; then
+    echo "$rev"
+  fi
+
+  return "$status"
+}


### PR DESCRIPTION
Adds `scripts/lib/sync-notify.sh` with `git_sync_notify <repo> <title> [branch]`, a small bridge from `git_sync`'s (#443) return codes to a `notify` (#444) call. `bin/dotfiles-sync` and `bin/claude-upgrade` both ran `git_sync` and then re-mapped its three return codes to the same `Failed: could not sync` notification, and `claude-upgrade` additionally re-checked the symlink and missing-`.git` guards that `git_sync` already performs, only to attach a notification.

`git_sync_notify` centralizes just the duplicated part: it runs `git_sync`, notifies on `GIT_SYNC_FAILED`, and passes the rev and status straight through so callers still capture `new_rev` and switch on `$?`. It sources nothing itself and documents that `git-sync.sh` and `report-failure.sh` must be sourced first, keeping `git_sync`'s narrow interface intact.

I deliberately left the caller-specific logic in place: `dotfiles-sync`'s submodule update, `Glass`-sound success notify, and `--bootstrap`; `claude-upgrade`'s interactive local-changes flow and `revert_cosmetic_json_changes`. The two duplicated guard blocks in `claude-upgrade`'s `sync_repo` are gone, since `git_sync` covers them.

## Testing

`zsh -n` covers both changed scripts and `shellcheck` covers the new `sync-notify.sh`. A source check confirms `git_sync_notify` is exposed once `git-sync.sh` and `report-failure.sh` load.
