### PR TITLE
tmux: remove two-line status bar spacer

### DIFF
--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -34,22 +34,6 @@ set -g window-status-current-format "#{?#{E:@resp_is_narrow},#{E:@resp_wsc_narro
 # color in and would render off-color edges on a transparent bar.
 set -g status-style "bg=#{?#{E:@resp_is_narrow},default,#{@thm_mantle}},fg=#{@thm_fg}"
 
-# A blank spacer row keeps the bar from touching the panes: the bar content
-# moves to the second status line and line 0 renders empty, filled with the
-# terminal background. Seeding copies tmux's default bar format into line 1,
-# then overwrites line 0 with the spacer. Guard on our own sentinel, not on
-# status-format[1] being empty: tmux 3.6 ships a non-empty default for line 1
-# (the pane list), so an emptiness check misfires, skips the copy, and leaves
-# the default pane list rendering in place of the real bar. The sentinel also
-# survives theme-sync re-sources, where line 0 already holds the spacer.
-set -g status 2
-%if "#{==:#{@resp_bar_seeded},}"
-set -gF 'status-format[1]' "#{status-format[0]}"
-set -g @resp_bar_seeded 1
-%endif
-set -g 'status-format[0]' "#[fill=default]"
-
-
 set -g pane-border-format " #P "
 set -g pane-border-style "fg=brightblack"
 set -g pane-active-border-style "fg=cyan"


### PR DESCRIPTION
Removes the blank spacer row above the status bar. The bar is back to a single line using tmux's default `status-format`.

The spacer worked by setting `status 2`, copying the live `status-format[0]` into line 1, then blanking line 0. That copy only preserves the bar when line 0 still holds tmux's pristine default at source time. On a long-running server already seeded by an earlier reload, line 0 was already the spacer, so the copy duplicated the spacer into line 1 and both lines rendered blank. `set -gu` removes an array element rather than restoring tmux's built-in default, so nothing at runtime could rebuild the lost bar. The sentinel guard from #485 didn't help: it was empty on any server seeded before the sentinel existed.

A one-cell gap isn't worth destructive, state-dependent seeding, so I dropped the feature. `status-left`, `status-right`, `window-status-format`, and `status-style` are untouched, so the catppuccin styling is unchanged.

## Testing

Sourced the change against a live server stuck in the broken two-line state and confirmed the normal single-line bar returned.
