### PR TITLE
worktree: add `wt all` fan-out and `wt prune` sweep

### DIFF
--- a/bin/wt-all
+++ b/bin/wt-all
@@ -1,0 +1,127 @@
+#!/usr/bin/env zsh
+# wt all <cmd>: run a wt command in every repo under the discovery roots.
+#
+# Worktrunk has no machine-wide registry, so we walk a known root and find each
+# repo's main worktree (the parent of a .git directory). Linked worktrees use a
+# .git file, so they're excluded. Pruning the main worktree covers all of a
+# repo's linked worktrees.
+#
+# Roots come from $WT_ALL_ROOT (colon-separated, PATH-style), falling back to
+# $PROJECTS, then ~/src. Repos run concurrently (WT_ALL_JOBS, default 8) since
+# the per-repo forge calls are network-bound.
+#
+# Repos whose command produces no output are skipped in the report, so
+# `wt all prune` shows only repos with something to remove, one line each, then
+# a totals trailer. A wrapped command can opt into a terse summary via $WT_ALL.
+
+set -uo pipefail
+
+# $0 is the function name inside main, so capture the script path up here.
+self="${0:A}"
+
+# Make sibling wt-* subcommands (e.g. wt-prune) resolvable by `wt` even when
+# this script is run by path, before install has put bin/ on PATH.
+export PATH="${self:h}:$PATH"
+
+# Internal per-repo worker, invoked in parallel by xargs.
+if [[ "${1:-}" == --worker ]]; then
+  cmd=("${(@f)$(<"$WT_ALL_DIR/.cmd")}")
+  out=$(wt -C "$2" "${cmd[@]}" 2>/dev/null)
+  rc=$?
+  # Percent-encode '/' so distinct repo paths map to distinct temp files; a
+  # plain '/'->'_' swap collides a nested path with an underscore in a name.
+  key="${2//\%/%25}"; key="${key//\//%2F}"
+  print -r -- "$out" > "$WT_ALL_DIR/$key"
+  (( rc )) && : > "$WT_ALL_DIR/$key.failed"
+  print   # one tick per completion drives the progress counter
+  exit 0
+fi
+
+main () {
+  local roots="${WT_ALL_ROOT:-${PROJECTS:-$HOME/src}}"
+
+  local -a repos
+  local root gitdir
+  for root in ${(s.:.)roots}; do
+    [[ -d "$root" ]] || continue
+    while IFS= read -r gitdir; do
+      repos+=("${gitdir%/.git}")
+    done < <(find "$root" -maxdepth 4 \
+      \( -type d \( -name node_modules -o -name vendor \) -prune \) -o \
+      \( -type d -name .git -prune -print \))
+  done
+
+  local -a wtcmd=("$@")
+  typeset -g dir
+  dir=$(mktemp -d "${TMPDIR:-/tmp}/wt-all.XXXXXX")
+  trap 'rm -rf "${dir:-}"' EXIT
+  print -rl -- "${wtcmd[@]}" > "$dir/.cmd"
+
+  export WT_ALL=1 WT_ALL_DIR="$dir"
+  integer jobs=${WT_ALL_JOBS:-8}
+  integer total=${#repos}
+
+  # Workers run under xargs and each emits one tick on completion. On a TTY we
+  # redraw a single "spinner N/total" line as ticks arrive; otherwise (the
+  # nightly job) we run silently and let the summary speak.
+  if [[ -t 2 ]]; then
+    integer scanned=0
+    local -a frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+    printf '%s\0' "${repos[@]}" \
+      | xargs -0 -P "$jobs" -n1 "$self" --worker \
+      | while IFS= read -r _; do
+          (( scanned++ ))
+          printf '\r\033[K%s  %d/%d  wt %s' \
+            "${frames[scanned % ${#frames} + 1]}" "$scanned" "$total" "${wtcmd[*]}" >&2
+        done
+    printf '\r\033[K' >&2
+  else
+    printf '%s\0' "${repos[@]}" | xargs -0 -P "$jobs" -n1 "$self" --worker >/dev/null
+  fi
+
+  local base="${PROJECTS:-$HOME/src}/"
+  integer active=0 worktrees=0 branches=0
+  local -a rows failed
+  local repo key disp out
+  for repo in "${repos[@]}"; do
+    key="${repo//\%/%25}"; key="${key//\//%2F}"
+    disp="${repo#$base}"
+    [[ -e "$dir/$key.failed" ]] && { failed+=("$disp"); continue; }
+    out="$(<"$dir/$key")"
+    [[ -z "$out" ]] && continue
+    (( active++ ))
+    # Each repo's output becomes a row keyed by repo. A wrapped command can emit
+    # tab-separated fields to land in their own columns; `wt prune` emits
+    # "<worktrees>\t<branches>", which we also total below.
+    rows+=("$disp"$'\t'"$out")
+    if [[ "$out" == <->$'\t'<-> ]]; then
+      (( worktrees += ${out%%$'\t'*} ))
+      (( branches  += ${out##*$'\t'} ))
+    fi
+  done
+
+  if (( ${#rows} )); then
+    if [[ "${wtcmd[1]}" == prune ]]; then
+      # Prune emits "<worktrees>\t<branches>"; head it and sort by worktree
+      # count (then branches) so the biggest cleanups sort to the top.
+      {
+        print -r -- "REPO"$'\t'"WORKTREES"$'\t'"BRANCHES"
+        print -rl -- "${rows[@]}" | sort -t $'\t' -k2,2nr -k3,3nr
+      } | column -t -s $'\t'
+    else
+      print -rl -- "${rows[@]}" | column -t -s $'\t'
+    fi
+  fi
+
+  local -a summary=("${#repos} scanned" "$active with output")
+  (( ${#failed} )) && summary+=("${#failed} failed")
+  (( worktrees || branches )) && summary+=("$worktrees worktrees, $branches branches")
+
+  print
+  gum log --level info "${(j: · :)summary}"
+  (( ${#failed} )) && gum log --level warn "failed: ${(j:, :)failed}"
+
+  (( ${#failed} == 0 ))
+}
+
+main "$@"

--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -1,0 +1,180 @@
+#!/usr/bin/env zsh
+# wt prune [args]: per-repo worktree prune, summarized to one line.
+#
+# Integration pass: `wt step prune` removes worktrees integrated into the
+# default branch (including squash merges, via patch-id). Forge pass: removes
+# worktrees whose branch was merged on the remote (gh/glab), catching PRs merged
+# remotely even when the local default branch is stale.
+#
+# Age pass (--before [DURATION], default 1mo): removes old, clean worktree
+# directories that aren't integrated anywhere, to clear out stale checkouts. It
+# keeps the branch (so committed work is recoverable) and skips worktrees with
+# uncommitted changes, relying on `wt remove`'s own guards.
+#
+# Prints one summary line ("N worktrees, M branches") or nothing when there's
+# nothing to remove. Honors --dry-run: counts what would be removed without
+# removing. For per-branch detail, run `wt step prune --dry-run` directly.
+
+set -uo pipefail
+
+# Convert a duration like 2w / 30d / 1mo into seconds. Returns nonzero on a
+# spec it doesn't understand so callers can fall back to a default.
+parse_duration () {
+  [[ "$1" =~ '^([0-9]+)(h|d|w|mo|y)$' ]] || return 1
+  integer n=$match[1]
+  case "$match[2]" in
+    h)  print -r -- $(( n * 3600 ));;
+    d)  print -r -- $(( n * 86400 ));;
+    w)  print -r -- $(( n * 604800 ));;
+    mo) print -r -- $(( n * 2592000 ));;
+    y)  print -r -- $(( n * 31536000 ));;
+  esac
+}
+
+main () {
+  # wt subcommands occasionally flush stray bookkeeping to stdout mid-run, which
+  # would corrupt our single summary line (and the `wt all` table). Detach the
+  # body's stdout to stderr and emit the summary on a saved descriptor; $(...)
+  # captures read a command's stdout directly, so they're unaffected.
+  local stdout_fd
+  exec {stdout_fd}>&1
+  exec 1>&2
+
+  local dry_run=0 before_enabled=0
+  integer before_secs=0
+  local -a passthrough
+  integer i=1
+  while (( i <= $# )); do
+    local a="${argv[i]}"
+    case "$a" in
+      --dry-run)
+        dry_run=1
+        passthrough+=("$a")
+        ;;
+      --before)
+        before_enabled=1
+        local nxt="${argv[i+1]:-}"
+        if [[ -n "$nxt" && "$nxt" != -* ]] && before_secs=$(parse_duration "$nxt"); then
+          (( i++ ))
+        else
+          before_secs=$(parse_duration 1mo)
+        fi
+        ;;
+      --before=*)
+        before_enabled=1
+        before_secs=$(parse_duration "${a#*=}") || before_secs=$(parse_duration 1mo)
+        ;;
+      *)
+        passthrough+=("$a")
+        ;;
+    esac
+    (( i++ ))
+  done
+
+  # Count from a dry-run probe. A dry-run always lists the candidates, whether
+  # or not this is a real run. Real-mode JSON reports only what it actually
+  # removed, which is empty when removal is approval-gated or raced by
+  # background cleanup, so counting from it under-counts.
+  local -a probe_args=("${passthrough[@]:#--dry-run}")
+  local probe_json
+  probe_json=$(wt step prune "${probe_args[@]}" --dry-run --format=json 2>/dev/null)
+
+  local -A seen
+  local worktrees=0 branches=0
+  if [[ -n "$probe_json" && "$probe_json" != "[]" ]]; then
+    local kind branch
+    while IFS=$'\t' read -r kind branch; do
+      seen[$branch]=1
+      if [[ "$kind" == worktree ]]; then ((worktrees++)); else ((branches++)); fi
+    done < <(jq -r '.[] | "\(.kind)\t\(.branch)"' <<<"$probe_json")
+  fi
+
+  # Real run: actually remove. --yes skips approval prompts and --foreground
+  # blocks until removal completes, both required under the non-interactive
+  # parallel fan-out and the nightly job.
+  (( dry_run )) || wt step prune "${probe_args[@]}" --yes --foreground </dev/null >/dev/null 2>&1
+
+  # Linked-worktree pass over a single `wt list`: forge-merged removals, plus
+  # the age pass when --before is set.
+  local list_json
+  list_json=$(wt list --format=json 2>/dev/null)
+
+  # Only consult the forge (a network round-trip) when a linked worktree
+  # survives the integration pass. Most repos in a fan-out have only their main
+  # worktree, so this skips a `gh`/`glab` call per such repo across the sweep.
+  local has_linked=false
+  [[ -n "$list_json" && "$list_json" != "[]" ]] \
+    && has_linked=$(jq -r 'any(.[]; .kind == "worktree" and (.is_main | not))' <<<"$list_json")
+
+  if [[ "$has_linked" == true ]]; then
+    local remote_host
+    remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
+
+    local -a merged_branches
+    if [[ "$remote_host" == *gitlab* ]]; then
+      merged_branches=("${(@f)$(glab mr list --state merged --output json 2>/dev/null | jq -r '.[].source_branch')}")
+    else
+      merged_branches=("${(@f)$(gh pr list --state merged --json headRefName --jq '.[].headRefName' 2>/dev/null)}")
+    fi
+
+    integer now=0
+    (( before_enabled )) && now=$(date +%s)
+    local branch is_main ts clean
+    while IFS=$'\t' read -r branch is_main ts clean; do
+      [[ "$is_main" == true ]] && continue
+      [[ -n "${seen[$branch]:-}" ]] && continue
+
+      # Removals read stdin from /dev/null: the loop's stdin is the jq pipe, and
+      # a `wt remove` that pauses on a prompt would otherwise consume it. We
+      # count only confirmed removals so the summary matches what was removed (a
+      # dry-run counts everything it lists, since it removes nothing).
+
+      # Merged on the remote: safe to drop the worktree and the branch.
+      if (( ${merged_branches[(Ie)$branch]} )); then
+        if (( dry_run )) || wt remove --foreground --force --force-delete "$branch" </dev/null >/dev/null 2>&1; then
+          (( worktrees++ )); seen[$branch]=1
+        fi
+        continue
+      fi
+
+      # Age pass: old and clean. Drop the worktree directory but keep the branch
+      # (plain `wt remove` deletes a branch only when merged), so committed work
+      # survives and a dirty worktree makes `wt remove` fail and get skipped.
+      if (( before_enabled )) && [[ "$clean" == clean ]] && (( now - ts >= before_secs )); then
+        if (( dry_run )) || wt remove --foreground "$branch" </dev/null >/dev/null 2>&1; then
+          (( worktrees++ )); seen[$branch]=1
+        fi
+      fi
+    done < <(jq -r '
+      .[]
+      | select(.kind == "worktree" and (.branch // "") != "")
+      | [ .branch,
+          (.is_main | tostring),
+          (.commit.timestamp | tostring),
+          (if (.working_tree.staged or .working_tree.modified or .working_tree.untracked or .working_tree.renamed or .working_tree.deleted) then "dirty" else "clean" end)
+        ] | @tsv' <<<"$list_json")
+  fi
+
+  (( worktrees == 0 && branches == 0 )) && return
+
+  # Under `wt all`, emit tab-separated counts so the caller can build a table.
+  # Standalone, print a friendly one-line summary.
+  if [[ -n "${WT_ALL:-}" ]]; then
+    print -r -- "$worktrees"$'\t'"$branches" >&$stdout_fd
+    return
+  fi
+
+  local -a parts
+  (( worktrees )) && parts+=("$(plural $worktrees worktree)")
+  (( branches )) && parts+=("$(plural $branches branch)")
+  print -r -- "${(j:, :)parts}" >&$stdout_fd
+}
+
+plural () {
+  local n=$1 noun=$2
+  (( n == 1 )) && print -r -- "$n $noun" && return
+  [[ "$noun" == branch ]] && noun=branches || noun="${noun}s"
+  print -r -- "$n $noun"
+}
+
+main "$@"

--- a/macos/com.user.worktree-prune.plist
+++ b/macos/com.user.worktree-prune.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.worktree-prune</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-l</string>
+        <string>-c</string>
+        <string>wt all prune --before</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/worktree-prune.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/worktree-prune.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -46,6 +46,10 @@ setup_dotfiles_upgrade() {
   install_launch_agent com.user.dotfiles-upgrade.plist "nightly dotfiles upgrade"
 }
 
+setup_worktree_prune() {
+  install_launch_agent com.user.worktree-prune.plist "nightly worktree prune"
+}
+
 setup_claude_upgrade() {
   # Remove old plist that pointed to ~/.claude-repo/bin/claude-upgrade
   local old_plist="$HOME/Library/LaunchAgents/com.user.claude-upgrade.plist"
@@ -63,4 +67,5 @@ install_launch_agent com.user.theme-sync.plist "theme-sync watcher"
 if [[ ! -L "$HOME/.dotfiles" ]]; then
   setup_dotfiles_upgrade
   setup_claude_upgrade
+  setup_worktree_prune
 fi

--- a/worktrunk/aliases.zsh
+++ b/worktrunk/aliases.zsh
@@ -1,29 +1,4 @@
 #!/usr/bin/env zsh
 
 alias wts='wt switch'
-
-wtp () {
-  wt step prune "$@"
-
-  local branches
-  branches=$(wt list --format=json | jq -r '.[] | select(.is_main | not) | .branch')
-  [[ -z "$branches" ]] && return
-
-  local remote_host
-  remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
-
-  local -a merged_branches
-  if [[ "$remote_host" == *gitlab* ]]; then
-    merged_branches=("${(@f)$(glab mr list --state merged --output json 2>/dev/null | jq -r '.[].source_branch')}")
-  else
-    merged_branches=("${(@f)$(gh pr list --state merged --json headRefName --jq '.[].headRefName' 2>/dev/null)}")
-  fi
-
-  local branch
-  for branch in ${(f)branches}; do
-    if (( ${merged_branches[(Ie)$branch]} )); then
-      echo "Removing $branch (PR merged)"
-      wt remove --force --force-delete "$branch"
-    fi
-  done
-}
+alias wtp='wt prune'


### PR DESCRIPTION
Adds two Worktrunk custom subcommands so worktrees can be pruned across every repo on the machine, not one at a time.

I run many worktrees across ~90 repos and had no way to sweep them. Worktrunk has no machine-wide registry and works one repo at a time, but a `wt-<name>` executable on `PATH` becomes `wt <name>`, and `-C` is forwarded as the working directory. That's enough to build a fan-out.

## What's Here

- `bin/wt-all` runs any `wt` command in every repo under the discovery root (`$WT_ALL_ROOT`, falling back to `$PROJECTS`, then `~/src`), in parallel. It walks for main worktrees (parent of a `.git` directory), shows a live progress counter on a TTY, and renders a per-repo results table.
- `bin/wt-prune` (`wt prune`) prunes one repo in three passes: worktrees integrated into the default branch (`wt step prune`, covers squash merges via patch-id), branches merged on the forge (`gh`/`glab`, catches PRs merged remotely when the local default branch is stale), and an opt-in age pass.
- The `wtp` function collapses to `alias wtp='wt prune'`, so the shortcut and the sweep share one implementation.
- A nightly launchd job (4am) runs `wt all prune --before`.

## The Age Pass

`--before [DURATION]` (default `1mo`; `--before 2w` / `--before=30d` to override) removes worktree directories whose last commit is older than the threshold but that aren't integrated anywhere. It leans on `wt remove`'s own guards: the branch is kept (plain `wt remove` deletes a branch only when merged), so committed work survives as a ref, and a dirty worktree makes `wt remove` fail and gets skipped. Detached worktrees are excluded since there's no branch to preserve. It's opt-in because removing a stale-but-unmerged checkout is a different risk profile than removing something already integrated.

## Verification

Dry-run swept all repos and previewed candidates without removing anything. A real `wt prune --before` on `route-agent` removed an old, clean linked worktree and left both branch refs at their original SHAs, including a branch with local-only commits and one ahead of its upstream.

Validation surfaced three bugs, now fixed:

- A `wt` subprocess flushed a stray line to stdout mid-run, corrupting the summary and the table. The body's stdout is now detached and only the summary is emitted on a saved descriptor.
- A detached worktree's empty branch produced a leading tab that `read` trimmed, shifting every parsed column left. Empty branches are now filtered in `jq`.
- Inside `while read … done < <(jq …)`, the in-loop `wt remove` inherited the `jq` pipe as stdin, stalled on a prompt, and removed nothing while the count incremented anyway. Removals now read from `/dev/null` and the count reflects confirmed removals only.

A review pass fixed two more: temp-file keys in `wt-all` could collide between distinct repo paths (now percent-encoded), and the forge query ran for repos with no linked worktrees (now gated on a surviving linked worktree, which matters across a full sweep).
