### PR TITLE
claude: inject worktree system prompt into launch aliases

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -4,7 +4,7 @@ Shell integration for [Claude Code](https://docs.anthropic.com/en/docs/claude-co
 
 ## Worktree Aliases
 
-Launch Claude in a [Worktrunk](https://worktrunk.dev) worktree. All variants pass `--name` to Claude, set from the branch name.
+Launch Claude in a [Worktrunk](https://worktrunk.dev) worktree. All variants pass `--name` to Claude, set from the branch name, and append a system prompt telling Claude it is in a dedicated worktree it can work in directly.
 
 | Command | Branch | Permission mode |
 |---------|--------|-----------------|

--- a/claude/aliases.zsh
+++ b/claude/aliases.zsh
@@ -1,10 +1,15 @@
 #!/usr/bin/env zsh
 
-alias cw='wt switch --execute="claude --name={{ branch }}"'
+# Injected into Claude sessions launched in a Worktrunk worktree so the agent
+# knows it has a dedicated branch to work on. Avoid apostrophes: the value is
+# single-quoted inside the --execute string that wt tokenizes.
+_claude_worktree_prompt='This is a dedicated git worktree that Worktrunk (the wt CLI) created for you. Do your work here directly: make changes, commit, and open a PR from this branch.'
+
+# Aliases (not functions) so zsh defers completion to `wt switch` for branch names.
+alias cw="wt switch --execute=\"claude --name={{ branch }} --append-system-prompt='$_claude_worktree_prompt'\""
 alias ccw='cw --create'
+alias cwa="wt switch --execute=\"claude --name={{ branch }} --permission-mode=auto --append-system-prompt='$_claude_worktree_prompt'\""
 
 cwp() {
-  wt switch --create --execute="claude --name={{ branch }} --permission-mode=plan" "$@" -- "$(pbpaste)"
+  wt switch --create --execute="claude --name={{ branch }} --permission-mode=plan --append-system-prompt='$_claude_worktree_prompt'" "$@" -- "$(pbpaste)"
 }
-
-alias cwa='wt switch --execute="claude --name={{ branch }} --permission-mode=auto"'


### PR DESCRIPTION
Launching Claude in a worktree via `cw`/`ccw`/`cwp`/`cwa` dropped the agent into a fresh worktree with no signal that Worktrunk had spun it up for that task. Each launcher now appends a system prompt so Claude knows it has a dedicated branch and can edit, commit, and open a PR there directly.

`_claude_worktree_prompt` holds the prompt once, and every launcher threads it into its `--execute` string.

`cw`, `ccw`, and `cwa` stay aliases rather than becoming functions. zsh completes an alias by expanding it and deferring to the underlying command, so `cw <TAB>` keeps completing branch names from `wt switch`. Functions would lose that. `cwp` was already a function and stays one, since it creates a new branch and has no existing name to complete.

Two constraints on the prompt text, both noted in a comment: `wt` tokenizes the `--execute` string, and the prompt sits single-quoted inside it, so the text must avoid apostrophes (and `$`, backticks, `"`) to stop `wt`'s tokenizer from splitting it.

I checked that the alias bodies expand as intended, that the inner command tokenizes the prompt into a single `--append-system-prompt=<text>` argv token, and that `wt switch` accepts the resulting `--execute` value.
