### PR TITLE
sync: fix silent exit 2 when already up to date

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -73,9 +73,9 @@ sync_repo() {
     fi
   fi
 
-  local new_rev
-  new_rev=$(git_sync_notify "$CLAUDE_REPO_HOME" "Claude Upgrade")
-  case $? in
+  local new_rev sync_rc=0
+  new_rev=$(git_sync_notify "$CLAUDE_REPO_HOME" "Claude Upgrade") || sync_rc=$?
+  case $sync_rc in
     "$GIT_SYNC_UPDATED")
       gum log --level info "Repository updated to $new_rev"
       ;;

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -11,8 +11,9 @@ source "${0:A:h}/../scripts/lib/git-sync.sh"
 source "${0:A:h}/../scripts/lib/report-failure.sh"
 source "${0:A:h}/../scripts/lib/sync-notify.sh"
 
-new_rev=$(git_sync_notify "$DOTFILES_HOME" "Dotfiles Sync")
-case $? in
+sync_rc=0
+new_rev=$(git_sync_notify "$DOTFILES_HOME" "Dotfiles Sync") || sync_rc=$?
+case $sync_rc in
   "$GIT_SYNC_CURRENT")
     exit 0
     ;;

--- a/scripts/lib/sync-notify.sh
+++ b/scripts/lib/sync-notify.sh
@@ -7,15 +7,17 @@
 #     updated  echo the new short rev, return GIT_SYNC_UPDATED
 #     current  return GIT_SYNC_CURRENT
 #     failed   notify "<title>" "Failed: could not sync", return GIT_SYNC_FAILED
-#   Callers own success messages and post-update side effects. Capture with
-#   command substitution to keep the rev and the code: rev=$(git_sync_notify …); rc=$?
+#   Callers own success messages and post-update side effects. Capture the rev
+#   and the code with command substitution. Under `set -e` a bare
+#   rev=$(git_sync_notify …); rc=$? aborts before rc=$? runs, because the nonzero
+#   "current" (2) result fails the assignment. Seed rc and capture in an AND-OR
+#   list so errexit is suppressed: rc=0; rev=$(git_sync_notify …) || rc=$?
 
 git_sync_notify() {
   local repo_dir="$1" title="$2" branch="${3:-}"
 
-  local rev rc
-  rev=$(git_sync "$repo_dir" "$branch")
-  rc=$?
+  local rev rc=0
+  rev=$(git_sync "$repo_dir" "$branch") || rc=$?
 
   if [[ "$rc" == "$GIT_SYNC_FAILED" ]]; then
     notify "$title" "Failed: could not sync"

--- a/scripts/spec/dotfiles_sync_spec.sh
+++ b/scripts/spec/dotfiles_sync_spec.sh
@@ -46,8 +46,10 @@ GUM
     git -C "$repo" remote set-head origin main
   }
 
+  # Run with `zsh -f` so the script's startup skips ~/.zshenv, which exports
+  # DOTFILES_HOME unconditionally and would otherwise clobber the sandbox path.
   run_sync() {
-    PATH="$stubdir:$PATH" DOTFILES_HOME="$repo" "$dotfiles_sync"
+    PATH="$stubdir:$PATH" DOTFILES_HOME="$repo" zsh -f "$dotfiles_sync"
   }
 
   BeforeEach 'setup'

--- a/scripts/spec/dotfiles_sync_spec.sh
+++ b/scripts/spec/dotfiles_sync_spec.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "dotfiles-sync exit status"
+  dotfiles_sync="$SHELLSPEC_PROJECT_ROOT/../bin/dotfiles-sync"
+
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/dotfiles-sync"
+    origin="$sandbox/origin.git"
+    repo="$sandbox/repo"
+    stubdir="$sandbox/stub"
+    rm -rf "$sandbox"
+    mkdir -p "$stubdir"
+
+    # gum stub: `gum spin … -- cmd` runs cmd; `gum log … msg` echoes msg.
+    cat > "$stubdir/gum" <<'GUM'
+#!/usr/bin/env bash
+case "$1" in
+  spin)
+    shift
+    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
+    [ "$1" = "--" ] && shift
+    exec "$@"
+    ;;
+  log)
+    # Real gum log writes to stderr; match that so command substitution in
+    # callers keeps log lines off the captured stdout rev.
+    printf '%s\n' "${@: -1}" >&2
+    ;;
+esac
+GUM
+    chmod +x "$stubdir/gum"
+
+    # notify shells out to osascript on macOS; stub it so the failure path
+    # stays silent and side-effect-free during the test.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$stubdir/osascript"
+    chmod +x "$stubdir/osascript"
+
+    # Bare origin with one commit on main; clone so HEAD == origin/main.
+    git init -q --bare -b main "$origin"
+    git init -q -b main "$repo"
+    git -C "$repo" -c user.email=test@example.com -c user.name=test \
+      commit -q --allow-empty -m init
+    git -C "$repo" remote add origin "$origin"
+    git -C "$repo" push -q origin main
+    git -C "$repo" remote set-head origin main
+  }
+
+  run_sync() {
+    PATH="$stubdir:$PATH" DOTFILES_HOME="$repo" "$dotfiles_sync"
+  }
+
+  BeforeEach 'setup'
+
+  # Regression: under `set -e`, the already-current path (git_sync returns 2)
+  # must map to exit 0, not abort the script with the raw "current" code.
+  It "exits 0 when the repo is already up to date"
+    When call run_sync
+    The status should be success
+    The stderr should include "Already up to date"
+  End
+
+  # The other side of the case block: a guard failure (git_sync returns 1) must
+  # surface as a nonzero exit.
+  It "exits 1 when the working tree is dirty"
+    touch "$repo/dirty"
+    git -C "$repo" add dirty
+    When call run_sync
+    The status should equal 1
+    The stderr should include "has local changes"
+  End
+End

--- a/scripts/spec/sync_notify_spec.sh
+++ b/scripts/spec/sync_notify_spec.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# notified is consumed by a shellspec matcher the linter cannot see, and the
+# stub functions read as unused.
+# shellcheck disable=SC2034,SC2329
+
+Describe "git_sync_notify"
+  setup() {
+    # shellcheck source=/dev/null
+    source "$SHELLSPEC_PROJECT_ROOT/lib/git-sync.sh"
+    # shellcheck source=/dev/null
+    source "$SHELLSPEC_PROJECT_ROOT/lib/sync-notify.sh"
+    notified=""
+  }
+  BeforeEach 'setup'
+
+  # Stubs override the real git_sync/notify sourced above; defined per example
+  # so they take effect after setup.
+
+  It "echoes the rev, returns updated, and does not notify"
+    git_sync() { echo "abc1234"; return "$GIT_SYNC_UPDATED"; }
+    notify() { notified="$1: $2"; }
+    When call git_sync_notify /repo "Title"
+    The status should equal "$GIT_SYNC_UPDATED"
+    The output should equal "abc1234"
+    The variable notified should equal ""
+  End
+
+  It "returns current with no rev and does not notify"
+    git_sync() { return "$GIT_SYNC_CURRENT"; }
+    notify() { notified="$1: $2"; }
+    When call git_sync_notify /repo "Title"
+    The status should equal "$GIT_SYNC_CURRENT"
+    The output should equal ""
+    The variable notified should equal ""
+  End
+
+  It "returns failed and notifies"
+    git_sync() { return "$GIT_SYNC_FAILED"; }
+    notify() { notified="$1: $2"; }
+    When call git_sync_notify /repo "Title"
+    The status should equal "$GIT_SYNC_FAILED"
+    The variable notified should equal "Title: Failed: could not sync"
+  End
+End


### PR DESCRIPTION
Fixes `dotfiles sync --bootstrap` exiting with code `2` right after printing `Already up to date`, when nothing actually failed.

## Issue

`bin/dotfiles-sync` runs under `set -e` and captured the sync result with a bare command substitution:

```zsh
new_rev=$(git_sync_notify "$DOTFILES_HOME" "Dotfiles Sync")
case $? in
  "$GIT_SYNC_CURRENT") exit 0 ;;
  ...
```

When the repo is already current, `git_sync` returns `GIT_SYNC_CURRENT` (`2`). Under `set -e`, an assignment whose command substitution exits nonzero aborts the script immediately, before the `case` runs. The branch meant to map "current" to `exit 0` was dead code, so the script died with `2`. The nightly upgrade job and anything checking the exit status saw a healthy no-op as a failure.

I verified the mechanism in zsh: `set -e; f(){ return 2; }; x=$(f); echo after` never prints `after`. Without `set -e`, `$?` is correctly `2`, so `set -e` is the sole trigger.

## Changes

- `bin/dotfiles-sync`: capture the code with the errexit-safe idiom `sync_rc=0; new_rev=$(...) || sync_rc=$?`, matching the existing pattern in `scripts/setup`.
- `bin/claude-upgrade`: same change. It works today only because it lacks `set -e`; this keeps it correct if that changes.
- `scripts/lib/sync-notify.sh`: guard `git_sync_notify`'s own internal capture so its failure `notify` still fires if a future caller invokes it bare under `set -e`. I also corrected the docstring, which recommended the exact `rev=$(...); rc=$?` pattern that breaks under `set -e`.

## Testing

Two shellspec specs under `scripts/spec/`, auto-discovered by the bootstrap CI job:

- `sync_notify_spec.sh`: locks the `git_sync_notify` contract. It checks the `updated`/`current`/`failed` return codes, the rev on stdout, and notify-on-failure.
- `dotfiles_sync_spec.sh`: runs the real `bin/dotfiles-sync` against an offline sandbox repo for both `case` branches (already-current to `0`, dirty tree to `1`).

Reverting the `dotfiles-sync` fix makes the already-current test fail with `2`.

I left shellcheck out of CI (brittle against the zsh shebangs and `${0:A:h}`) and skipped a live-network sync test (the offline sandbox covers it). I also dropped an errexit unit test I drafted: shellspec runs under bash 3.2, which has no `inherit_errexit`, so it passed whether or not the lib was guarded. That propagation only bites in zsh, which the integration spec exercises directly.
