### PR TITLE
tmux: surface per-pane Claude status in wide pill

### DIFF
--- a/tmux/appearance/appearance.conf
+++ b/tmux/appearance/appearance.conf
@@ -7,9 +7,11 @@ set -g @catppuccin_window_flags 'icon'
 set -g @catppuccin_session_icon "󰆍 "
 set -g @catppuccin_session_text "#[bold] #S#[nobold]"
 # Wide clients only: narrow clients bypass catppuccin's pills entirely via the
-# window-status wrapper in status.conf.
-set -g @catppuccin_window_text " #{E:@resp_winname}"
-set -g @catppuccin_window_current_text " #{E:@resp_winname}"
+# window-status wrapper in status.conf. @resp_pane_status (defined in
+# responsive.conf) appends a per-pane Claude strip on multi-pane windows, kept
+# behind #{E:...} so status.conf's -F capture defers it to render time.
+set -g @catppuccin_window_text " #{E:@resp_winname}#{E:@resp_pane_status}"
+set -g @catppuccin_window_current_text " #{E:@resp_winname}#{E:@resp_pane_status}"
 
 # Sync catppuccin flavor with macOS appearance (fallback for watch-theme-change daemon).
 # theme-sync-tmux self-gates, so it's safe to call unconditionally on every focus event.

--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -32,6 +32,24 @@ set -g @resp_is_narrow "#{?#{client_width},#{e|<:#{client_width},#{@resp_narrow}
 # already 1/0. Single quotes so \( reaches tmux's regex engine unmolested.
 set -g @resp_winname '#{?#{automatic-rename},#{=24:#{s/^\([^)]*\) //:pane_title}},#W}'
 
+# Per-pane Claude status for the wide pill: a multi-pane Claude window otherwise
+# collapses to one label, hiding that the other panes are working. One glyph per
+# pane keys on pane_current_command, not pane_title: Claude's spinner is a
+# transient pane_title frame that would thrash the bar every tick. Active pane is
+# ●, a backgrounded Claude pane ○, a non-Claude pane a low-key middot so columns
+# still line up.
+set -g @resp_pane_glyph '#{?#{m:claude,#{pane_current_command}},#{?#{==:#{pane_active},1},●,○},·}'
+
+# Per-pane glyphs via the P: pane iterator (window context, no per-pane shell).
+# The inner #{E:...} defers @resp_pane_glyph so it expands once per pane.
+set -g @resp_pane_strip '#{P:#{E:@resp_pane_glyph}}'
+
+# Append the strip (leading space) only on multi-pane windows; single-pane (the
+# common case) stays clean. The #{E:@resp_pane_strip} indirection mirrors
+# @resp_is_narrow above so the strip survives status.conf's -F capture of the
+# wide pill and re-expands per render against the current panes.
+set -g @resp_pane_status '#{?#{>:#{window_panes},1}, #{E:@resp_pane_strip},}'
+
 # Narrow status bar pieces (referenced by the wrappers in status.conf).
 # Commas inside #[...] are only legal because these live in their own options;
 # inlined into a #{?...} they would split its branches.


### PR DESCRIPTION
Surfaces per-pane Claude status in the wide window pill. A window running Claude across several panes used to collapse to one window label, hiding that the other panes were working. The wide current-window pill now appends one glyph per pane: a filled circle for the active Claude pane, a hollow circle for a backgrounded Claude pane, and a low-key middot for a non-Claude pane.

Original Task: [Surface multi-pane Claude task status in tmux window labels](https://things.bendrucker.me/show?id=9kp9NndDTHSCHVQYuuLZ9t)

The original premise referenced a now-removed `_tmux-window-label` helper. I re-grounded it against the current responsive-statusbar model: the window label is built from `@resp_*` formats in `tmux/responsive/responsive.conf` and wired through `tmux/appearance/status.conf` and `tmux/appearance/appearance.conf`.

## Changes

- `tmux/responsive/responsive.conf`: three new `@resp_*` options.
  - `@resp_pane_glyph` keys the glyph on `pane_current_command` matching `claude` and `pane_active`, i.e. pane STATE tmux already tracks. I deliberately did not parse the first non-ASCII char of `pane_title`: that is Claude's spinner, a transient animation frame that would thrash the status bar on every tick.
  - `@resp_pane_strip` iterates panes with the `#{P:...}` pane iterator (`#{P:#{E:@resp_pane_glyph}}`), concatenating per-pane glyphs with no per-pane shell call. The inner `#{E:...}` defers the glyph so it expands once per pane.
  - `@resp_pane_status` gates on `#{>:#{window_panes},1}` so single-pane windows (the common case) stay clean.
- `tmux/appearance/appearance.conf`: extends `@catppuccin_window_text` and `@catppuccin_window_current_text` with `#{E:@resp_pane_status}`.

The strip stays behind `#{E:...}` so it survives `status.conf`'s `-F` capture of the wide pill (a single expansion) and re-expands per render against the current panes, mirroring the existing `@resp_is_narrow` deferral idiom. The new options are plain `set -g` so they survive a theme re-source idempotently.

This targets the wide pill only. I left the narrow path (`@resp_ws_narrow` / `@resp_wsc_narrow`) untouched: narrow clients auto-zoom multi-pane windows, so per-pane glyphs there would fight the design.

## Testing

I validated the format strings read-only against the live tmux server (tmux 3.6b) using scratch option names, then unset them:

- `#{P:#{E:@resp_pane_glyph}}` over the current window yields one glyph per pane; the active Claude pane resolves to the filled circle.
- The `#{>:#{window_panes},1}` gate yields empty on a single-pane window, so the pill stays clean.
- The `#{E:@resp_pane_strip}` indirection expands correctly through the deferral chain.

`pre-commit` passes on both files (`.conf` is not covered by shellcheck/ast-grep; trailing-whitespace and end-of-file-fixer pass). The CI tmux smoke test starts a server and asserts no stderr plus catppuccin options, which a local sandbox can't fork, so it runs in CI.
