### PR TITLE
tmux: guard responsive predicates against empty client size

### DIFF
--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -18,8 +18,17 @@ set -g @resp_short  20
 # Note the arithmetic form #{e|<:...}: tmux's plain #{<:...} compares as STRINGS
 # ("180" < "80" is true because '1' < '8'), which silently breaks once a dimension
 # reaches three digits. #{e|<:...} compares numerically.
-set -g @resp_is_narrow "#{e|<:#{client_width},#{@resp_narrow}}"
-set -g @resp_is_short  "#{e|<:#{client_height},#{@resp_short}}"
+#
+# Guard on #{?#{client_width},...}: client_width/client_height are EMPTY when a
+# format resolves with no settled client size, e.g. the client-resized hook firing
+# mid-attach before the real terminal size arrives. Empty compares numerically as 0,
+# so the bare form would treat an unsized client as smaller than any breakpoint,
+# flipping the status bar off on a full-size desktop client and leaving it off (the
+# status option is only recomputed on resize) until the next manual resize. An
+# unknown dimension must mean "not small": only shrink when the size is positively
+# known and below the cap.
+set -g @resp_is_narrow "#{?#{client_width},#{e|<:#{client_width},#{@resp_narrow}},0}"
+set -g @resp_is_short  "#{?#{client_height},#{e|<:#{client_height},#{@resp_short}},0}"
 
 # The window name to display: the live pane title when auto-renaming, else the
 # manually-set name (#W). #{automatic-rename} is already 1/0. Auto-named titles


### PR DESCRIPTION
Fixes the responsive status bar disappearing on a full-size client until you manually resize.

## Issue

`@resp_is_narrow` and `@resp_is_short` compared the client dimension to the breakpoint with the bare arithmetic form:

```tmux
set -g @resp_is_short "#{e|<:#{client_height},#{@resp_short}}"
```

`client_width`/`client_height` resolve to an empty string when a format is evaluated before the client's size is settled, for example the `client-resized` hook firing mid-attach before the real terminal size arrives. Empty compares numerically as `0`, so `#{e|<:,20}` is `1`, the client reads as "short", and `@resp_status_visible` resolves to `off`. Because the `status` option is only recomputed on `client-resized`, the bar then stays hidden on a normal desktop client until the next manual resize. The same empty-dimension hazard drives `@resp_is_narrow`, spuriously clipping window names and dropping the session module.

## Changes

Guards each predicate so an unknown dimension means "not small":

```tmux
set -g @resp_is_short "#{?#{client_height},#{e|<:#{client_height},#{@resp_short}},0}"
```

`#{?#{client_height},...}` is false for an empty (or zero) dimension, so the predicate is `0` and the layout stays full. It only shrinks when the size is positively known and below the breakpoint. A real client dimension is never `0`, so nothing legitimate is lost.

## Testing

Reproduced in an isolated tmux server: with `client_height` empty, the old predicate evaluated to `1`/`off`; the guarded form evaluates to `0`/`on`. Verified the guarded predicate still reports `1` below the breakpoint and `0` above it for known dimensions, and that the full `responsive.conf` parses. Applied the updated predicates to the live server.

## References

Follows up on #440.
