### PR TITLE
tmux: let a pane resume its session on restore

### DIFF
--- a/terminal/README.md
+++ b/terminal/README.md
@@ -22,8 +22,9 @@ access via mosh/Blink Shell, and sane copy/paste defaults.
   windows, panes, and more
 - **Session persistence:**
   [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) saves and
-  restores sessions across tmux server restarts (`prefix + Ctrl-s` to save,
-  `prefix + Ctrl-r` to restore)
+  restores sessions across tmux server restarts (`prefix + S` to save,
+  `prefix + Ctrl-r` to restore), including
+  [letting a pane resume its own session](#resuming-sessions)
 - **Catppuccin theme:**
   [catppuccin/tmux](https://github.com/catppuccin/tmux) (mocha) for the status
   bar
@@ -42,6 +43,39 @@ current automatically. To manage manually inside tmux:
 | `prefix + I` | Install new plugins |
 | `prefix + U` | Update all plugins |
 | `prefix + alt + u` | Remove unlisted plugins |
+
+### Resuming sessions
+
+A pane can resume its own session on restore instead of starting fresh. The
+mechanism is one pane-scoped tmux option, `@resume-command`: a pane sets it to
+the command that restores its session, and the `@resurrect-hook-post-save-all`
+hook (`tmux/session/bin/tmux-resurrect-resume`) swaps that command into the
+pane's saved restore command before the save file is finalized. A pane that
+never set the option restores fresh.
+
+This stays program-agnostic: the restore command comes entirely from the pane,
+so the config holds no per-program logic. The one exception is
+`@resurrect-processes` in `session.conf`: resurrect re-runs a restored command
+only if it matches that allowlist, so each binary is listed there (`~claude`).
+
+A session id (the runtime state that makes resume possible) is lost by restore
+time, so resurrect's built-in strategies, which see only the saved command and
+directory, cannot recover it. Capturing it as a pane option at save time is what
+closes that gap.
+
+#### Setting the option
+
+A program sets `@resume-command` from a hook that fires on session start. For
+Claude Code, a `SessionStart` hook (matching the `startup` and `resume` sources,
+so it stays current across resumes) does it in one line, since
+`$CLAUDE_CODE_SESSION_ID` and `$TMUX_PANE` are already in the environment:
+
+```sh
+[ -n "$TMUX_PANE" ] && tmux set-option -p -t "$TMUX_PANE" @resume-command "claude --resume $CLAUDE_CODE_SESSION_ID"
+```
+
+The `$TMUX_PANE` guard makes it a no-op outside tmux. The only contract between
+a program and tmux is the option name; either side can change independently.
 
 ### Copy/paste
 

--- a/tmux/session/bin/tmux-resurrect-resume
+++ b/tmux/session/bin/tmux-resurrect-resume
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# @resurrect-hook-post-save-all hook: for each pane that set the @resume-command
+# option, swap that command into the pane's saved restore command (field 11).
+# Panes without it restore fresh.
+
+set -euo pipefail
+
+tab=$'\t'
+
+resurrect_dir=$(tmux show-option -gqv @resurrect-dir)
+resurrect_dir=${resurrect_dir:-${XDG_DATA_HOME:-$HOME/.local/share}/tmux/resurrect}
+
+# Default to the `last` symlink; rewrite its target, not the link itself.
+savefile=${1:-$resurrect_dir/last}
+if [ -L "$savefile" ]; then
+  savefile=$resurrect_dir/$(readlink "$savefile")
+fi
+[ -f "$savefile" ] || exit 0
+
+# session:window.pane -> pane_id for every live pane
+panes=$(tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_id}')
+
+tmpfile=$(mktemp "${savefile}.XXXXXX")
+trap 'rm -f "$tmpfile"' EXIT
+
+while IFS= read -r line || [ -n "$line" ]; do
+  case $line in
+    pane"$tab"*) ;;
+    *) printf '%s\n' "$line" >>"$tmpfile"; continue ;;
+  esac
+
+  IFS=$tab read -r f_type f_session f_window f_wactive f_wflags \
+    f_pindex f_title f_dir f_pactive f_pcommand f_cmd <<<"$line"
+
+  key=$f_session:$f_window.$f_pindex
+  pane_id=$(awk -v k="$key" '$1 == k { print $2; exit }' <<<"$panes")
+  if [ -n "$pane_id" ]; then
+    resume=$(tmux show-options -p -t "$pane_id" -qv @resume-command)
+    [ -n "$resume" ] && f_cmd=:$resume
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$f_type" "$f_session" "$f_window" "$f_wactive" "$f_wflags" \
+    "$f_pindex" "$f_title" "$f_dir" "$f_pactive" "$f_pcommand" "$f_cmd" >>"$tmpfile"
+done <"$savefile"
+
+mv "$tmpfile" "$savefile"
+trap - EXIT

--- a/tmux/session/session.conf
+++ b/tmux/session/session.conf
@@ -6,3 +6,13 @@ set -g @continuum-restore 'on'
 # Manual save on prefix S. C-s is the tmux prefix and passes through to apps
 # (prefix C-s), so resurrect's default C-s save would collide with it.
 set -g @resurrect-save 'S'
+
+# Let a pane resume itself on restore. A pane sets @resume-command to the command
+# that restores its session (e.g. a program's SessionStart hook sets it) and the
+# post-save-all hook below rewrites that pane's saved command to it. Resurrect
+# only re-runs a restored command that matches @resurrect-processes, so list each
+# binary here; `~claude` substring-matches the rewritten `claude --resume …`.
+set -g @resurrect-processes '"~claude"'
+
+# Rewrite saved commands to their @resume-command before the file is finalized.
+set -g @resurrect-hook-post-save-all 'tmux-resurrect-resume'


### PR DESCRIPTION
Lets a pane resume its own session on tmux restore instead of coming back as a bare shell. tmux-resurrect and continuum already restore the pane tree, but a pane running a long-lived program (Claude Code) lost its conversation: `@resurrect-processes` was unset and the saved launch command starts fresh.

The mechanism is one pane-scoped tmux option, `@resume-command`. A pane sets it to the command that restores its session, and a new `@resurrect-hook-post-save-all` hook (`tmux-resurrect-resume`) swaps that value into the pane's saved restore command (field 11) before the save file is finalized. A pane that never set the option restores fresh.

I kept this program-agnostic: nothing here knows about Claude or coding agents. The restore command comes entirely from the pane, so a program owns its own resume syntax. The single per-program line is `@resurrect-processes '"~claude"'`, which is resurrect's own gate for which restored commands are safe to re-run.

## Why a pane option

Resurrect's built-in extension points (the processes allowlist, inline strategies, and strategy files) all run at restore time against only the saved command and directory. A session id is runtime state that's gone by then, so none of them can recover it. Capturing it as a pane option at save time, via the sanctioned `post-save-all` hook, is what closes the gap. This could become a native resurrect feature (read a pane option as the restore command); I may file that upstream separately.

## Setting the option

A program sets `@resume-command` from a hook that fires on session start. For Claude Code, a `SessionStart` hook (out of scope here, in the program's own config) does it in one line, since `$CLAUDE_CODE_SESSION_ID` and `$TMUX_PANE` are already in the environment:

```sh
[ -n "$TMUX_PANE" ] && tmux set-option -p -t "$TMUX_PANE" @resume-command "claude --resume $CLAUDE_CODE_SESSION_ID"
```

The `$TMUX_PANE` guard makes it a no-op outside tmux. Without it, restore degrades to a fresh launch.

## Testing

Ran the hook against synthetic save files covering every branch: a pane with the option set is rewritten (including a plain `zsh` pane, confirming there is no program coupling), live panes without the option and saved panes with no matching live pane pass through untouched, and non-pane lines are preserved byte-for-byte including each field's leading `:`.

## References

- Claude Code `SessionStart` hook that sets `@resume-command`: bendrucker/claude#771
