### PR TITLE
terminal: install moshi-hook with service autostart

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,12 @@
-# In CI, avoid installing Casks and Mac App Store apps which are slow and depended upon by dotfiles
+# In CI, avoid installing Casks and Mac App Store apps which are slow and depended upon by dotfiles,
+# and skip service management since runners lack a user launchd/systemd session
 if ENV['CI']
   def cask(*args) end
   def mas(*args) end
+
+  def brew(name, options = {})
+    super(name, options.except(:restart_service, :start_service))
+  end
 elsif !$stdin.tty?
   def mas(*args) end
 end

--- a/claude/Brewfile
+++ b/claude/Brewfile
@@ -6,4 +6,4 @@ cask 'claude-devtools'
 cask 'commander'
 brew 'agent-browser'
 brew 'ast-grep'
-brew 'rjyo/moshi/moshi-hook', restart_service: ENV['CI'] ? false : :changed
+brew 'rjyo/moshi/moshi-hook', restart_service: :changed

--- a/claude/Brewfile
+++ b/claude/Brewfile
@@ -1,6 +1,9 @@
+tap 'rjyo/moshi'
+
 cask 'claude'
 cask 'claude-code@latest'
 cask 'claude-devtools'
 cask 'commander'
 brew 'agent-browser'
 brew 'ast-grep'
+brew 'rjyo/moshi/moshi-hook', restart_service: ENV['CI'] ? false : :changed

--- a/claude/Brewfile
+++ b/claude/Brewfile
@@ -1,9 +1,6 @@
-tap 'rjyo/moshi'
-
 cask 'claude'
 cask 'claude-code@latest'
 cask 'claude-devtools'
 cask 'commander'
 brew 'agent-browser'
 brew 'ast-grep'
-brew 'rjyo/moshi/moshi-hook', restart_service: :changed

--- a/terminal/Brewfile
+++ b/terminal/Brewfile
@@ -1,5 +1,8 @@
+tap 'rjyo/moshi'
+
 cask 'iterm2'
 cask 'font-monaspice-nerd-font'
+brew 'rjyo/moshi/moshi-hook', restart_service: :changed
 brew 'shellspec'
 brew 'yazi'
 brew 'zoxide'


### PR DESCRIPTION
Adds the `rjyo/moshi` tap and `moshi-hook` to `terminal/Brewfile` so the daemon that bridges Claude Code to the Moshi mobile app installs via `brew bundle`.

I used `restart_service: :changed` so brew bundle starts the service when it isn't running and restarts it when the formula version changes (the nightly upgrade picks up new releases).

The root `Brewfile` now strips `restart_service`/`start_service` from all `brew` entries in CI: brew bundle has no global services toggle, and runners lack the user launchd/systemd session that `brew services` needs. This reuses the existing pattern that no-ops `cask`/`mas` in CI.

Pairing (`moshi-hook pair --token ...` and `moshi-hook install`) is a one-time interactive step and stays manual.

## Testing

- `brew ruby` DSL check: with `CI=1` the `moshi-hook` entry parses with `options={}`; without it, `options={restart_service: :changed}`
- Installed and started locally: `brew services info moshi-hook` reports `Running: true`