### PR TITLE
tmux: enable resurrect pane-contents and nvim session restore

### DIFF
--- a/tmux/session/session.conf
+++ b/tmux/session/session.conf
@@ -6,3 +6,11 @@ set -g @continuum-restore 'on'
 # Manual save on prefix S. C-s is the tmux prefix and passes through to apps
 # (prefix C-s), so resurrect's default C-s save would collide with it.
 set -g @resurrect-save 'S'
+
+# Save/restore visible pane contents (scrollback). default-command is unset,
+# so the &&/|| caveat from the resurrect docs does not apply.
+set -g @resurrect-capture-pane-contents 'on'
+
+# When a restored pane was running neovim and a Session.vim exists in its dir,
+# reopen it with `nvim -S`. Inert when no Session.vim is present.
+set -g @resurrect-strategy-nvim 'session'


### PR DESCRIPTION
Enables two opt-in tmux-resurrect features that were off by default, both in `tmux/session/session.conf`.

## Changes

- `@resurrect-capture-pane-contents 'on'`: saves and restores each pane's visible scrollback. `default-command` is unset here, so the `&&`/`||` caveat from the resurrect docs doesn't apply.
- `@resurrect-strategy-nvim 'session'`: when a restored pane was running neovim and a `Session.vim` exists in its directory, reopen it with `nvim -S`. Inert otherwise.

I deliberately left out vim-obsession (auto-updating `Session.vim`) as overkill, so the neovim strategy relies on a manually created `Session.vim` (`:mksession`). I also left `@resurrect-strategy-vim` out (`EDITOR=nvim` and there's no vim here). The `@resurrect-processes` list stays at its defaults.

## Testing

Sourced the module into the running server and confirmed both options registered (`show-options -gv` returns `on` and `session`). Triggered a resurrect save and confirmed it produced `pane_contents.tar.gz` with per-pane scrollback captures.
