### PR TITLE
tmux: drop Nerd Font glyph from terminal title

### DIFF
--- a/terminal/ghostty.config
+++ b/terminal/ghostty.config
@@ -1,9 +1,5 @@
 font-family = MonaspiceNe NFM
 
-# Render the title in the Nerd Font so tmux's title glyphs show instead of tofu.
-# macOS title chrome won't fall back to PUA glyphs; it needs a single patched face.
-window-title-font-family = MonaspiceNe NFM
-
 # Always use the tab-bar titlebar so a single tab gets the same wide, left-aligned
 # title slot as multiple tabs. The default centered titlebar truncates one tab's title.
 macos-titlebar-style = tabs

--- a/tmux/core/core.conf
+++ b/tmux/core/core.conf
@@ -28,11 +28,11 @@ set -g focus-events on                     # apps detect pane/window focus chang
 # preserved. The pane_in_mode/pane_dead markers match the tmux default.
 set -g automatic-rename-format '#{?pane_in_mode,[tmux],#{b:pane_current_path}}#{?pane_dead,[dead],}'
 
-# Mirror the active window's name into the outer terminal's tab title.
-# Prefixed with a Nerd Font glyph, then session/window. The title chrome renders the
-# glyph via Ghostty's window-title-font-family (set to the patched terminal font).
+# Mirror the active window's name into the outer terminal's tab title, as session/window.
+# No glyph prefix: the title is rendered by whatever terminal attaches (often a thin SSH
+# client without the patched font), and macOS title chrome won't fall back to PUA glyphs.
 set -g set-titles on
-set -g set-titles-string ' #S/#W'
+set -g set-titles-string '#S/#W'
 
 # Only break words on spaces and @ so double-click selects full URLs and ticket IDs
 setw -g word-separators ' @'


### PR DESCRIPTION
Removes the Nerd Font Codicon glyph that #509 added to the tmux `set-titles-string`.

The glyph was baked into the synced config, but the terminal tab title is rendered by whatever client attaches. Attaching over SSH from a thin client without the patched font, macOS title chrome can't fall back to PUA glyphs and renders the glyph as tofu. The host's tmux has no signal for the viewer's font (`client_termname` is just `xterm-256color`, `TERM_PROGRAM` is masked to `tmux`, and `client_termfeatures` carries nothing about fonts), so there is no reliable way to gate the glyph per-client.

Drops the glyph and the now-dead `window-title-font-family` from `ghostty.config`, which only existed to render it. Keeps the `#S/#W` session/window separator and `macos-titlebar-style = tabs`, both independent of the glyph.
