### PR TITLE
terminal: drop moshi-hook

### DIFF
--- a/terminal/Brewfile
+++ b/terminal/Brewfile
@@ -1,9 +1,6 @@
-tap 'rjyo/moshi'
-
 cask 'iterm2'
 cask 'font-monaspice-nerd-font'
 brew 'glow'
-brew 'rjyo/moshi/moshi-hook', restart_service: :changed
 brew 'shellspec'
 brew 'yazi'
 brew 'zoxide'


### PR DESCRIPTION
Removes the `rjyo/moshi` tap and the `moshi-hook` brew formula from the Brewfile. moshi is no longer used.