### PR TITLE
tmux: open fzf-links files in nvim

### DIFF
--- a/tmux/search/search.conf
+++ b/tmux/search/search.conf
@@ -3,6 +3,8 @@ set -g @plugin 'alberti42/tmux-fzf-links'
 # Plugin needs python >= 3.10; bare `python3` resolves to Xcode's 3.9 in tmux's
 # PATH. Pin to the mise shim (self-resolves without mise on PATH).
 set -g @fzf-links-python '~/.local/share/mise/shims/python3'
+# Open files in nvim instead of the default vim
+set -g @fzf-links-editor-open-cmd "tmux new-window -n 'nvim' nvim +%line '%file'"
 
 # Fuzzy search scrollback buffer
 set -g @plugin 'roosta/tmux-fuzzback'


### PR DESCRIPTION
Sets `@fzf-links-editor-open-cmd` so the tmux-fzf-links plugin opens selected file links in `nvim`. The plugin defaults to `vim`.
