### PR TITLE
tmux: resolve fzf-links issue vs PR from OSC 8 link targets

### DIFF
--- a/tmux/search/fzf-links/README.md
+++ b/tmux/search/fzf-links/README.md
@@ -9,12 +9,28 @@ schemes from `schemes.py`. Each module sits beside its `_test.py` sidecar.
 
 | Pattern | Opens |
 |---|---|
-| `#123` | issue/PR on the current repo's forge (GitHub redirects `/issues/N` to `/pull/N` for PRs) |
+| `#123` | issue/PR on the current repo's forge; labeled `[PR]` when the token is a hyperlinked pull request (see below) |
 | `!123` | GitLab merge request |
 | `owner/repo#123` | issue/PR in another repo |
 | `a1b2c3d` | commit page |
 | `ENG-1234` | Linear issue |
 | `localhost:3000` | dev-server URL |
+
+## OSC 8 hyperlink targets
+
+Tools like Claude Code, `gh`, and `delta` print refs as
+[OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda):
+the visible text is `#497` but the escape sequence carries the real target,
+`https://github.com/owner/repo/pull/497`. That URL already encodes the
+issue-vs-PR distinction, with no API call or per-repo cache.
+
+`osc8.py` re-captures the pane with `tmux capture-pane -e` (which preserves the
+escape sequences the plugin's own capture strips), parses it into a visible-text
+→ target-URL index, and the reference handlers prefer that target when a matched
+token was hyperlinked. So `#497` linked to `/pull/497` opens the PR directly and
+shows `[PR]`; an un-hyperlinked `#123` falls back to forge-guessing `/issues/N`
+(GitHub redirects that to `/pull/N` for PRs anyway). Commit and `owner/repo#N`
+matches likewise open their exact target when one is present.
 
 ## How the forge is resolved
 

--- a/tmux/search/fzf-links/osc8.py
+++ b/tmux/search/fzf-links/osc8.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import functools
+import re
+import subprocess
+
+# OSC 8 hyperlink: ESC ] 8 ; params ; URI ST  text  ESC ] 8 ; ; ST
+# ST (string terminator) is ESC \ or BEL. The URI runs to the terminator; the
+# visible text may carry its own SGR color codes, stripped out below.
+_ST = r"(?:\x1b\\|\x07)"
+_HYPERLINK = re.compile(
+    rf"\x1b\]8;[^;]*;(?P<uri>[^\x1b\x07]*){_ST}(?P<text>.*?)\x1b\]8;;{_ST}",
+    re.DOTALL,
+)
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+def parse_links(data: str) -> dict[str, str]:
+    """Map each hyperlink's visible text to its target URI.
+
+    Text that appears with conflicting URIs is dropped so a lookup never
+    resolves to the wrong target.
+    """
+    found: dict[str, str | None] = {}
+    for m in _HYPERLINK.finditer(data):
+        text = _ANSI.sub("", m.group("text")).strip()
+        uri = m.group("uri").strip()
+        if not text or not uri:
+            continue
+        if text in found and found[text] != uri:
+            found[text] = None
+        else:
+            found.setdefault(text, uri)
+    return {text: uri for text, uri in found.items() if uri}
+
+
+def url_kind(url: str) -> str:
+    """Classify a forge URL as 'pr', 'issue', 'commit', or 'other'."""
+    if "/pull/" in url or "/merge_requests/" in url:
+        return "pr"
+    if "/issues/" in url:
+        return "issue"
+    if "/commit/" in url:
+        return "commit"
+    return "other"
+
+
+@functools.lru_cache(maxsize=1)
+def _index() -> dict[str, str]:
+    try:
+        out = subprocess.run(
+            ("tmux", "capture-pane", "-p", "-e", "-J", "-S", "-5000"),
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+    except Exception:
+        return {}
+    return parse_links(out.stdout) if out.returncode == 0 else {}
+
+
+def target_for(text: str) -> str | None:
+    """Resolve a matched token to the URL it was hyperlinked to, if any."""
+    return _index().get(text)

--- a/tmux/search/fzf-links/osc8_test.py
+++ b/tmux/search/fzf-links/osc8_test.py
@@ -1,0 +1,55 @@
+import pytest
+
+from osc8 import parse_links, url_kind
+
+ESC = "\x1b"
+ST = f"{ESC}\\"
+
+
+def link(uri: str, text: str, params: str = "") -> str:
+    return f"{ESC}]8;{params};{uri}{ST}{text}{ESC}]8;;{ST}"
+
+
+def test_parse_extracts_text_to_uri():
+    pr = "https://github.com/bendrucker/dotfiles/pull/497"
+    data = f"shipped {link(pr, 'bendrucker/dotfiles#497', params='id=7jn05')} today"
+    assert parse_links(data) == {"bendrucker/dotfiles#497": pr}
+
+
+def test_parse_strips_sgr_codes_inside_text():
+    pr = "https://github.com/o/r/pull/497"
+    # Claude Code wraps the visible text in color codes and leaves a trailing
+    # reset before the closing OSC 8 sequence.
+    data = f"{ESC}[94m{link(pr, f'#497{ESC}[0m{ESC}[38;5;246m')}"
+    assert parse_links(data) == {"#497": pr}
+
+
+def test_parse_drops_ambiguous_text():
+    a = link("https://x/issues/1", "#1")
+    b = link("https://x/pull/1", "#1")
+    assert parse_links(a + b) == {}
+
+
+def test_parse_accepts_bel_terminator():
+    bel = "\x07"
+    uri = "https://example.com/issues/9"
+    data = f"{ESC}]8;;{uri}{bel}#9{ESC}]8;;{bel}"
+    assert parse_links(data) == {"#9": uri}
+
+
+def test_parse_ignores_plain_text():
+    assert parse_links("no links here #123") == {}
+
+
+@pytest.mark.parametrize(
+    ("url", "kind"),
+    [
+        ("https://github.com/o/r/pull/497", "pr"),
+        ("https://gitlab.com/g/p/-/merge_requests/7", "pr"),
+        ("https://github.com/o/r/issues/12", "issue"),
+        ("https://github.com/o/r/commit/c91b594", "commit"),
+        ("https://example.com/whatever", "other"),
+    ],
+)
+def test_url_kind(url: str, kind: str):
+    assert url_kind(url) == kind

--- a/tmux/search/fzf-links/references.py
+++ b/tmux/search/fzf-links/references.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 
 from format import AMBER, BLUE, GREEN, LOCAL, ORANGE, colorize
 from git_context import Forge
+from osc8 import url_kind
 from results import Candidate, Link
 
 ISSUE_RE = re.compile(r"(?<![\w/#!])#(?P<num>\d+)\b")
@@ -19,20 +20,34 @@ LOCALHOST_RE = re.compile(
 
 ForgeProvider = Callable[[], Forge | None]
 CommitChecker = Callable[[str], bool]
+LinkResolver = Callable[[str], str | None]
 
 
 class References:
-    def __init__(self, get_forge: ForgeProvider, commit_exists: CommitChecker) -> None:
+    def __init__(
+        self,
+        get_forge: ForgeProvider,
+        commit_exists: CommitChecker,
+        link_target: LinkResolver,
+    ) -> None:
         self._get_forge = get_forge
         self._commit_exists = commit_exists
+        self._link_target = link_target
 
     def issue_pre(self, m: re.Match[str]) -> Candidate | None:
+        url = self._link_target(m.group(0))
         forge = self._get_forge()
-        if not forge:
+        if not forge and not url:
             return None
-        return Candidate(colorize(f"{forge.path}#{m.group('num')}", BLUE), "issue")
+        label = f"{forge.path}#{m.group('num')}" if forge else f"#{m.group('num')}"
+        if url and url_kind(url) == "pr":
+            return Candidate(colorize(label, GREEN), "PR")
+        return Candidate(colorize(label, BLUE), "issue")
 
     def issue_post(self, m: re.Match[str]) -> Link:
+        url = self._link_target(m.group(0))
+        if url:
+            return Link(url)
         forge = self._get_forge()
         assert forge  # issue_pre kept this match, so the forge resolved
         return Link(forge.issue_url(m.group("num")))
@@ -44,6 +59,9 @@ class References:
         return Candidate(colorize(f"{forge.path}!{m.group('num')}", ORANGE), "MR")
 
     def merge_request_post(self, m: re.Match[str]) -> Link:
+        url = self._link_target(m.group(0))
+        if url:
+            return Link(url)
         forge = self._get_forge()
         assert forge
         return Link(forge.merge_request_url(m.group("num")))
@@ -53,20 +71,26 @@ class References:
         return Candidate(colorize(ref, GREEN), "repo#n")
 
     def cross_repo_post(self, m: re.Match[str]) -> Link:
+        url = self._link_target(m.group(0))
+        if url:
+            return Link(url)
         forge = self._get_forge()
         host = forge.host if forge and forge.kind == "gitlab" else "github.com"
         owner, repo, num = m.group("owner"), m.group("repo"), m.group("num")
         return Link(f"https://{host}/{owner}/{repo}/issues/{num}")
 
     def commit_pre(self, m: re.Match[str]) -> Candidate | None:
-        if not self._get_forge():
-            return None
         sha = m.group("sha")
-        if not self._commit_exists(sha):
+        if not self._link_target(m.group(0)) and not (
+            self._get_forge() and self._commit_exists(sha)
+        ):
             return None
         return Candidate(colorize(sha[:10], AMBER), "commit")
 
     def commit_post(self, m: re.Match[str]) -> Link:
+        url = self._link_target(m.group(0))
+        if url:
+            return Link(url)
         forge = self._get_forge()
         assert forge
         return Link(forge.commit_url(m.group("sha")))

--- a/tmux/search/fzf-links/references_test.py
+++ b/tmux/search/fzf-links/references_test.py
@@ -9,8 +9,16 @@ GITHUB = Forge(host="github.com", path="bendrucker/dotfiles", kind="github")
 GITLAB = Forge(host="gitlab.com", path="group/proj", kind="gitlab")
 
 
-def refs(forge: Forge | None = None, commit=lambda _: False) -> References:
-    return References(get_forge=lambda: forge, commit_exists=commit)
+def refs(
+    forge: Forge | None = None,
+    commit=lambda _: False,
+    links: dict[str, str] | None = None,
+) -> References:
+    return References(
+        get_forge=lambda: forge,
+        commit_exists=commit,
+        link_target=lambda text: (links or {}).get(text),
+    )
 
 
 def find(regex: re.Pattern[str], text: str) -> re.Match[str]:
@@ -43,6 +51,36 @@ def test_issue_kept_in_repo():
 def test_issue_dropped_outside_repo():
     m = find(references.ISSUE_RE, "see #454")
     assert refs(None).issue_pre(m) is None
+
+
+# --- issue/PR resolved from an OSC 8 hyperlink target ---
+
+
+def test_issue_labeled_pr_from_link_target():
+    pr = "https://github.com/bendrucker/dotfiles/pull/497"
+    m = find(references.ISSUE_RE, "shipped #497")
+    r = refs(GITHUB, links={"#497": pr})
+    candidate = r.issue_pre(m)
+    assert candidate is not None and candidate.tag == "PR"
+    assert r.issue_post(m) == Link(pr)
+
+
+def test_issue_uses_exact_link_target_when_an_issue():
+    url = "https://github.com/bendrucker/dotfiles/issues/12"
+    m = find(references.ISSUE_RE, "see #12")
+    r = refs(GITHUB, links={"#12": url})
+    candidate = r.issue_pre(m)
+    assert candidate is not None and candidate.tag == "issue"
+    assert r.issue_post(m) == Link(url)
+
+
+def test_issue_kept_when_hyperlinked_outside_repo():
+    pr = "https://github.com/some/repo/pull/3"
+    m = find(references.ISSUE_RE, "see #3")
+    r = refs(None, links={"#3": pr})
+    candidate = r.issue_pre(m)
+    assert candidate is not None and candidate.tag == "PR"
+    assert r.issue_post(m) == Link(pr)
 
 
 # --- gitlab merge request (!N) ---
@@ -81,6 +119,13 @@ def test_cross_repo_uses_gitlab_host_when_present():
     )
 
 
+def test_cross_repo_prefers_link_target():
+    pr = "https://github.com/alberti42/tmux-fzf-links/pull/12"
+    m = find(references.CROSS_REPO_RE, "fixed alberti42/tmux-fzf-links#12")
+    r = refs(None, links={"alberti42/tmux-fzf-links#12": pr})
+    assert r.cross_repo_post(m) == Link(pr)
+
+
 # --- commit SHA ---
 
 
@@ -96,6 +141,14 @@ def test_commit_validated_against_repo():
 def test_commit_dropped_outside_repo():
     m = find(references.COMMIT_RE, "c91b594c5fa")
     assert refs(None).commit_pre(m) is None
+
+
+def test_commit_kept_when_hyperlinked():
+    url = "https://github.com/some/repo/commit/c91b594c5fa"
+    m = find(references.COMMIT_RE, "c91b594c5fa")
+    r = refs(None, links={"c91b594c5fa": url})
+    assert r.commit_pre(m) is not None
+    assert r.commit_post(m) == Link(url)
 
 
 # --- localhost ---

--- a/tmux/search/fzf-links/schemes.py
+++ b/tmux/search/fzf-links/schemes.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 import git_context
 import options
+import osc8
 from linear import Linear, parse_teams
 from references import (
     COMMIT_RE,
@@ -38,7 +39,9 @@ def _post(handler: PostHandler) -> Callable[[re.Match[str]], dict[str, str]]:
 
 
 def build_schemes() -> list[SchemeEntry]:
-    refs = References(git_context.current_forge, git_context.commit_exists)
+    refs = References(
+        git_context.current_forge, git_context.commit_exists, osc8.target_for
+    )
     linear = Linear(
         options.get("@fzf-links-linear-workspace"),
         parse_teams(options.get("@fzf-links-linear-teams")),
@@ -59,7 +62,7 @@ def build_schemes() -> list[SchemeEntry]:
             "regex": [MERGE_REQUEST_RE],
         },
         {
-            "tags": ("issue",),
+            "tags": ("issue", "PR"),
             "opener": OpenerType.BROWSER,
             "pre_handler": _pre(refs.issue_pre),
             "post_handler": _post(refs.issue_post),


### PR DESCRIPTION
Resolves a `#123` ambiguity the fzf-links handlers couldn't: on GitHub the token might be an issue or a PR, so `issue_post` guessed `/issues/N` and leaned on GitHub's redirect. The answer is usually already on screen. Tools like Claude Code, `gh`, and `delta` print refs as OSC 8 hyperlinks whose target is the canonical URL, and `.../pull/497` already settles issue-vs-PR with no API call and no per-repo cache.

The catch was purely the capture flag. `capture-pane -p` strips the escape sequences; `capture-pane -p -e` keeps them. `osc8.py` re-captures the pane with `-e`, parses the sequences into a visible-text → target-URL index, and the reference handlers prefer that target when a matched token was hyperlinked. A `#497` linked to `/pull/497` opens the PR directly and shows `[PR]`. An un-hyperlinked `#123` falls back to the existing forge guess. Commit and `owner/repo#N` matches likewise open their exact target when one is present.

I went with this handler-side capture rather than forking the plugin: it stays self-contained in `user_schemes`, needs no upstream change, and the handlers already run in the process that can shell out to tmux. The lookup is injected into `References` the same way `commit_exists` is, so it unit-tests without a live tmux.

Two deliberate edges. Only the issue scheme carries the `PR` tag; `cross_repo` doesn't share it. The plugin dispatches the post-handler by the tag parsed back out of the fzf line, so two schemes sharing a tag would route to the wrong handler. As a result a hyperlinked `owner/repo#N` opens the exact PR URL but keeps its `[repo#n]` label. And a `#N` that's hyperlinked is now kept even outside a git repo, since the link target makes it meaningful on its own.

Verified the parser against a live pane: both `#497` and `bendrucker/dotfiles#497` resolved to `/pull/497` and classified as a PR. The `osc8_test.py` and `references_test.py` sidecars cover the parsing (BEL/ESC terminators, inner SGR stripping, ambiguous-text dropping), URL classification, and each handler's hyperlink-vs-fallback paths.

Native OSC 8 support belongs in the plugin itself, which would let this shim retire. That's being pursued upstream separately.
