### PR TITLE
ssh: extend non-interactive PATH via ~/.ssh/environment

### DIFF
--- a/ssh/210-permit-user-environment.conf
+++ b/ssh/210-permit-user-environment.conf
@@ -1,0 +1,2 @@
+# Allow ~/.ssh/environment to extend PATH for non-interactive sessions
+PermitUserEnvironment PATH

--- a/ssh/environment
+++ b/ssh/environment
@@ -1,0 +1,1 @@
+PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin

--- a/ssh/install.sh
+++ b/ssh/install.sh
@@ -8,7 +8,7 @@ if [[ -n "${NONINTERACTIVE-}" ]]; then
 fi
 
 # Copy SSH daemon configuration to system directory
-sudo cp "$(dirname "$0")/200-require-key-auth.conf" /etc/ssh/sshd_config.d/
+sudo cp "$(dirname "$0")"/*.conf /etc/ssh/sshd_config.d/
 
 # Reload SSH daemon based on OS
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -17,4 +17,4 @@ else
     sudo systemctl reload sshd
 fi
 
-echo "SSH configuration updated to require public key authentication"
+echo "SSH daemon configuration updated"

--- a/ssh/symlinks.conf
+++ b/ssh/symlinks.conf
@@ -1,1 +1,2 @@
 config:~/.ssh/config
+environment:~/.ssh/environment


### PR DESCRIPTION
Extends the non-interactive SSH PATH so [Moshi](https://getmoshi.app/docs/tmux) detects Homebrew tmux. Moshi's preflight check runs `tmux` over a non-interactive session, which skips shell rc files and never sees `/opt/homebrew/bin`.

## Changes

- `ssh/environment`: full PATH including Homebrew, symlinked to `~/.ssh/environment` via `symlinks.conf`. sshd reads literal `NAME=value` lines and the value replaces the default PATH, so it lists every directory.
- `ssh/210-permit-user-environment.conf`: enables `PermitUserEnvironment PATH`, scoped to `PATH` only (OpenSSH 7.8+) rather than `yes` to avoid permitting arbitrary variables like `LD_PRELOAD`.
- `ssh/install.sh`: copies all `*.conf` drops instead of the single hardcoded file.

## Testing

After merge and sync, verify with:

```bash
ssh -o StrictHostKeyChecking=accept-new localhost 'command -v tmux'
```

Expect `/opt/homebrew/bin/tmux`, then confirm Moshi detects tmux on reconnect.
