### PR TITLE
tmux: stop hiding status bar, add compact-mode indicator

### DIFF
--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -8,7 +8,11 @@ set -g status-left "#{?#{E:@resp_is_narrow},,#{E:@catppuccin_status_session}#[bg
 %hidden MODULE_NAME="bell"
 source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"
 
-set -g status-right "#{?#{==:#(_tmux-bell-count),0},,#{E:@catppuccin_status_bell}}"
+# Compact-mode indicator (see responsive.conf): shown only on a narrow client,
+# where window names are clipped and the session module is dropped. Signals that
+# responsive compression is active. The status bar itself is never hidden. Pure
+# format, so it tracks client width on every redraw and can never get stuck.
+set -g status-right "#{?#{E:@resp_is_narrow},#[fg=#{E:@thm_blue}]  #[default] ,}#{?#{==:#(_tmux-bell-count),0},,#{E:@catppuccin_status_bell}}"
 
 
 set -g pane-border-format " #P "

--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -3,61 +3,76 @@
 # shorten window names, and auto-zoom multi-pane windows so one pane stays usable.
 #
 # How it works: the status-bar and window-name *formats* (in appearance.conf and
-# status.conf) reference the predicates defined here. tmux re-evaluates those
-# formats on every redraw, including on resize, so they need no hook. Only the
-# *behavioral* pieces (auto-zoom, hiding the status bar) use the client-resized
-# hook below.
+# status.conf) reference the predicate defined here. tmux re-evaluates those
+# formats on every redraw, including on resize, so they self-heal and need no hook.
+# The status bar is never hidden; a compact-mode indicator (status.conf) shows when
+# compression is active. Only the *behavioral* piece (auto-zoom) uses hooks.
 
-# Breakpoints. Override per-machine in tmux.conf.local if desired.
+# Breakpoint. Override per-machine in tmux.conf.local if desired.
 set -g @resp_narrow 80
-set -g @resp_short  20
 
-# Predicates, each resolving to 1 (true) or 0. Reference them elsewhere as
+# Narrowness predicate, resolving to 1 (true) or 0. Reference it elsewhere as
 # #{E:@resp_is_narrow}, which expands the stored format in the caller's context.
 #
 # Note the arithmetic form #{e|<:...}: tmux's plain #{<:...} compares as STRINGS
 # ("180" < "80" is true because '1' < '8'), which silently breaks once a dimension
 # reaches three digits. #{e|<:...} compares numerically.
 #
-# Guard on #{?#{client_width},...}: client_width/client_height are EMPTY when a
-# format resolves with no settled client size, e.g. the client-resized hook firing
-# mid-attach before the real terminal size arrives. Empty compares numerically as 0,
-# so the bare form would treat an unsized client as smaller than any breakpoint,
-# flipping the status bar off on a full-size desktop client and leaving it off (the
-# status option is only recomputed on resize) until the next manual resize. An
-# unknown dimension must mean "not small": only shrink when the size is positively
-# known and below the cap.
+# Guard on #{?#{client_width},...}: client_width is EMPTY when a format resolves
+# with no settled client size, e.g. a hook firing mid-attach before the real
+# terminal size arrives. Empty compares numerically as 0, so the bare form would
+# treat an unsized client as narrower than any breakpoint. An unknown dimension
+# must mean "not small": only compress when the size is positively known and below
+# the cap.
 set -g @resp_is_narrow "#{?#{client_width},#{e|<:#{client_width},#{@resp_narrow}},0}"
-set -g @resp_is_short  "#{?#{client_height},#{e|<:#{client_height},#{@resp_short}},0}"
 
 # The window name to display: the live pane title when auto-renaming, else the
 # manually-set name (#W). #{automatic-rename} is already 1/0. Auto-named titles
 # clip to 24; a narrow client clips the whole result to 10 (see window_text).
 set -g @resp_winname "#{?#{automatic-rename},#{=24:#{pane_title}},#W}"
 
-# Whether the status bar should be shown. Hidden only when the client is too
-# short to spare the row (never on zoom: the status bar carries the prefix
-# indicator and other state you want visible even when a pane is zoomed).
-# Resolves to the literal on/off that the `status` option expects.
-set -g @resp_status_visible "#{?#{E:@resp_is_short},off,on}"
-
 # Auto-zoom: on a narrow client, collapse a multi-pane window to a single zoomed
 # pane so the focused pane stays tappable. @resp_autozoom marks ownership so we
 # never fight you: unset = idle, 'auto' = we zoomed it, 'user' = you toggled zoom
 # manually (the prefix-z binding sets this) so we leave it alone. We zoom only
-# when you are the sole client viewing the window (zoom is window state shared
-# by every client, so zooming for a narrow client would collapse a wide client's
-# view of the same window).
-set-hook -g  client-resized 'if -F "#{&&:#{E:@resp_is_narrow},#{&&:#{e|>:#{window_panes},1},#{&&:#{!=:#{window_zoomed_flag},1},#{&&:#{==:#{window_active_clients},1},#{==:#{@resp_autozoom},}}}}}" "resize-pane -Z ; set -w @resp_autozoom auto"'
-# Back to wide: restore the pane we auto-zoomed (if it is still zoomed), then
-# release ownership so a later narrow episode can auto-zoom afresh.
-set-hook -ga client-resized 'if -F "#{&&:#{==:#{E:@resp_is_narrow},0},#{&&:#{==:#{@resp_autozoom},auto},#{==:#{window_zoomed_flag},1}}}" "resize-pane -Z"'
-set-hook -ga client-resized 'if -F "#{&&:#{==:#{E:@resp_is_narrow},0},#{!=:#{@resp_autozoom},}}" "set -uw @resp_autozoom"'
+# when you are the sole client viewing the window (zoom is window state shared by
+# every client, so zooming for a narrow client would collapse a wide client's
+# view of the same window). The status bar is intentionally exempt: it carries the
+# prefix indicator and other state you want visible even when a pane is zoomed.
+#
+# The three conditions are named once here and referenced by the hooks below, so
+# the same verdict drives every triggering event. #{E:...} recursively expands the
+# stored format in the hook's (triggering client's) context.
+set -g @resp_zoom_in      "#{&&:#{E:@resp_is_narrow},#{&&:#{e|>:#{window_panes},1},#{&&:#{!=:#{window_zoomed_flag},1},#{&&:#{==:#{window_active_clients},1},#{==:#{@resp_autozoom},}}}}}"
+set -g @resp_zoom_restore "#{&&:#{==:#{E:@resp_is_narrow},0},#{&&:#{==:#{@resp_autozoom},auto},#{==:#{window_zoomed_flag},1}}}"
+set -g @resp_zoom_release "#{&&:#{==:#{E:@resp_is_narrow},0},#{!=:#{@resp_autozoom},}}"
+
+# Re-evaluate on any event that can change the narrow/wide verdict or the active
+# window: a terminal resize, attaching an already-correctly-sized client (no resize
+# fires), switching the active window (a multi-pane window should collapse on a
+# phone), or moving a client between sessions. client-resized alone misses the last
+# three. Each event replaces (not appends) its hook via -g, so re-sourcing this file
+# rebuilds cleanly instead of stacking duplicates.
+set-hook -g client-resized {
+  if -F "#{E:@resp_zoom_in}"      { resize-pane -Z ; set -w @resp_autozoom auto }
+  if -F "#{E:@resp_zoom_restore}" { resize-pane -Z }
+  if -F "#{E:@resp_zoom_release}" { set -uw @resp_autozoom }
+}
+set-hook -g client-attached {
+  if -F "#{E:@resp_zoom_in}"      { resize-pane -Z ; set -w @resp_autozoom auto }
+  if -F "#{E:@resp_zoom_restore}" { resize-pane -Z }
+  if -F "#{E:@resp_zoom_release}" { set -uw @resp_autozoom }
+}
+set-hook -g session-window-changed {
+  if -F "#{E:@resp_zoom_in}"      { resize-pane -Z ; set -w @resp_autozoom auto }
+  if -F "#{E:@resp_zoom_restore}" { resize-pane -Z }
+  if -F "#{E:@resp_zoom_release}" { set -uw @resp_autozoom }
+}
+set-hook -g client-session-changed {
+  if -F "#{E:@resp_zoom_in}"      { resize-pane -Z ; set -w @resp_autozoom auto }
+  if -F "#{E:@resp_zoom_restore}" { resize-pane -Z }
+  if -F "#{E:@resp_zoom_release}" { set -uw @resp_autozoom }
+}
+
 # A manual `prefix z` marks the window user-owned so auto-zoom leaves it alone.
 bind z resize-pane -Z \; set -w @resp_autozoom user
-
-# Hide the status bar on a short client, restore it otherwise. Scoped to the
-# resized client's session (-g would leak to every session) and applied only when
-# you are the sole client on that session: `status` is a session option, so two
-# clients of different heights cannot both be satisfied.
-set-hook -ga client-resized 'if -F "#{==:#{session_attached},1}" "set -F status #{E:@resp_status_visible}"'


### PR DESCRIPTION
Stops hiding the tmux status bar on small clients and replaces the behavior with an always-visible compact-mode indicator. Hiding the bar was chronically broken: it failed to update when switching windows, and got stuck off after mosh/ssh reconnects.

## Issue

`status` is a tmux option, not a format, so unlike every other responsive piece (window-name clipping, the session module) it can't re-evaluate on redraw. It only changed via the `client-resized` hook, which doesn't fire on window switch, on attaching an already-correctly-sized terminal, or reliably on mosh reconnect. So a stale `status off` was never corrected. The `session_attached == 1` guard made it worse, silently skipping the update whenever a transient second client (a mosh reconnect zombie) was attached, leaving the bar stuck.

I considered driving the option from more hooks, but that piles more triggers onto a racy mechanism that can never self-heal. Removing the hiding behavior entirely deletes the only option-driven piece and the whole bug class with it.

## Changes

- Removes the status-hiding mechanism: `@resp_short`, `@resp_is_short`, `@resp_status_visible`, and the status-setting hook. The status bar is now always visible.
- Adds a compact-mode indicator to `status-right` in `status.conf`: a `` (U+F066 compress) glyph in `@thm_blue`, shown only when `@resp_is_narrow`. It's a pure format, so it tracks client width on every redraw and can't get stuck.
- Extends auto-zoom (the one remaining hook-driven piece) from `client-resized` alone to also fire on `client-attached`, `session-window-changed`, and `client-session-changed`, so it reacts when you attach a narrow client or switch to a multi-pane window on a phone. The three conditions are factored into `@resp_zoom_in`/`@resp_zoom_restore`/`@resp_zoom_release` and registered as per-event brace blocks, which also fixes a latent duplicate-on-reload bug in the old `-ga` append form.

## Testing

Verified against a real narrow nested client (a second client attached to a throwaway session, sized below the 80-column breakpoint):

- Narrow client shows the indicator and keeps the status bar visible.
- Switching to a multi-pane window from the narrow client auto-zooms it (`zoomed=1`, `@resp_autozoom=auto`), exercising the previously-broken window-switch path.
- Widening past 80 columns restores the zoom and releases ownership; the indicator disappears.
