### PR TITLE
Brewfile: add vibe-island cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -52,6 +52,7 @@ cask 'raycast'
 cask 'screens-connect'
 cask 'slack'
 cask 'the-unarchiver'
+cask 'vibe-island'
 cask 'wispr-flow'
 cask 'zoom', args: corporate_cask_args
 


### PR DESCRIPTION
Adds the `vibe-island` cask to the root `Brewfile`. Vibe Island is a Dynamic Island AI agent utility.
