### PR TITLE
tmux: window picker and directory auto-naming

### DIFF
--- a/tmux/CLAUDE.md
+++ b/tmux/CLAUDE.md
@@ -22,7 +22,7 @@ Permanent unbinds of tmux defaults (e.g. `unbind C-b` to free the prefix) stay w
 
 ## Plugin variable changes
 
-Plugins (`set -g @<plugin>-<var>`) read their variables at init only. Sourcing `tmux.conf` updates the variable but doesn't rebind anything. Re-run the plugin's loader directly. The entrypoint filename varies by plugin (`tmux-fzf/tmux-fzf.tmux`, `tmux-fuzzback/fuzzback.tmux`), so list it first:
+Plugins (`set -g @<plugin>-<var>`) read their variables at init only. Sourcing `tmux.conf` updates the variable but doesn't rebind anything. Re-run the plugin's loader directly. The entrypoint filename varies by plugin (`tmux-fuzzback/fuzzback.tmux`, `tmux-floax/floax.tmux`), so list it first:
 
 ```sh
 ls $TMUX_PLUGIN_MANAGER_PATH/<plugin>/*.tmux

--- a/tmux/core/core.conf
+++ b/tmux/core/core.conf
@@ -22,6 +22,12 @@ setw -g pane-base-index 1
 set -g renumber-windows on
 set -g focus-events on                     # apps detect pane/window focus changes
 
+# Auto-name windows after their working directory (the worktree/project), not the
+# process. Every window running claude/zsh would otherwise read the same. A manual
+# `rename-window` turns automatic-rename off for that window, so custom names are
+# preserved. The pane_in_mode/pane_dead markers match the tmux default.
+set -g automatic-rename-format '#{?pane_in_mode,[tmux],#{b:pane_current_path}}#{?pane_dead,[dead],}'
+
 # Only break words on spaces and @ so double-click selects full URLs and ticket IDs
 setw -g word-separators ' @'
 

--- a/tmux/navigation/bin/_tmux-window-picker
+++ b/tmux/navigation/bin/_tmux-window-picker
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fzf window switcher rendered as a table. The primary column is the window name,
+# which is meaningful now that auto-naming uses the working directory (see
+# automatic-rename-format in core.conf) while manual names are preserved. A
+# trailing zone of single-cell glyphs flags multi-pane / zoomed / bell windows.
+# Keeping every glyph trailing means an omitted one never shifts the name column.
+
+# Drop the preview on a narrow client, matching the responsive popups.
+preview=1
+[[ "$(tmux display-message -p '#{E:@resp_is_narrow}')" == 1 ]] && preview=0
+
+MULTI='󰕰'   # nf-md-view-grid: window has multiple panes
+ZOOM='󰊓'    # nf-md-fullscreen: window is zoomed
+BELL='󰂞'    # nf-md-bell: bell/alert flag set
+
+current=$(tmux display-message -p '#{session_name}:#{window_index}')
+
+sep=$'\t'
+declare -a target name panes zoomed belled
+while IFS="$sep" read -r s i n p z b; do
+  t="$s:$i"
+  [[ "$t" == "$current" ]] && continue
+  target+=("$t"); name+=("$n"); panes+=("$p"); zoomed+=("$z"); belled+=("$b")
+done < <(tmux list-windows -a \
+  -F "#{session_name}${sep}#{window_index}${sep}#{window_name}${sep}#{window_panes}${sep}#{window_zoomed_flag}${sep}#{window_bell_flag}")
+
+[[ ${#target[@]} -gt 0 ]] || exit 0
+
+w_name=0
+for x in "${name[@]}"; do (( ${#x} > w_name )) && w_name=${#x}; done
+(( w_name < 6 )) && w_name=6   # "window"
+
+rows=""
+for k in "${!target[@]}"; do
+  pane=' '; (( ${panes[$k]} > 1 )) && pane="$MULTI"
+  zoom=' '; [[ "${zoomed[$k]}" == 1 ]] && zoom=$'\033[33m'"$ZOOM"$'\033[0m'
+  bell=' '; [[ "${belled[$k]}" == 1 ]] && bell=$'\033[31m'"$BELL"$'\033[0m'
+  printf -v line '%s%s%-*s  \033[36m%s\033[0m %s%s' \
+    "${target[$k]}" "$sep" "$w_name" "${name[$k]}" "$pane" "$zoom" "$bell"
+  rows+="$line"$'\n'
+done
+
+# Header doubles as a column label and a glyph legend so the table reads itself.
+printf -v header '\033[2m%-*s  󰕰 multiple panes   󰊓 zoomed   󰂞 bell\033[0m' \
+  "$w_name" "window"
+
+opts=(--no-sort --ansi --border --border-label ' windows ' --prompt '  '
+      --delimiter="$sep" --with-nth=2
+      --header "$header" --header-first)
+(( preview )) && opts+=(--preview 'tmux capture-pane -ep -t {1}' --preview-window 'right,55%')
+
+# fzf exits 130 on abort, which set -e would turn into a popup error flash
+selection=$(printf '%s' "$rows" | fzf "${opts[@]}") || exit 0
+chosen=${selection%%"$sep"*}
+[[ -n $chosen ]] || exit 0
+tmux switch-client -t "${chosen%%:*}"
+tmux select-window -t "$chosen"

--- a/tmux/navigation/navigation.conf
+++ b/tmux/navigation/navigation.conf
@@ -11,15 +11,12 @@ bind -N "Search prefix bindings" ? if -F "#{E:@resp_is_narrow}" \
   "display-popup -E -w 100% -h 100% tmux-keys" \
   "display-popup -E -w 60% -h 60% tmux-keys"
 
-set -g @plugin 'sainnhe/tmux-fzf'
-set-environment -gu TMUX_FZF_LAUNCH_KEY
-# Boot default; the responsive hooks flip this at runtime (see responsive.conf).
-set-environment -g TMUX_FZF_OPTIONS "-p -w 60% -h 60%"
-
 bind -N "Switch session" t if -F "#{E:@resp_is_narrow}" \
   "display-popup -E -w 100% -h 100% _tmux-sesh-picker" \
   "display-popup -E -w 80% -h 80% _tmux-sesh-picker"
-bind -N "Switch window" w run-shell -b '$TMUX_PLUGIN_MANAGER_PATH/tmux-fzf/scripts/window.sh switch'
+bind -N "Switch window" w if -F "#{E:@resp_is_narrow}" \
+  "display-popup -E -w 100% -h 100% _tmux-window-picker" \
+  "display-popup -E -w 80% -h 80% _tmux-window-picker"
 
 bind -N "Grab scrollback to clipboard" g run-shell tmux-grab-scrollback
 

--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -26,11 +26,11 @@ set -g @resp_narrow 80
 # the cap.
 set -g @resp_is_narrow "#{?#{client_width},#{e|<:#{client_width},#{@resp_narrow}},0}"
 
-# The window name to display: the live pane title when auto-renaming, else the
-# manually-set name (#W). Apps like Claude Code prepend a "(Machine) " prefix
-# to pane titles, which is pure noise here, so strip it. #{automatic-rename} is
-# already 1/0. Single quotes so \( reaches tmux's regex engine unmolested.
-set -g @resp_winname '#{?#{automatic-rename},#{=24:#{s/^\([^)]*\) //:pane_title}},#W}'
+# The window name to display. Auto-naming uses the working directory (see
+# automatic-rename-format in core.conf) and manual renames are preserved, so
+# window_name is meaningful on its own. Cap it so long worktree names stay tidy.
+# The =N modifier ignores #W-style aliases, so window_name is spelled out.
+set -g @resp_winname '#{=/24/…:window_name}'
 
 # Narrow status bar pieces (referenced by the wrappers in status.conf).
 # Commas inside #[...] are only legal because these live in their own options;
@@ -53,10 +53,10 @@ set -g @resp_chip_bg '#{?#{||:#{window_bell_flag},#{window_activity_flag}},#{@th
 set -g @resp_chip_fg '#{?#{||:#{window_bell_flag},#{window_activity_flag}},#{@thm_crust},#{@thm_overlay_1}}'
 set -g @resp_ws_narrow '#[fg=#{E:@resp_chip_bg}]#[fg=#{E:@resp_chip_fg},bg=#{E:@resp_chip_bg}]#I#[fg=#{E:@resp_chip_bg},bg=default]#[default]'
 
-# Current window: rounded pill with index block + name + zoom flag. The name
-# is #W (the process name under automatic-rename, the manual name otherwise);
-# pane_title is too noisy at this width. window_name spelled out: the =N
-# truncation modifier ignores #W-style aliases.
+# Current window: rounded pill with index block + name + zoom flag. The name is
+# window_name, the working directory under automatic-rename and the manual name
+# otherwise. pane_title is too noisy at this width. window_name is spelled out
+# because the =N truncation modifier ignores #W-style aliases.
 set -g @resp_wsc_narrow '#[fg=#{@thm_mauve}]#[fg=#{@thm_crust},bg=#{@thm_mauve},bold]#I #[fg=#{@thm_fg},bg=#{@thm_surface_1},nobold] #{=/12/…:window_name}#{?window_zoomed_flag, 󰁌,}#[fg=#{@thm_surface_1},bg=default]#[default]'
 
 # Auto-zoom: on a narrow client, collapse a multi-pane window to a single zoomed
@@ -78,7 +78,7 @@ set -g @resp_zoom_release "#{&&:#{==:#{E:@resp_is_narrow},0},#{!=:#{@resp_autozo
 # Popups should be near-fullscreen on a narrow client (60-80% of 43x34 is an
 # unusable postage stamp) and keep their desktop sizes otherwise. display-popup
 # sizes are not format-expanded, so bindings we own dispatch via `if -F`
-# (navigation.conf). The fzf plugins (fuzzback, floax, tmux-fzf) read their
+# (navigation.conf). The fzf plugins (fuzzback, floax) read their
 # sizing from global options/environment on every invocation, so the hooks
 # below flip those globals whenever the narrow/wide verdict can change. The
 # conditional formats expand in the triggering client's context, like the zoom
@@ -102,8 +102,6 @@ set-hook -g client-resized {
   set -gF @fuzzback-hide-preview "#{?#{E:@resp_is_narrow},1,0}"
   setenv -gF FLOAX_WIDTH "#{?#{E:@resp_is_narrow},100%,80%}"
   setenv -gF FLOAX_HEIGHT "#{?#{E:@resp_is_narrow},100%,80%}"
-  setenv -gF TMUX_FZF_OPTIONS "#{?#{E:@resp_is_narrow},-p -w 100% -h 100%,-p -w 60% -h 60%}"
-  setenv -gF TMUX_FZF_PREVIEW "#{?#{E:@resp_is_narrow},0,1}"
 }
 set-hook -g client-attached {
   if -F "#{E:@resp_zoom_in}"      { resize-pane -Z ; set -w @resp_autozoom auto }
@@ -113,8 +111,6 @@ set-hook -g client-attached {
   set -gF @fuzzback-hide-preview "#{?#{E:@resp_is_narrow},1,0}"
   setenv -gF FLOAX_WIDTH "#{?#{E:@resp_is_narrow},100%,80%}"
   setenv -gF FLOAX_HEIGHT "#{?#{E:@resp_is_narrow},100%,80%}"
-  setenv -gF TMUX_FZF_OPTIONS "#{?#{E:@resp_is_narrow},-p -w 100% -h 100%,-p -w 60% -h 60%}"
-  setenv -gF TMUX_FZF_PREVIEW "#{?#{E:@resp_is_narrow},0,1}"
 }
 set-hook -g session-window-changed {
   if -F "#{E:@resp_zoom_in}"      { resize-pane -Z ; set -w @resp_autozoom auto }
@@ -124,8 +120,6 @@ set-hook -g session-window-changed {
   set -gF @fuzzback-hide-preview "#{?#{E:@resp_is_narrow},1,0}"
   setenv -gF FLOAX_WIDTH "#{?#{E:@resp_is_narrow},100%,80%}"
   setenv -gF FLOAX_HEIGHT "#{?#{E:@resp_is_narrow},100%,80%}"
-  setenv -gF TMUX_FZF_OPTIONS "#{?#{E:@resp_is_narrow},-p -w 100% -h 100%,-p -w 60% -h 60%}"
-  setenv -gF TMUX_FZF_PREVIEW "#{?#{E:@resp_is_narrow},0,1}"
 }
 set-hook -g client-session-changed {
   if -F "#{E:@resp_zoom_in}"      { resize-pane -Z ; set -w @resp_autozoom auto }
@@ -135,8 +129,6 @@ set-hook -g client-session-changed {
   set -gF @fuzzback-hide-preview "#{?#{E:@resp_is_narrow},1,0}"
   setenv -gF FLOAX_WIDTH "#{?#{E:@resp_is_narrow},100%,80%}"
   setenv -gF FLOAX_HEIGHT "#{?#{E:@resp_is_narrow},100%,80%}"
-  setenv -gF TMUX_FZF_OPTIONS "#{?#{E:@resp_is_narrow},-p -w 100% -h 100%,-p -w 60% -h 60%}"
-  setenv -gF TMUX_FZF_PREVIEW "#{?#{E:@resp_is_narrow},0,1}"
 }
 
 # A manual `prefix z` marks the window user-owned so auto-zoom leaves it alone.


### PR DESCRIPTION
Replaces the `tmux-fzf` window switcher with a dedicated fzf picker and makes window auto-naming useful.

The old picker showed tmux's default `session:idx: name (N panes) [WxH]`, and every window read `claude` because `automatic-rename` falls back to the process name. Neither the window name nor the pane count was scannable at a glance.

## Picker

`_tmux-window-picker` renders an aligned table leading with the window name, a trailing zone of single-cell glyphs for multi-pane / zoomed / bell state, and a pinned header that labels the column and legends the glyphs. It's a dedicated script rather than a `TMUX_FZF_WINDOW_FORMAT` because the plugin hardcodes `session:index: ` at the start of every row, which leaves the first column ragged and a real table impossible. Keeping every glyph in the trailing zone means an omitted indicator never shifts the text column.

Glyphs are all `nf-md`, the only Nerd Font family Monaspace renders at full cell width (FontAwesome and codicon glyphs came back blank). Circled numbers for the exact pane count read poorly because they're East-Asian-ambiguous width, so the count collapses to single-vs-multi: blank for one pane, one view-grid glyph for more.

## Auto-Naming

`automatic-rename-format` now uses the working-directory basename instead of the process name, so a window identifies by its worktree/project. Manual names survive. tmux turns `automatic-rename` off for a window the moment it's renamed, so a `rename-window` always wins. The wide status bar (`@resp_winname`) drops its `pane_title` stripping hack and reads `window_name` directly, matching the picker.

## Removed

`sainnhe/tmux-fzf` was used only for the old `w` binding, so it and its responsive `TMUX_FZF_*` env vars are gone.

## Verifying

Ran the picker against live windows with a stubbed `fzf`: columns align, the current window is excluded, and field parsing plus switch targets are correct. Confirmed glyph rendering and the new directory names in popups against the real Monaspace font.

Not live-reloaded: the new script isn't on the running server's `$PATH`, so the `w` binding activates on install (`dotfiles dev enable` or sync). Auto-naming and the status-bar change were applied to the running session live.
