### PR TITLE
brewfile: guard against duplicate package entries

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,14 +1,41 @@
+# Fail fast if a formula or cask is declared in more than one Brewfile. The topic
+# Brewfiles are eval'd through these same overrides (see the glob below), so this
+# spans every Brewfile. brew bundle installs in parallel, so duplicates race on
+# the Homebrew lock and abort bootstrap with a cryptic error.
+def assert_unique_package(type, name)
+  @declared_packages ||= {}
+  key = [type, name]
+  if @declared_packages[key]
+    raise "Duplicate #{type} '#{name}' declared in more than one Brewfile. " \
+          'Declare each package in exactly one topic Brewfile.'
+  end
+  @declared_packages[key] = true
+end
+
 # In CI, avoid installing Casks and Mac App Store apps which are slow and depended upon by dotfiles,
 # and skip service management since runners lack a user launchd/systemd session
 if ENV['CI']
-  def cask(*args) end
+  def cask(*args)
+    assert_unique_package('cask', args.first)
+  end
   def mas(*args) end
 
   def brew(name, options = {})
+    assert_unique_package('brew', name)
     super(name, options.except(:restart_service, :start_service))
   end
-elsif !$stdin.tty?
-  def mas(*args) end
+else
+  def brew(name, options = {})
+    assert_unique_package('brew', name)
+    super
+  end
+
+  def cask(name, *args)
+    assert_unique_package('cask', name)
+    super
+  end
+
+  def mas(*args) end unless $stdin.tty?
 end
 
 corporate = Dir.exist?('/Library/Managed Preferences') && !Dir.empty?('/Library/Managed Preferences')

--- a/zsh/Brewfile
+++ b/zsh/Brewfile
@@ -1,4 +1,3 @@
 brew 'highlight'
-brew 'hyperfine'
 brew 'pure'
 brew 'zsh'


### PR DESCRIPTION
Every macOS `bootstrap` job has been failing on `main` and all PRs, blocking unrelated work. `hyperfine` was declared in two topic Brewfiles, `system/Brewfile` and `zsh/Brewfile`. The root `Brewfile` globs and evals every topic Brewfile, so the aggregated bundle emitted `hyperfine` twice. Recent `brew bundle` installs formulae in parallel, so the two `brew install --formula hyperfine` jobs raced and collided on the Cellar lock:

```
A `brew install --formula hyperfine` process has already locked /opt/homebrew/Cellar/hyperfine.
```

It was the only duplicate across all Brewfiles, which is why only this package broke. The duplicate was latent and harmless under serial installs; parallel installs surfaced it.

Removes `hyperfine` from `zsh/Brewfile`, leaving `system/Brewfile` as the sole owner.

To stop this class of bug recurring, the root `Brewfile` now tracks declared packages in its `brew`/`cask` overrides and raises on a repeat. Topic Brewfiles are eval'd through those same overrides, so the guard spans every Brewfile and fires at bundle time, before any install, instead of letting the cryptic Cellar-lock error surface minutes into bootstrap. `brew` and `cask` names are tracked separately, so `brew 'x'` and `cask 'x'` don't collide.

I first wired this as a shell/grep CI lint, but parsing the Ruby Brewfiles with a regex is brittle and has to contort around the root file's own `def brew`/`def cask` overrides. Detecting inside those overrides is authoritative and needs no separate CI step.

The non-CI branch previously had no `brew`/`cask` override at all, so I added pass-through wrappers that `super` after the check. `mas` stays a no-op only when non-interactive, as before.

Verified: `ruby -c Brewfile` passes, the guard raises on a real duplicate and not on distinct entries, and a full scan of all Brewfiles shows no remaining duplicates.
