### PR TITLE
hunk: install via Homebrew instead of mise

### DIFF
--- a/hunk/Brewfile
+++ b/hunk/Brewfile
@@ -1,0 +1,3 @@
+tap 'modem-dev/tap'
+
+brew 'modem-dev/tap/hunk'

--- a/hunk/mise.toml
+++ b/hunk/mise.toml
@@ -1,2 +1,0 @@
-[tools]
-"npm:hunkdiff" = "0.14.1"

--- a/terminal/default-npm-packages
+++ b/terminal/default-npm-packages
@@ -1,1 +1,0 @@
-hunkdiff


### PR DESCRIPTION
Switches Hunk from a mise/npm install to the project's official Homebrew tap.

The npm route installed `hunkdiff` two ways through mise: `hunk/mise.toml`'s `"npm:hunkdiff"` tool and a `hunkdiff` entry in `terminal/default-npm-packages` (aggregated into `~/.default-npm-packages`, which mise runs as `npm i -g` into each node install). Neither produced a clean global binary; the bin lived under the mise-managed node's `lib/node_modules` and only resolved when that node was on `PATH`.

## Changes

- Add `hunk/Brewfile`, which taps `modem-dev/tap` and installs `modem-dev/tap/hunk`.
- Remove `hunk/mise.toml`.
- Remove `terminal/default-npm-packages` (`hunkdiff` was its only entry; left in place it would reinstall the npm global and shadow the brew binary on the next `mise install`).

`hunk/config.toml` and `hunk/install.sh` (theme-sync config handling) are unchanged; they're independent of how the binary is installed.

## Testing

Locally uninstalled the mise/npm copies, ran `brew bundle` from `hunk/Brewfile`, and confirmed `hunk` resolves to `/opt/homebrew/bin/hunk` (v0.14.1).
