### PR TITLE
scripts: tap trusted taps explicitly before brew bundle

### DIFF
--- a/scripts/install-trust
+++ b/scripts/install-trust
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
 # Usage: install-trust [dotfiles-root]
 #
-# Trust the taps declared in the Brewfiles. The Brewfiles are the single source
-# of truth: trusting a tap here just records the decision already made by
-# committing its `tap` line. The trust file is rebuilt from scratch each run, so
-# a tap removed from the Brewfiles drops out of it too.
+# Tap and trust the taps declared in the Brewfiles. The Brewfiles are the single
+# source of truth: committing a `tap` line records the decision, and this script
+# enforces it. The trust file is rebuilt from scratch each run, so a tap removed
+# from the Brewfiles drops out of it too.
+#
+# Homebrew 6.0.0 stopped auto-tapping untrusted taps from `brew bundle`
+# (Homebrew/brew#22599), so trusting a tap is no longer enough to let `brew
+# bundle` clone it. Tap each one explicitly so the formulae are on disk before
+# `brew bundle` runs, then trust so `brew bundle` can install from it.
 set -e
 
 DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
@@ -13,5 +18,6 @@ DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
 rm -f "$XDG_CONFIG_HOME/homebrew/trust.json"
 
 brew bundle list --file "$DOTFILES_ROOT/Brewfile" --tap | while IFS= read -r tap; do
+  brew tap "$tap"
   brew trust --tap "$tap"
 done


### PR DESCRIPTION
Taps each tap declared in the Brewfiles before `brew bundle` runs, then trusts it. Homebrew 6.0.0 (released 2026-06-11) stopped auto-tapping untrusted taps from `brew bundle` in [Homebrew/brew#22599](https://github.com/Homebrew/brew/pull/22599), so trusting a tap is no longer enough for `brew bundle` to clone it. The tap has to be on disk first.

## Issue

The `bootstrap (macos)` CI job started failing on 2026-06-11. Every third-party tap formula (`schpet/tap`, `teamookla/speedtest`, `withgraphite/tap`, `oven-sh/bun`, and the rest) reported "unreadable: No available formula ... This command requires the tap X. If you trust this tap, tap it explicitly", then `brew bundle` exited 1.

`scripts/install-trust` ran `brew trust --tap` for each tap and every trust succeeded, but `brew bundle` still could not read any third-party formula. Homebrew 6.0.0 landed [#22599](https://github.com/Homebrew/brew/pull/22599) the same day, which removes implicit auto-tapping. Before, `brew bundle` would clone a missing tap as a side effect of installing from it. Now a missing tap surfaces an error so it can be tapped explicitly, and `brew trust` alone does not clone it.

This is environmental, not branch-specific. The unrelated `tmux-mobile` PR (run `27359381615`) failed identically the same day, including `modem-dev/tap/hunk` as unreadable. `main` was green on 2026-06-10 and would fail the same way on its next run.

## Changes

- `scripts/install-trust` now runs `brew tap "$tap"` before `brew trust --tap "$tap"` for each tap enumerated from the Brewfiles.

Tapping first also lets `brew trust` infer the package type from the on-disk tap files, which is the order [#22599](https://github.com/Homebrew/brew/pull/22599) recommends. The Brewfiles stay the single source of truth: `trust.json` is still rebuilt from scratch each run, so a tap removed from a Brewfile drops out of trust. `brew tap` is idempotent and CI sets `HOMEBREW_NO_AUTO_UPDATE=1`, so re-tapping an already-tapped repo is cheap. The script runs on both Linux and macOS and the change is symmetric, so no OS guard is needed.
