### PR TITLE
tmux: apply narrow session pill and bell color to wide clients

### DIFF
--- a/tmux/appearance/appearance.conf
+++ b/tmux/appearance/appearance.conf
@@ -4,8 +4,26 @@ set -goq @catppuccin_flavor 'mocha'
 set -g @catppuccin_window_status_style 'rounded'
 set -g @catppuccin_status_right_separator '#[bg=default]'
 set -g @catppuccin_window_flags 'icon'
-set -g @catppuccin_session_icon "󰆍 "
-set -g @catppuccin_session_text "#[bold] #S#[nobold]"
+
+# Session pill: drop the icon and paint the whole pill the prefix color (red
+# while the prefix is held, green otherwise). The background is the prefix
+# indicator; the icon carried no information. Mirrors the narrow pill
+# (@resp_sl_narrow) so every client width reads the same. @catppuccin_session_color
+# is catppuccin's own prefix-flipping color; reuse it for the name background,
+# with crust text for contrast on the saturated fill.
+set -g @catppuccin_session_icon ""
+set -g @catppuccin_session_text "#[bold]#S#[nobold]"
+set -g @catppuccin_status_session_text_fg "#{E:@thm_crust}"
+set -g @catppuccin_status_session_text_bg "#{E:@catppuccin_session_color}"
+
+# Non-current window pills flip to yellow on bell or activity, matching the
+# narrow chips (@resp_chip_bg). Only the index block recolors: its fg is crust,
+# which stays legible on yellow, whereas the name block's fg is the light
+# foreground. The flag icons still render alongside. The bell/activity test is
+# evaluated per window at render; it survives catppuccin's format build and
+# status.conf's capture the same way the existing flag conditionals do.
+set -g @catppuccin_window_number_color "#{?#{||:#{window_bell_flag},#{window_activity_flag}},#{@thm_yellow},#{@thm_overlay_2}}"
+
 # Wide clients only: narrow clients bypass catppuccin's pills entirely via the
 # window-status wrapper in status.conf.
 set -g @catppuccin_window_text " #{E:@resp_winname}"


### PR DESCRIPTION
Two visual treatments that previously only appeared on narrow clients (phone, SSH, Mosh) now apply at every width. The narrow theming proved that the background color is a better prefix indicator than a fixed icon, and that a color flip reads as a bell faster than a flag glyph. This carries both to wide clients.

## Session Pill

Drops the session icon and paints the whole pill the prefix color: red while the prefix is held, green otherwise. The icon was static and carried no information; the background already encodes the one thing worth seeing at a glance. This mirrors the narrow pill (`@resp_sl_narrow`), so the session block now reads the same at any width, differing only in that wide clients show the full session name.

It rides catppuccin's own `@catppuccin_session_color` (the prefix-flipping color the plugin already defines) for both the caps and the name background, with crust text for contrast on the saturated fill.

## Window Bell Color

Non-current window pills flip their index block to yellow on bell or activity, matching the narrow chips (`@resp_chip_bg`). Only the index block recolors: its foreground is crust, which stays legible on yellow, whereas the name block's foreground is the light theme foreground and would wash out. The existing flag icon still renders alongside, so this is additive. Wide clients get color plus glyph, narrow clients get color alone. Current-window pills keep their mauve accent, matching narrow, where the active chip does not flip either.

## How It Works

Both changes are pure catppuccin variable settings in `appearance.conf`, set before the plugin builds its formats. The bell/activity test is a per-window conditional that catppuccin bakes into `window-status-format`; it then survives `status.conf`'s capture into the wide-format wrappers the same way the existing flag conditionals do, and resolves per window at render. No format wrapping or capture logic changed.

## Testing

Verified the built formats and their render-time resolution in a throwaway tmux server loading the worktree config: the session background resolves to green with no prefix and the window index resolves to overlay normally and yellow under a bell/activity flag. Applied to the live server and confirmed the alert styles stay neutralized so the rounded caps don't pick up a rectangular merged style. A rendered screenshot was not captured (screen was locked at the time).
