### PR TITLE
tmux: guard status-format seeding on a sentinel

### DIFF
--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -37,10 +37,15 @@ set -g status-style "bg=#{?#{E:@resp_is_narrow},default,#{@thm_mantle}},fg=#{@th
 # A blank spacer row keeps the bar from touching the panes: the bar content
 # moves to the second status line and line 0 renders empty, filled with the
 # terminal background. Seeding copies tmux's default bar format into line 1,
-# guarded so re-sourcing this file doesn't copy the spacer over the content.
+# then overwrites line 0 with the spacer. Guard on our own sentinel, not on
+# status-format[1] being empty: tmux 3.6 ships a non-empty default for line 1
+# (the pane list), so an emptiness check misfires, skips the copy, and leaves
+# the default pane list rendering in place of the real bar. The sentinel also
+# survives theme-sync re-sources, where line 0 already holds the spacer.
 set -g status 2
-%if "#{==:#{status-format[1]},}"
+%if "#{==:#{@resp_bar_seeded},}"
 set -gF 'status-format[1]' "#{status-format[0]}"
+set -g @resp_bar_seeded 1
 %endif
 set -g 'status-format[0]' "#[fill=default]"
 


### PR DESCRIPTION
Guards the two-line status bar seeding on a dedicated sentinel instead of `status-format[1]` being empty.

## Issue

The bar moves its content to line 1 and blanks line 0 as a spacer. To seed line 1 it copies tmux's default bar format from line 0, then overwrites line 0 with `#[fill=default]`. The copy was guarded by `%if "#{==:#{status-format[1]},}"` so a re-source wouldn't clobber the content with the spacer.

tmux 3.6 broke that assumption. It ships a non-empty default for `status-format[1]`: the pane-list format. So the guard sees line 1 as already populated, skips the copy, and blanks line 0 anyway. You end up with an empty line 0 and the default pane list (`#P[WxH]`) rendering on line 1 where the catppuccin bar should be. Older tmux defaults line 1 to empty, so only 3.6 machines hit it.

## Changes

- Guard the copy on a `@resp_bar_seeded` sentinel that this file sets, not on line-1 emptiness. It's version-independent, and it stays set across the theme-sync re-sources of this file, where line 0 already holds the spacer.

## Testing

Repaired the affected server in place. Then I re-sourced `status.conf` twice: line 0 stays the spacer, line 1 stays the real bar. The catppuccin session and window pills render again.
