### PR TITLE
tmux: export TMUX_TMPDIR in path.zsh for non-interactive shells

### DIFF
--- a/tmux/path.zsh
+++ b/tmux/path.zsh
@@ -1,5 +1,9 @@
 #!/usr/bin/env zsh
 
+# In path.zsh (sourced by zshenv) so non-interactive shells get it too.
+export TMUX_TMPDIR="$HOME/.tmux"
+[[ -d "$TMUX_TMPDIR" ]] || mkdir -p "$TMUX_TMPDIR"
+
 for d in $ZSH/tmux/*/bin(N); do
   export PATH="$d:$PATH"
 done

--- a/tmux/tmux.zsh
+++ b/tmux/tmux.zsh
@@ -1,8 +1,5 @@
 #!/usr/bin/env zsh
 
-export TMUX_TMPDIR="$HOME/.tmux"
-mkdir -p "$TMUX_TMPDIR"
-
 [[ -n "$TMUX" ]] || return 0
 
 twd() {


### PR DESCRIPTION
Setting `TMUX_TMPDIR` only in `tmux.zsh` left it confined to interactive shells, since `zshrc` is the only thing that sources that file. Non-interactive shells (an `ssh host tmux ...` command, RootShell's auto-start) never saw it and fell back to the stock `/tmp/tmux-<uid>/default` socket. That put those clients on a separate tmux server with none of the real sessions, so RootShell's session discovery turned up empty and its auto-start "Main" was isolated.

Moves the export to `path.zsh`, which `zshenv` sources for every shell. Now interactive and non-interactive shells agree on `~/.tmux`, so SSH clients attach to the same server. Verified a bare `zsh` sourcing only `zshenv` resolves `TMUX_TMPDIR=~/.tmux`.
