### PR TITLE
deepen theme reconcile, sync guard, and bootstrap

### DIFF
--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -11,13 +11,6 @@ source "${0:A:h}/../scripts/lib/git-sync.sh"
 source "${0:A:h}/../scripts/lib/report-failure.sh"
 source "${0:A:h}/../scripts/lib/sync-notify.sh"
 
-if [[ -d "$DOTFILES_HOME/.git" ]] && { ! git -C "$DOTFILES_HOME" diff --quiet 2>/dev/null || ! git -C "$DOTFILES_HOME" diff --cached --quiet 2>/dev/null; }; then
-  gum log --level error "Local changes in $DOTFILES_HOME - skipping sync"
-  gum log --level error "Run 'git -C $DOTFILES_HOME status' to see changes"
-  notify "Dotfiles Sync" "Skipped: local changes present"
-  exit 1
-fi
-
 new_rev=$(git_sync_notify "$DOTFILES_HOME" "Dotfiles Sync")
 case $? in
   "$GIT_SYNC_CURRENT")

--- a/hunk/install.sh
+++ b/hunk/install.sh
@@ -5,11 +5,7 @@
 set -euo pipefail
 
 topic_dir="$(cd "$(dirname "$0")" && pwd)"
-dotfiles_root="$(cd "$topic_dir/.." && pwd)"
 
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/hunk"
 mkdir -p "$config_dir"
 cp "$topic_dir/config.toml" "$config_dir/config.toml"
-
-# Reconcile the freshly copied default flavor with the active appearance.
-"$dotfiles_root/theme/bin/theme-sync-hunk"

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
-# bootstrap installs things.
+# bootstrap does the first-run-only setup (gitconfig, submodules), then hands
+# off to dotf for the shared reconcile: Homebrew packages, default package
+# lists, config symlinks, and every topic installer.
 
 cd "$(dirname "$0")/.." || exit 1
 DOTFILES_ROOT=$(pwd -P)
@@ -12,6 +14,7 @@ for arg in "$@"; do
   esac
 done
 
+# Install Homebrew and gum up front; setup_gitconfig prompts via gum.
 "$DOTFILES_ROOT/scripts/homebrew.sh"
 
 setup_gitconfig () {
@@ -40,18 +43,11 @@ init_submodules () {
   git -C "$DOTFILES_ROOT" submodule update --init --recursive
 }
 
-install_dotfiles () {
-  gum log --level info 'installing dotfiles'
-  "$DOTFILES_ROOT/scripts/install-symlinks" "$DOTFILES_ROOT"
-}
-
 setup_gitconfig
 init_submodules
-install_dotfiles
 
-gum log --level info 'building default packages'
-./bin/build-default-packages
-
+# dotf installs Homebrew packages, builds the default package lists, links
+# configs, and runs every topic installer.
 # shellcheck disable=SC1091
 if ! source ./bin/dotf; then
   gum log --level error 'error installing dependencies'

--- a/scripts/install
+++ b/scripts/install
@@ -30,3 +30,8 @@ for sm_path in ${(f)"$(git submodule foreach --quiet 'echo $sm_path' 2>/dev/null
 done
 
 find . -name install.sh "${excludes[@]}" | while read -r installer; do "${installer}"; done
+
+# Reconcile theme-managed configs to the active flavor. Runs after every
+# installer so each config exists and tmux plugins are present; failures here
+# shouldn't abort an otherwise successful install.
+./theme/bin/theme-sync || gum log --level warn "theme-sync had issues"

--- a/scripts/lib/git-sync.sh
+++ b/scripts/lib/git-sync.sh
@@ -6,7 +6,8 @@
 #   set-head retry and falling back to "main".
 #
 # git_sync <repo_dir> [branch]
-#   Guard the target, fetch with retry, and fast-forward only.
+#   Guard the target (reject symlinks, non-repos, and dirty working trees),
+#   fetch with retry, and fast-forward only.
 #   Returns:
 #     0  updated   (new short rev echoed to stdout)
 #     2  current   (already up to date)
@@ -61,6 +62,12 @@ git_sync() {
 
   if [[ ! -d "$repo_dir/.git" ]]; then
     gum log --level error "$repo_dir is not a git repository"
+    return "$GIT_SYNC_FAILED"
+  fi
+
+  if ! git -C "$repo_dir" diff --quiet 2>/dev/null ||
+     ! git -C "$repo_dir" diff --cached --quiet 2>/dev/null; then
+    gum log --level error "$repo_dir has local changes - skipping sync"
     return "$GIT_SYNC_FAILED"
   fi
 

--- a/system/fzf.zsh
+++ b/system/fzf.zsh
@@ -2,5 +2,5 @@
 # Catppuccin colors for fzf, flavored to the active macOS appearance.
 # fzf reads this file fresh on every launch, so the theme-sync watcher only has
 # to rewrite its contents (no per-shell export, no subshell at startup). The
-# file is seeded at install time by theme/install.sh.
+# file is seeded by the theme reconcile at install time.
 export FZF_DEFAULT_OPTS_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/fzf-default-opts"

--- a/system/install.sh
+++ b/system/install.sh
@@ -3,13 +3,11 @@
 # silence the login prompt
 touch "$HOME/.hushlogin"
 
-# btop: seed btop.conf if missing, then apply the active catppuccin flavor.
-script_dir="$(cd "$(dirname "$0")" && pwd)"
+# btop: seed btop.conf if missing. The active flavor is reconciled by the
+# theme-sync pass that runs once all installers have created their configs.
 btop_conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/btop"
 btop_conf="$btop_conf_dir/btop.conf"
 mkdir -p "$btop_conf_dir"
 if [ ! -f "$btop_conf" ]; then
   btop --default-config > "$btop_conf"
 fi
-"$script_dir/../theme/bin/theme-sync-btop"
-"$script_dir/../theme/bin/theme-sync-fzf"

--- a/theme/install.sh
+++ b/theme/install.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Seed the fzf opts cache so FZF_DEFAULT_OPTS_FILE resolves to a real file
-# before the theme-sync watcher's first run.
-set -euo pipefail
-
-bin_dir="$(cd "$(dirname "$0")" && pwd)/bin"
-"$bin_dir/theme-sync-fzf"


### PR DESCRIPTION
Three independent refactors, each turning a shallow module into a deeper one: more behaviour behind a smaller interface, with logic that was scattered across callers concentrated in one place. Surfaced by an architecture review; no behaviour change intended.

## Changes

**`theme`: one reconcile pass at install.** `system/install.sh`, `hunk/install.sh`, and `theme/install.sh` each reached past the `theme-sync` dispatcher to invoke individual `theme-sync-<tool>` scripts, so the set of theme-managed tools leaked across topic seams. I moved that to a single `theme-sync` run at the end of `scripts/install`, after every installer has created its config and tmux plugins exist. Each reconciler already self-gates on a missing config, so the full pass is safe and idempotent. `theme/install.sh` only seeded fzf, so it's deleted.

**`git-sync`: clean-tree guard behind the interface.** `git_sync` already rejected symlinks and non-repos, but the "working tree is clean" check lived in `dotfiles-sync`, re-implemented per caller. I folded it into `git_sync` (returns `FAILED` with a logged reason) and dropped the redundant pre-check. `claude-upgrade` and `setup` keep their own richer state handling and both leave a clean tree before `git_sync` runs, so they compose unchanged, and any future caller inherits the guard for free.

**`bootstrap`: delegate the shared reconcile to `dotf`.** `bootstrap` installed symlinks and built default packages, then sourced `dotf`, which re-runs `homebrew.sh`, rebuilds default packages, and (via `scripts/install`) re-links the same symlinks. I kept only bootstrap's first-run-unique work (gitconfig, submodules) plus the up-front `homebrew.sh` that the gitconfig prompts need, then hand off to `dotf`. Symlinks and default package lists now run once.

## Testing

Pre-commit (`shellcheck`, `shellspec`) passes on all three commits. Not yet exercised end-to-end on a fresh machine; the changes are behaviour-preserving by construction (removed calls are subsumed by an existing later step in each case).
