### PR TITLE
fzf-links: require Python 3.14, drop annotation boilerplate

### DIFF
--- a/tmux/search/fzf-links/git_context.py
+++ b/tmux/search/fzf-links/git_context.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import functools
 import os
 from dataclasses import dataclass

--- a/tmux/search/fzf-links/linear.py
+++ b/tmux/search/fzf-links/linear.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import re
 
 from format import PURPLE, colorize

--- a/tmux/search/fzf-links/options.py
+++ b/tmux/search/fzf-links/options.py
@@ -2,7 +2,7 @@ import functools
 import subprocess
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def get(name: str) -> str:
     try:
         out = subprocess.run(

--- a/tmux/search/fzf-links/pyproject.toml
+++ b/tmux/search/fzf-links/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fzflinks"
 version = "0"
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 dependencies = [
     "giturlparse>=0.12.0",
     "pygit2>=1.18.2",

--- a/tmux/search/fzf-links/references.py
+++ b/tmux/search/fzf-links/references.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import re
 from collections.abc import Callable
 

--- a/tmux/search/fzf-links/results.py
+++ b/tmux/search/fzf-links/results.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 

--- a/tmux/search/fzf-links/schemes.py
+++ b/tmux/search/fzf-links/schemes.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import re
 from collections.abc import Callable


### PR DESCRIPTION
Modernizes the `fzflinks` tool against the Python version it already runs on. The toolchain pins 3.14.5 and CI runs `uv run --frozen pytest`, but the package still declared `requires-python = ">=3.10"` and carried idioms from that floor.

Python 3.14 makes deferred annotation evaluation the default ([PEP 649](https://peps.python.org/pep-0649/)), which subsumes `from __future__ import annotations`. The future import was load-bearing, not stylistic: `_repo() -> pygit2.Repository | None` references a `TYPE_CHECKING`-only import, which would raise `NameError` at definition time on 3.13 and earlier without it. On 3.14 the annotation is lazy regardless, so the import is now dead weight in all five files that had it.

Dropping it is behavior-identical here because nothing in the package reads annotations back. PEP 649 and PEP 563 diverge only when code touches `__annotations__` or `get_type_hints` (objects vs. strings, and eager resolution can `NameError` on `TYPE_CHECKING` names). There are no such call sites, so the dataclasses and runtime paths are unaffected.

Also swaps `functools.lru_cache(maxsize=None)` for `functools.cache` in `options.py`. The bounded caches in `git_context.py` are left alone, since `cache` only stands in for the unbounded form.

Raising the floor is free: `fzflinks` is private (`package = false`) with no external consumers, and 3.14 is already the only interpreter it runs against. The existing suite covers git context resolution, Linear reference parsing, and scheme reference matching, and runs green on 3.14.
