### PR TITLE
terminal: replace markless with glow and leaf

### DIFF
--- a/terminal/Brewfile
+++ b/terminal/Brewfile
@@ -2,6 +2,7 @@ tap 'rjyo/moshi'
 
 cask 'iterm2'
 cask 'font-monaspice-nerd-font'
+brew 'glow'
 brew 'rjyo/moshi/moshi-hook', restart_service: :changed
 brew 'shellspec'
 brew 'yazi'

--- a/terminal/mise.toml
+++ b/terminal/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-"github:jvanderberg/markless" = "0.9.29"
+"github:RivoLink/leaf" = "1.24.2"


### PR DESCRIPTION
Switches the terminal topic's markdown viewer from `markless` to two tools: `glow` for reading, `leaf` for live editing.

`markless` is feature-rich, but it rendered inline images and Mermaid diagrams poorly enough that the breadth was not paying off. `glow` (Homebrew) takes over as the default reader. It brings mature `glamour` rendering, stdin/URL/remote-repo input, and a recursive file-browser TUI.

The catch: `glow` has no file-watch mode. Auto-reload-on-save with preserved scroll position was the one `markless` feature worth keeping, and no Homebrew-installable markdown tool offers it. `leaf` does. It takes the `mise` `github:` slot `markless` held. `leaf -w` reloads on save without losing scroll position, and `Ctrl+E` opens an external editor then reloads on return. Like `markless`, it installs as a global `mise` shim.

Verified locally. `glow` installs from Homebrew (`2.1.2`). `leaf` installs from the `mise` `github:` backend (`1.24.2`), runs, and exposes `--watch`, with its shim landing on `PATH` exactly as the old `markless` shim did.
