### PR TITLE
lib: rename read-only zsh status var, add ast-grep guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,8 +200,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Add brew to PATH
         run: echo "$(/home/linuxbrew/.linuxbrew/bin/brew --prefix)/bin" >> "$GITHUB_PATH"
-      - name: Install shellspec
-        run: brew install shellspec
+      - name: Install lint dependencies
+        run: brew install shellspec ast-grep
       - uses: j178/prek-action@v2
       - name: Check completion file naming convention
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,16 @@ repos:
     rev: v0.2.0
     hooks:
       - id: ast-grep
-        files: Brewfile$
+        files: (Brewfile$|\.(sh|zsh)$)
 
   - repo: local
     hooks:
+      - id: ast-grep-test
+        name: ast-grep rule tests
+        language: system
+        entry: ast-grep test --skip-snapshot-tests
+        files: ^(rules|rule-tests)/
+        pass_filenames: false
       - id: shellspec
         name: shellspec
         language: system

--- a/rule-tests/no-zsh-readonly-status-test.yml
+++ b/rule-tests/no-zsh-readonly-status-test.yml
@@ -1,0 +1,16 @@
+id: no-zsh-readonly-status
+valid:
+  # normal, assignable names
+  - state=1
+  - local context state line
+  - exit_status=$?
+  - status_code=1
+  - git status
+  # reading an intentional $status / $? is allowed, only binding is flagged
+  - foo="$status"
+invalid:
+  - status=$?
+  - local rev status
+  - local status=2
+  - typeset status
+  - for status in a b; do echo "$status"; done

--- a/rules/no-zsh-readonly-status.yml
+++ b/rules/no-zsh-readonly-status.yml
@@ -1,0 +1,23 @@
+id: no-zsh-readonly-status
+language: bash
+severity: error
+message: >-
+  'status' is a read-only special parameter in zsh (a synonym for $?), so
+  assigning to it fails at runtime with "read-only variable". These shell
+  sources are sourced into zsh entrypoints (bin/dotfiles-sync,
+  bin/claude-upgrade), so use a different name (e.g. 'rc', 'code', or something
+  descriptive).
+note: >-
+  This flags binding 'status' (assignment, local/typeset/for), not reading an
+  intentional $status. 'state' is intentionally excluded: it is a normal,
+  assignable name and the canonical local in zsh _arguments '->state'
+  completions.
+rule:
+  kind: variable_name
+  regex: '^status$'
+  not:
+    inside:
+      any:
+        - kind: simple_expansion
+        - kind: expansion
+      stopBy: end

--- a/scripts/lib/sync-notify.sh
+++ b/scripts/lib/sync-notify.sh
@@ -8,20 +8,20 @@
 #     current  return GIT_SYNC_CURRENT
 #     failed   notify "<title>" "Failed: could not sync", return GIT_SYNC_FAILED
 #   Callers own success messages and post-update side effects. Capture with
-#   command substitution to keep the rev and status: rev=$(git_sync_notify …); status=$?
+#   command substitution to keep the rev and the code: rev=$(git_sync_notify …); rc=$?
 
 git_sync_notify() {
   local repo_dir="$1" title="$2" branch="${3:-}"
 
-  local rev status
+  local rev rc
   rev=$(git_sync "$repo_dir" "$branch")
-  status=$?
+  rc=$?
 
-  if [[ "$status" == "$GIT_SYNC_FAILED" ]]; then
+  if [[ "$rc" == "$GIT_SYNC_FAILED" ]]; then
     notify "$title" "Failed: could not sync"
-  elif [[ "$status" == "$GIT_SYNC_UPDATED" ]]; then
+  elif [[ "$rc" == "$GIT_SYNC_UPDATED" ]]; then
     echo "$rev"
   fi
 
-  return "$status"
+  return "$rc"
 }

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,2 +1,4 @@
 ruleDirs:
   - rules
+testConfigs:
+  - testDir: rule-tests


### PR DESCRIPTION
Fixes a runtime crash in `git_sync_notify` and adds a lint guard so the class of bug can't recur silently.

## Issue

`scripts/lib/sync-notify.sh` assigned to `status`:

```sh
local rev status
rev=$(git_sync "$repo_dir" "$branch")
status=$?
```

`status` is a read-only special parameter in zsh (a synonym for `$?`). Both callers—`bin/dotfiles-sync` and `bin/claude-upgrade`—are `#!/usr/bin/env zsh`, so the assignment failed at runtime with `read-only variable: status`. The doc comment also recommended the same idiom to callers.

`shellcheck` runs these files as bash (`# shellcheck shell=bash`) and has no way to know they're sourced into zsh, so nothing flagged it.

## Changes

- Rename the internal local to `rc` and stop suggesting the buggy `status=$?` idiom in the doc comment. The actual callers already use `case $?` directly, so they were never affected.
- Add `rules/no-zsh-readonly-status.yml`, an ast-grep rule that flags binding `status` (assignment, `local`, `typeset`, `for`) while allowing intentional `$status` reads.
- Add `rule-tests/no-zsh-readonly-status-test.yml` with valid/invalid cases, run via `ast-grep test`.
- Widen the existing `ast-grep` pre-commit hook from `Brewfile$` to also scan `*.sh`/`*.zsh`, and add an `ast-grep-test` hook so the rule itself is regression-tested. Both run in CI through the existing `prek-action`.

I scoped the rule to `status` only. `state` is freely assignable in zsh and is the canonical local in `_arguments '->state'` completions (used in `claude/completion.zsh`), so flagging it would break correct code.

## Testing

- `ast-grep test --skip-snapshot-tests` passes all 11 cases.
- Reintroducing `status=$?` makes the `ast-grep` hook fail with the rule's message; the current tree scans clean.
- `shellcheck` and the full pre-commit suite pass.
