### PR TITLE
scripts: derive Homebrew tap trust from Brewfiles

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -11,6 +11,9 @@ if [[ -z "${NONINTERACTIVE-}" ]] && [[ ! -t 0 ]]; then
   export NONINTERACTIVE=1
 fi
 
+# Trust declared taps before bundle evaluates their formulae
+./scripts/install-trust
+
 brew bundle
 
 # Expose brew configuration to installers

--- a/scripts/install-trust
+++ b/scripts/install-trust
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# Usage: install-trust [dotfiles-root]
+#
+# Trust the taps declared in the Brewfiles. The Brewfiles are the single source
+# of truth: trusting a tap here just records the decision already made by
+# committing its `tap` line. The trust file is rebuilt from scratch each run, so
+# a tap removed from the Brewfiles drops out of it too.
+set -e
+
+DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
+: "${XDG_CONFIG_HOME:=$HOME/.config}"
+
+rm -f "$XDG_CONFIG_HOME/homebrew/trust.json"
+
+brew bundle list --file "$DOTFILES_ROOT/Brewfile" --tap | while IFS= read -r tap; do
+  brew trust --tap "$tap"
+done


### PR DESCRIPTION
Adds `scripts/install-trust`, which derives Homebrew's tap trust list from the taps declared across the Brewfiles and writes `~/.config/homebrew/trust.json`. `scripts/install` runs it before `brew bundle`, so trust exists before third-party formulae get evaluated.

Homebrew 5.2/6.0 will require explicit trust for non-official taps (`HOMEBREW_REQUIRE_TAP_TRUST`), and warns once per command until then. Rather than hand-maintain a parallel trust file, I generate it from the `tap` lines that already declare which taps I trust: `brew bundle list --tap` reads them. The file is neither committed nor symlinked; it's regenerated on every install, so it can't drift from the Brewfiles. A manual `brew trust` gets overwritten on the next install, which is intended since the Brewfiles own the decision.

I trust at the tap level rather than per-formula: it mirrors the `tap` lines one-to-one, and adding a formula from an already-declared tap needs no change here. Pure `awk` formats the JSON because this runs before `brew bundle`, so `jq` isn't installed yet on a fresh machine.

## Testing

- `shellcheck scripts/install-trust` clean
- `HOMEBREW_REQUIRE_TAP_TRUST=1 brew tap` emits no trust warnings—all 10 declared taps trusted
