### PR TITLE
clone: add fuzzy picker for bare invocation

### DIFF
--- a/bin/clone-repo
+++ b/bin/clone-repo
@@ -3,14 +3,29 @@
 import { $ } from "bun";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { mkdir, rename } from "node:fs/promises";
+import { mkdir, rename, stat } from "node:fs/promises";
 
 const CACHE_DIR = join(process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache"), "clone-repo");
-const CACHE_FILE = join(CACHE_DIR, "owners.json");
-const TTL_MS = 24 * 60 * 60 * 1000;
+const OWNERS_CACHE = join(CACHE_DIR, "owners.json");
+const REPOS_CACHE = join(CACHE_DIR, "repos.json");
+const OWNERS_TTL_MS = 24 * 60 * 60 * 1000;
+const REPOS_TTL_MS = 6 * 60 * 60 * 1000;
 
 if (process.argv.includes("--refresh-owners")) {
-  await writeCache(await fetchOwners());
+  await writeCache(OWNERS_CACHE, await fetchOwners());
+  process.exit(0);
+}
+
+if (process.argv.includes("--refresh-repos")) {
+  const repos = await fetchRepos();
+  if (repos.length > 0) await writeCache(REPOS_CACHE, repos);
+  process.exit(0);
+}
+
+if (process.argv.includes("--list")) {
+  for (const name of await getRepos()) {
+    console.log(name);
+  }
   process.exit(0);
 }
 
@@ -44,6 +59,12 @@ if (completions) {
 
 org = await resolveOwner(org);
 const target = `${projects}/${org}/${repo}`;
+
+if (await exists(target)) {
+  console.log(target);
+  process.exit(0);
+}
+
 await $`mkdir -p ${projects}/${org}`;
 
 switch (host) {
@@ -75,25 +96,37 @@ async function listRepos(org: string, query?: string, host?: string): Promise<st
 
 async function resolveOwner(org: string): Promise<string> {
   if (org !== "@me") return org;
-  const cached = await readCache();
+  const cached = await readCache(OWNERS_CACHE);
   if (cached && cached.length > 0) return cached[0];
   return (await $`gh api user --jq .login`.text()).trim();
 }
 
 async function getOwners(): Promise<string[]> {
-  const cached = await readCache();
+  const cached = await readCache(OWNERS_CACHE);
   if (!cached) {
     const owners = await fetchOwners();
-    await writeCache(owners);
+    await writeCache(OWNERS_CACHE, owners);
     return ["@me", ...owners];
   }
-  const { mtimeMs } = await Bun.file(CACHE_FILE).stat();
-  if (Date.now() - mtimeMs > TTL_MS) spawnRefresh();
+  const { mtimeMs } = await Bun.file(OWNERS_CACHE).stat();
+  if (Date.now() - mtimeMs > OWNERS_TTL_MS) spawnRefresh("--refresh-owners");
   return ["@me", ...cached];
 }
 
-function spawnRefresh(): void {
-  const proc = Bun.spawn([process.execPath, import.meta.path, "--refresh-owners"], {
+async function getRepos(): Promise<string[]> {
+  const cached = await readCache(REPOS_CACHE);
+  if (cached && cached.length > 0) {
+    const { mtimeMs } = await Bun.file(REPOS_CACHE).stat();
+    if (Date.now() - mtimeMs > REPOS_TTL_MS) spawnRefresh("--refresh-repos");
+    return cached;
+  }
+  const repos = await fetchRepos();
+  if (repos.length > 0) await writeCache(REPOS_CACHE, repos);
+  return repos;
+}
+
+function spawnRefresh(flag: string): void {
+  const proc = Bun.spawn([process.execPath, import.meta.path, flag], {
     stdin: "ignore",
     stdout: "ignore",
     stderr: "ignore",
@@ -109,19 +142,53 @@ async function fetchOwners(): Promise<string[]> {
   return [login.trim(), ...lines(orgs)];
 }
 
+async function fetchRepos(): Promise<string[]> {
+  const cachedOwners = await readCache(OWNERS_CACHE);
+  const orgs = cachedOwners ? cachedOwners.slice(1) : [];
+  const tsv = ".[] | [.nameWithOwner, .pushedAt] | @tsv";
+  const sources = [
+    $`gh repo list --json nameWithOwner,pushedAt --limit 200 --jq ${tsv}`.text(),
+    $`gh api user/starred --paginate --jq '.[] | [.full_name, .pushed_at] | @tsv'`.text(),
+    ...orgs.map((owner) =>
+      $`gh repo list ${owner} --json nameWithOwner,pushedAt --limit 100 --jq ${tsv}`.text(),
+    ),
+  ];
+  const results = await Promise.all(sources.map((p) => p.catch(() => "")));
+  const pushedAt = new Map<string, string>();
+  for (const result of results) {
+    for (const line of lines(result)) {
+      const [name, ts] = line.split("\t");
+      const existing = pushedAt.get(name);
+      if (!existing || ts > existing) pushedAt.set(name, ts);
+    }
+  }
+  return [...pushedAt.entries()]
+    .sort(([, a], [, b]) => (a < b ? 1 : a > b ? -1 : 0))
+    .map(([name]) => name);
+}
+
 function lines(text: string): string[] {
   return text.trim().split("\n").filter(Boolean);
 }
 
-async function writeCache(owners: string[]): Promise<void> {
-  await mkdir(CACHE_DIR, { recursive: true });
-  const tmp = `${CACHE_FILE}.${process.pid}.tmp`;
-  await Bun.write(tmp, JSON.stringify(owners));
-  await rename(tmp, CACHE_FILE);
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
-async function readCache(): Promise<string[] | null> {
-  const file = Bun.file(CACHE_FILE);
+async function writeCache(path: string, data: string[]): Promise<void> {
+  await mkdir(CACHE_DIR, { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  await Bun.write(tmp, JSON.stringify(data));
+  await rename(tmp, path);
+}
+
+async function readCache(path: string): Promise<string[] | null> {
+  const file = Bun.file(path);
   if (!(await file.exists())) return null;
   try {
     return JSON.parse(await file.text());

--- a/functions/clone
+++ b/functions/clone
@@ -1,3 +1,12 @@
 #!/usr/bin/env zsh
 
+if [[ -z "$1" ]]; then
+  local out
+  out=$(clone-repo --list | fzf --prompt='clone> ' --print-query \
+        --preview 'gh repo view {1} 2>/dev/null') || return
+  local sel=${out##*$'\n'}
+  [[ -n "$sel" ]] || return
+  set -- "$sel"
+fi
+
 cd "$(clone-repo "$1")"


### PR DESCRIPTION
Adds an interactive fuzzy picker to `clone`. Running bare `clone` (no args) opens fzf over your starred, own, and org repos, sorted most-recently-active first, and clones whatever you pick.

## Why Not Replace `clone` With an Upstream Tool

`clone` has grown enough to ask whether something off-the-shelf could take its place. After reviewing the landscape (`ghq`, `gh-repo-man`, `gh-stars`, `ghorg`, `grm`, and others), the answer is no, and the picker is the reason it doesn't matter:

- **`ghq` (the gold standard) lacks remote tab-completion.** It completes only repos you've *already* cloned. `clone` completes *remote, not-yet-cloned* repos via `gh search repos`. No mainstream tool offers that. Switching would be a regression here.
- **No upstream clone tool does fuzzy/starred discovery natively.** You'd wire `gh api user/starred | fzf | <backend> get` regardless. The fuzzy layer is the same amount of glue whether the backend is `ghq` or `clone`, so "delegate upstream" doesn't hand you this feature for free.
- A full `ghq` switch would also change the on-disk layout (`~/src/owner/repo` → `~/ghq/github.com/owner/repo`), break `c`/`_c` navigation, and require migrating every existing checkout. The only features gained in exchange (multi-VCS, worktrees, partial clone) go unused.

So: keep `clone`, add the picker on top.

## How It Works

`bin/clone-repo` gains `--list` and `--refresh-repos` modes backed by a new `repos.json` cache alongside the existing `owners.json`, reusing the same stale-while-revalidate pattern (serve stale immediately, refresh in a detached process). Candidates merge `gh repo list` (own), `gh repo list <org>` per cached org, and `gh api user/starred`, deduped by `owner/repo` and sorted by `pushedAt` descending. Clone is now idempotent: if the target already exists, it prints the path and exits, so picking an already-cloned repo behaves like `c` instead of erroring on a non-empty dir.

`functions/clone` gains the bare-invocation branch. `--print-query` lets a typed-but-unmatched `owner/repo` fall through and clone anyway, so the picker never blocks cloning something brand new.

Remote tab-completion (`functions/_clone`) and `c`/`_c` navigation are unchanged. No new dependencies. `fzf`, `gh`, and `glab` are already installed.

## Testing

- `clone-repo --refresh-repos` then `--list`: 986 deduped repos, recently-active first, spanning starred/own/org.
- Re-run `--list`: instant cache hit.
- Idempotent path: an existing clone prints its path in ~0.02s with no git call.

Two bugs caught in self-review and fixed before this PR: aborting fzf after typing would clone the typed text (`| tail -1` masked fzf's exit code), and a transient `gh` failure would poison `repos.json` with an empty list for the full 6h TTL (an empty array read back as a valid fresh cache).
