### PR TITLE
tmux: add Nerd Font glyph to terminal tab title

### DIFF
--- a/terminal/ghostty.config
+++ b/terminal/ghostty.config
@@ -1,5 +1,13 @@
 font-family = MonaspiceNe NFM
 
+# Render the title in the Nerd Font so tmux's title glyphs show instead of tofu.
+# macOS title chrome won't fall back to PUA glyphs; it needs a single patched face.
+window-title-font-family = MonaspiceNe NFM
+
+# Always use the tab-bar titlebar so a single tab gets the same wide, left-aligned
+# title slot as multiple tabs. The default centered titlebar truncates one tab's title.
+macos-titlebar-style = tabs
+
 theme = dark:Catppuccin Mocha,light:Catppuccin Latte
 
 # Match tmux copy-mode selection rendering (which inverts via mode-style) so

--- a/tmux/core/core.conf
+++ b/tmux/core/core.conf
@@ -29,8 +29,10 @@ set -g focus-events on                     # apps detect pane/window focus chang
 set -g automatic-rename-format '#{?pane_in_mode,[tmux],#{b:pane_current_path}}#{?pane_dead,[dead],}'
 
 # Mirror the active window's name into the outer terminal's tab title.
+# Prefixed with a Nerd Font glyph, then session/window. The title chrome renders the
+# glyph via Ghostty's window-title-font-family (set to the patched terminal font).
 set -g set-titles on
-set -g set-titles-string '#S  #W'
+set -g set-titles-string ' #S/#W'
 
 # Only break words on spaces and @ so double-click selects full URLs and ticket IDs
 setw -g word-separators ' @'


### PR DESCRIPTION
#508 set the Ghostty tab title to `#S  #W`, which renders as two bare words
(`automation  dotfiles`) with no cue for which is the session and which is the window.
This prefixes the title with a Nerd Font glyph and joins the names with a slash, so the
tab reads ` automation/dotfiles`.

macOS draws the tab/window title with the UI font, which does not fall back to Nerd Font
private-use glyphs, so the glyph rendered as tofu. Pointing `window-title-font-family` at
the patched terminal face (`MonaspiceNe NFM`) makes the title chrome render the glyph.

`macos-titlebar-style = tabs` is a side fix: with the default centered titlebar a single
tab truncated the title, while two-plus tabs looked fine. Forcing the tab-bar style gives
a single tab the same wide, left-aligned slot.

Settled along the way:

- Started with a glyph on both fields (session and window). The window glyph was overkill,
  so it's one session glyph with `session/window` after it.
- Wanted to tint the glyph with a Catppuccin color. Not possible: the title goes out as an
  OSC 2 string, which is plain text with no SGR, so the whole title is a single
  theme-driven color. Left monochrome.

Verified live by sourcing the module and reloading Ghostty: glyph renders (no tofu), and
the single-tab title no longer truncates.

Builds on #508.
