### PR TITLE
scripts: extract shared symlink primitive

### DIFF
--- a/claude/install.sh
+++ b/claude/install.sh
@@ -3,6 +3,9 @@ set -e
 
 [[ "$(uname -s)" == "Darwin" ]] || exit 0
 
+# shellcheck source=../scripts/lib/symlinks.sh
+. "$(cd "$(dirname "$0")/.." && pwd)/scripts/lib/symlinks.sh"
+
 CLAUDE_REPO_URL="https://github.com/bendrucker/claude.git"
 CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
 
@@ -32,19 +35,20 @@ install_claude_symlinks() {
 
   mkdir -p "$target_dir"
 
+  local desired=""
   for item in "$source_dir"/*; do
     [[ -e "$item" ]] || continue
     local name
     name="$(basename "$item")"
     local target="$target_dir/$name"
 
-    if [[ -L "$target" ]] && [[ "$(readlink "$target")" == "$item" ]]; then
-      continue
-    fi
-
-    ln -sfn "$item" "$target"
+    symlink_create "$item" "$target"
     echo "  ✓ ~/.claude/$name"
+
+    desired+="${desired:+$'\n'}$target"
   done
+
+  find "$target_dir" -maxdepth 1 -type l | symlink_prune "$CLAUDE_REPO_HOME/user" "$desired"
 }
 
 setup_claude_repo

--- a/scripts/install-symlinks
+++ b/scripts/install-symlinks
@@ -2,6 +2,9 @@
 # Usage: install-symlinks [dotfiles-root]
 set -e
 
+# shellcheck source=lib/symlinks.sh
+. "$(dirname "$0")/lib/symlinks.sh"
+
 DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
 : "${XDG_CONFIG_HOME:=$HOME/.config}"
 
@@ -17,8 +20,7 @@ for conf in "$DOTFILES_ROOT"/*/symlinks.conf; do
       echo "install-symlinks: $conf: source '$src' does not exist" >&2
       exit 1
     fi
-    mkdir -p "$(dirname "$dst")"
-    ln -sfn "$topic_dir/$src" "$dst"
+    symlink_create "$topic_dir/$src" "$dst"
     if [ -z "$desired_targets" ]; then
       desired_targets="$dst"
     else
@@ -28,34 +30,13 @@ $dst"
   done < "$conf"
 done
 
-# Remove stale symlinks pointing into DOTFILES_ROOT that are no longer declared
-is_desired() {
-  printf '%s\n' "$desired_targets" | grep -qFx "$1"
-}
-
-# Read candidate link paths from stdin (one per line) and remove those that
-# point into DOTFILES_ROOT but are no longer declared.
-remove_stale() {
-  while IFS= read -r link; do
-    [ -L "$link" ] || continue
-    target="$(readlink "$link" 2>/dev/null)" || continue
-    case "$target" in
-      "$DOTFILES_ROOT"/*) ;;
-      *) continue ;;
-    esac
-    is_desired "$link" || {
-      echo "install-symlinks: removing stale symlink $link -> $target"
-      rm "$link"
-    }
-  done
-}
-
+# Remove stale symlinks pointing into DOTFILES_ROOT that are no longer declared.
 # Scan directories that could contain managed symlinks. The HOME glob enumerates
 # dotfiles directly under $HOME (and ~/.ssh); the XDG scan recurses to find nested
 # links. Both feed the same removal rule.
 {
   printf '%s\n' "$HOME"/.[!.]*
   [ -d "$HOME/.ssh" ] && printf '%s\n' "$HOME/.ssh"/*
-} | remove_stale
+} | symlink_prune "$DOTFILES_ROOT" "$desired_targets"
 
-find "$XDG_CONFIG_HOME" -type l 2>/dev/null | remove_stale
+find "$XDG_CONFIG_HOME" -type l 2>/dev/null | symlink_prune "$DOTFILES_ROOT" "$desired_targets"

--- a/scripts/lib/symlinks.sh
+++ b/scripts/lib/symlinks.sh
@@ -1,0 +1,33 @@
+# shellcheck shell=sh
+# The repo's symlink primitive: create idempotent links and prune stale ones.
+# POSIX sh so both the sh install-symlinks and the bash claude/install.sh can
+# source it. Sourcing has no side effects.
+
+# symlink_create <src> <dst>
+#   Create dst as a symlink to src, making parent directories as needed.
+#   Silent and idempotent. Source-existence validation belongs in the caller.
+symlink_create() {
+  mkdir -p "$(dirname "$2")"
+  ln -sfn "$1" "$2"
+}
+
+# symlink_prune <root> <desired>
+#   Read candidate link paths from stdin (one per line) and remove those that
+#   are symlinks pointing under <root> but absent from the newline-delimited
+#   <desired> list. Echoes each removal.
+symlink_prune() {
+  prune_root="$1"
+  prune_desired="$2"
+  while IFS= read -r link; do
+    [ -L "$link" ] || continue
+    target="$(readlink "$link" 2>/dev/null)" || continue
+    case "$target" in
+      "$prune_root"/*) ;;
+      *) continue ;;
+    esac
+    if ! printf '%s\n' "$prune_desired" | grep -qFx "$link"; then
+      echo "install-symlinks: removing stale symlink $link -> $target"
+      rm "$link"
+    fi
+  done
+}

--- a/scripts/spec/symlinks_lib_spec.sh
+++ b/scripts/spec/symlinks_lib_spec.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "symlinks.sh"
+  setup() {
+    # shellcheck source=/dev/null
+    source "$SHELLSPEC_PROJECT_ROOT/lib/symlinks.sh"
+    sandbox="$SHELLSPEC_TMPBASE/symlinks-lib"
+    rm -rf "$sandbox"
+    mkdir -p "$sandbox"
+  }
+  BeforeEach 'setup'
+
+  Describe "symlink_create"
+    It "creates missing parent directories and an idempotent link"
+      src="$sandbox/source"
+      dst="$sandbox/nested/deep/link"
+      printf 'content\n' > "$src"
+
+      When call symlink_create "$src" "$dst"
+      The status should be success
+      The path "$dst" should be symlink
+      The contents of file "$dst" should equal "content"
+
+      # A second call must succeed without error and leave the same link.
+      symlink_create "$src" "$dst"
+      The path "$dst" should be symlink
+    End
+  End
+
+  Describe "symlink_prune"
+    setup_prune() {
+      root="$sandbox/root"
+      other="$sandbox/other"
+      home="$sandbox/home"
+      mkdir -p "$root" "$other" "$home"
+      printf 'x\n' > "$root/declared-source"
+      printf 'x\n' > "$root/stale-source"
+      printf 'x\n' > "$other/outside-source"
+
+      ln -sfn "$root/declared-source" "$home/declared"
+      ln -sfn "$root/stale-source" "$home/stale"
+      ln -sfn "$other/outside-source" "$home/outside"
+    }
+    BeforeEach 'setup_prune'
+
+    run_prune() {
+      printf '%s\n' "$home/declared" "$home/stale" "$home/outside" \
+        | symlink_prune "$root" "$home/declared"
+    }
+
+    It "removes an undeclared link into root, keeps declared and outside links"
+      When call run_prune
+      The status should be success
+      The output should include "removing stale symlink $home/stale"
+      The path "$home/declared" should be symlink
+      The path "$home/stale" should not be exist
+      The path "$home/outside" should be symlink
+    End
+  End
+End


### PR DESCRIPTION
Extracts the repo's symlink primitive into `scripts/lib/symlinks.sh`, then makes both `install-symlinks` and `claude/install.sh` thin adapters over it. The primitive is the create/track/prune trio: create an idempotent link, track which links are desired, prune stale links that point into the managed tree.

The logic was welded into `install-symlinks`, with its core (`remove_stale` + `is_desired`) as nested functions reading candidate links from stdin. That made it untestable in isolation. `claude/install.sh` was the one topic that reimplemented linking by hand instead of going through this system, with its own readlink-idempotency check and no stale cleanup at all.

## Why a Shared Lib, Not Declarative Conf

Claude's links are imperative: `claude/install.sh` clones `~/.claude-repo` and links each `user/*` child into `~/.claude/`. Folding that into the declarative `symlinks.conf` format would fight install ordering, since the central symlink pass runs before the clone exists. Extracting the primitive keeps Claude's clone-then-link flow intact while still giving it the create/track/prune behavior.

## Design

`scripts/lib/symlinks.sh` is POSIX `sh` so both the `sh` `install-symlinks` and the `bash` `claude/install.sh` can source it, with no side effects on source. Two functions mirror the two halves of the old behavior:

- `symlink_create <src> <dst>`: `mkdir -p` the parent, then `ln -sfn`. Silent and idempotent. Source-existence validation stays in the caller, where it stays conf-typo-specific.
- `symlink_prune <root> <desired>`: reads candidate links from stdin and removes those that are symlinks resolving under `<root>` but absent from the newline-delimited `<desired>` list. This is the old `remove_stale` + `is_desired`, generalized from the hard-coded `DOTFILES_ROOT` to a `<root>` parameter.

The two prune callers can't interfere: the central pass prunes links into `DOTFILES_ROOT`, Claude prunes links into `$CLAUDE_REPO_HOME/user`. Claude's links point into `~/.claude-repo`, outside `DOTFILES_ROOT`, so the central scan never touches them, and vice versa.

The payoff beyond dedup: `claude/install.sh` now prunes stale `~/.claude` links. Deleting a file from `~/.claude-repo/user/` used to leave its link dangling forever.

## Testing

- New `scripts/spec/symlinks_lib_spec.sh` exercises the functions in isolation: `symlink_create` makes parent dirs and is idempotent; `symlink_prune` removes an undeclared link into root, keeps a declared one, and keeps a link pointing outside root.
- The existing `scripts/spec/install_symlinks_spec.sh` is untouched and still passes. It's the regression guard proving the driver's end-to-end behavior is unchanged. `cd scripts && shellspec` is green (8 examples, 0 failures).
- Sandboxed both drivers by hand: the central pass creates a declared link, removes a stale link into the fake root, and preserves an unrelated link; the Claude path prunes a deleted `user/b` link while `user/a` survives.
- `shellcheck -x --source-path=SCRIPTDIR` (the CI args) is clean across the lib and both callers.
