### PR TITLE
worktrunk: eval dynamic completions registration

### DIFF
--- a/worktrunk/completion.zsh
+++ b/worktrunk/completion.zsh
@@ -1,13 +1,5 @@
 #!/usr/bin/env zsh
 
-# init.zsh (sourced before compinit) defines _wt_lazy_complete but cannot bind it,
-# since compdef does not exist until compinit runs. Bind it here, after compinit.
-# The lazy completer delegates to clap's dynamic completer (COMPLETE=zsh wt), which
-# yields branch and worktree names. Do not eval `wt config shell completions zsh`:
-# on the installed binary that emits a static completer (subcommands and flags only).
-if (( $+functions[_wt_lazy_complete] )); then
-  compdef _wt_lazy_complete wt
-  # Single-column display keeps each branch's recency description on its own line.
-  zstyle ':completion:*:wt:*' list-max 1
-  zstyle ':completion:*:*:wt:*' list-grouped false
+if command -v wt > /dev/null; then
+  eval "$(wt config shell completions zsh)"
 fi


### PR DESCRIPTION
Reverts the workaround from #493. `completion.zsh` goes back to the documented `eval "$(wt config shell completions zsh)"`.

#493 existed because, on an installed binary, `wt config shell completions zsh` emitted a static completer (subcommands and flags only), so `wt switch <TAB>` never offered branch or worktree names. The workaround instead bound `init.zsh`'s `_wt_lazy_complete` by hand after compinit.

worktrunk 0.60.0 ships the upstream fix (worktrunk/worktrunk#3105): `wt config shell completions zsh` now emits a dynamic registration (the maintained `clap_complete::env` path) that calls the binary at completion time, completing branch and worktree names and carrying the recency-ordering zstyles. So the one-liner is sufficient again. It runs in the deferred completion hook, after compinit, so its `compdef` binding takes effect.

Verified on 0.60.0: sourcing `completion.zsh` under compinit binds `_clap_dynamic_completer_wt` for `wt`, and the completer emits the repo's branch and worktree names with recency descriptions.
