### PR TITLE
worktrunk: bind lazy dynamic completer for branch names

### DIFF
--- a/worktrunk/completion.zsh
+++ b/worktrunk/completion.zsh
@@ -1,5 +1,13 @@
 #!/usr/bin/env zsh
 
-if command -v wt > /dev/null; then
-  eval "$(wt config shell completions zsh)"
+# init.zsh (sourced before compinit) defines _wt_lazy_complete but cannot bind it,
+# since compdef does not exist until compinit runs. Bind it here, after compinit.
+# The lazy completer delegates to clap's dynamic completer (COMPLETE=zsh wt), which
+# yields branch and worktree names. Do not eval `wt config shell completions zsh`:
+# on the installed binary that emits a static completer (subcommands and flags only).
+if (( $+functions[_wt_lazy_complete] )); then
+  compdef _wt_lazy_complete wt
+  # Single-column display keeps each branch's recency description on its own line.
+  zstyle ':completion:*:wt:*' list-max 1
+  zstyle ':completion:*:*:wt:*' list-grouped false
 fi


### PR DESCRIPTION
Makes `wt switch <TAB>` complete branch and worktree names. It only offered subcommands and flags before.

Three places tried to bind `wt`'s completer and the dynamic one never won:

- Homebrew autoloads a static `_wt` from `fpath` at `compinit` (subcommands and flags only).
- `completion.zsh` eval'd `wt config shell completions zsh`, which on the installed 0.58.0 binary is that same static completer, and its trailing `compdef _wt wt` re-bound it. Redundant with the Homebrew autoload.
- `init.zsh` defines `_wt_lazy_complete`, which delegates to clap's dynamic `COMPLETE=zsh wt` completer (already dynamic on 0.58.0). But `init.zsh` is sourced before `compinit`, so its `compdef` is guarded behind `(( $+functions[compdef] ))` and silently skipped.

So `wt` stayed bound to the static completer.

`completion.zsh` now binds `_wt_lazy_complete` itself, guarded by `(( $+functions[_wt_lazy_complete] ))`, with the display zstyles from the init template. Because `completion.zsh` runs after `compinit` (in the deferred precmd hook), this binding wins over Homebrew's static one, and it drops the redundant static eval. `init.zsh` is unchanged: its `wt()` wrapper and `_wt_lazy_complete` definition are still needed, and its pre-`compinit` `compdef` is a harmless no-op.

This stays correct after a future brew upgrade makes the static command dynamic, since we no longer eval it. The binding rides on `COMPLETE=zsh wt`, which is the dynamic runtime path in both current and future binaries. (Worktrunk is also making `wt config shell completions zsh` dynamic upstream in a separate change.)

## Testing

Launched a real interactive zsh loading this worktree's config (`ZDOTDIR` + `DOTFILES_USE_DEV`). `wt switch <TAB>` listed branch and worktree names with recency markers on the first TAB. `${_comps[wt]}` then read `_clap_dynamic_completer_wt`, confirming the chain: `_wt_lazy_complete` bootstrapped on first TAB, eval'd `COMPLETE=zsh wt`, and handed off to clap's dynamic completer.
