### PR TITLE
tmux: set terminal tab title to window name

### DIFF
--- a/tmux/core/core.conf
+++ b/tmux/core/core.conf
@@ -28,6 +28,10 @@ set -g focus-events on                     # apps detect pane/window focus chang
 # preserved. The pane_in_mode/pane_dead markers match the tmux default.
 set -g automatic-rename-format '#{?pane_in_mode,[tmux],#{b:pane_current_path}}#{?pane_dead,[dead],}'
 
+# Mirror the active window's name into the outer terminal's tab title.
+set -g set-titles on
+set -g set-titles-string '#S  #W'
+
 # Only break words on spaces and @ so double-click selects full URLs and ticket IDs
 setw -g word-separators ' @'
 


### PR DESCRIPTION
Enables `set-titles` so tmux mirrors the active window's name into the outer terminal's tab title via `set-titles-string '#S  #W'`. rootshell suggests `'#T'` (pane title), but this config drives identification off window names — already auto-renamed to the worktree/project directory through `automatic-rename` — so `#W` keeps the tab title consistent with how windows are labeled everywhere else.
