### PR TITLE
ci: force brew bundle cleanup without prompting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,8 +60,9 @@ jobs:
         # later runs (e.g. bat against libllhttp.so on Linux).
         HOMEBREW_NO_AUTO_UPDATE: '1'
         HOMEBREW_NO_INSTALL_UPGRADE: '1'
-        # remove stale packages from cache
-        HOMEBREW_BUNDLE_INSTALL_CLEANUP: '1'
+        # remove stale packages from cache without prompting for confirmation
+        # (plain HOMEBREW_BUNDLE_INSTALL_CLEANUP now requires --force/$HOMEBREW_ASK)
+        HOMEBREW_BUNDLE_FORCE_INSTALL_CLEANUP: '1'
         # skip deps installed without homebrew in https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
         HOMEBREW_BUNDLE_BREW_SKIP: >
           awscli


### PR DESCRIPTION
Switches the bootstrap jobs from `HOMEBREW_BUNDLE_INSTALL_CLEANUP` to `HOMEBREW_BUNDLE_FORCE_INSTALL_CLEANUP` so cleanup runs non-interactively.

## Issue

Every PR's `bootstrap (linux)` and `bootstrap (macos)` jobs were failing at the `brew bundle` step:

```
Invalid usage: `brew bundle install --cleanup` requires `--force`, `--force-cleanup` or `$HOMEBREW_ASK`.
```

A recent Homebrew release made `--cleanup` (which `HOMEBREW_BUNDLE_INSTALL_CLEANUP=1` maps to) prompt for confirmation before removing packages, and that prompt can't be answered in CI.

## Changes

`HOMEBREW_BUNDLE_FORCE_INSTALL_CLEANUP=1` is the equivalent of `--force-cleanup`: it performs the same stale-package removal but without asking, which is what the CI environment needs.
