### PR TITLE
tmux: adopt native theme hooks and pane scrollbars

### DIFF
--- a/tmux/appearance/appearance.conf
+++ b/tmux/appearance/appearance.conf
@@ -29,9 +29,11 @@ set -g @catppuccin_window_number_color "#{?#{||:#{window_bell_flag},#{window_act
 set -g @catppuccin_window_text " #{E:@resp_winname}"
 set -g @catppuccin_window_current_text " #{E:@resp_winname}"
 
-# Sync catppuccin flavor with macOS appearance (fallback for watch-theme-change daemon).
-# theme-sync-tmux self-gates, so it's safe to call unconditionally on every focus event.
-set-hook -g client-focus-in 'run-shell -b "$ZSH/theme/bin/theme-sync-tmux"'
+# Sync catppuccin flavor when the terminal reports a theme switch (OSC 2031),
+# which fires only on an actual light/dark flip. Fallback to the
+# watch-theme-change (dark-notify) daemon. theme-sync-tmux self-gates either way.
+set-hook -g client-dark-theme  'run-shell -b "$ZSH/theme/bin/theme-sync-tmux"'
+set-hook -g client-light-theme 'run-shell -b "$ZSH/theme/bin/theme-sync-tmux"'
 
 # Status bar
 set -g status-position bottom
@@ -40,3 +42,10 @@ set -g status-right-length 100
 
 # Bolder selection highlight for choose-tree / copy mode
 set -g mode-style "bg=#{@thm_surface_2},bold"
+
+# Native scrollbar, copy-mode only (modal) so it never eats a column in normal
+# use. This matters on narrow clients. Themed to match the catppuccin palette,
+# and re-applied on theme switch because this file is re-sourced then.
+set -g pane-scrollbars modal
+set -g pane-scrollbars-position right
+set -g pane-scrollbars-style 'fg=#{@thm_overlay_0},bg=#{@thm_surface_0}'


### PR DESCRIPTION
Adopts two tmux 3.6+ built-ins in the appearance config, replacing a poll-based hook and adding a copy-mode scrollbar.

## Native theme hooks

The catppuccin flavor sync previously ran on `client-focus-in`, firing `theme-sync-tmux` on every focus change and relying on the script to self-gate. tmux 3.6 added `client-dark-theme` / `client-light-theme`, driven by the terminal's OSC 2031 report (Ghostty supports it), which fire only on an actual light/dark flip. Swapping to those hooks keeps the same `theme-sync-tmux` call but trades a focus poll for a precise event. The `dark-notify` launchd daemon and the post-TPM startup apply are untouched. This remains the in-tmux fallback path.

## Pane scrollbars

Adds `pane-scrollbars modal`, so the native scrollbar appears only in copy mode and never costs a column during normal use. That matters on narrow clients. It's themed to the catppuccin palette and re-applies on a theme switch because this file is re-sourced then. This complements `tmux-smooth-scroll` (smooth wheel scrolling), which is a separate feature.

## Notes

floax stays. The 3.7 `new-pane` floating panes are ephemeral and lack a persistent summon/dismiss, so they don't replace floax's toggle-able scratch session.

Both changes are 3.6 features, so they apply to the running 3.6b server immediately without a restart. Two 3.7-only follow-ups are deferred to the next server cycle: simplifying `tmux-keys` with `list-keys -F`, and a possible floating-pane binding.

## Testing

Reloaded the module live (clearing the old `client-focus-in` hook first) and confirmed registration: both theme hooks carry the `theme-sync-tmux` command, the old hook is unset, and `pane-scrollbars` reports `modal` / `right` with the themed style. Verified the `pane-scrollbars-style` sub-fields (`fg` = slider, `bg` = rest) against `man tmux`. The theme flip and copy-mode scrollbar render are left for manual exercise.
