### PR TITLE
ssh: forward a connected device's agent for remote git

### DIFF
--- a/bin/tmux-ssh-agent-link
+++ b/bin/tmux-ssh-agent-link
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Repoint the stable ~/.ssh/agent.sock symlink at the attaching client's
+# forwarded SSH agent. Called by the tmux client-attached hook.
+# Usage: tmux-ssh-agent-link <session-name>
+#
+# tmux's update-environment carries SSH_AUTH_SOCK, so on attach the session
+# env holds the connecting client's forwarded socket. IdentityAgent (ssh/config)
+# follows this symlink, so git on this Mac signs with the connected device's key.
+#
+# Only repoint when the socket path matches a real forwarded agent (tsshd or
+# ssh) and the socket is live. A local or Mosh attach carries the empty launchd agent (or no var
+# at all); ignoring those is the safety that keeps a good link from being
+# clobbered when you also have a device connected.
+
+set -euo pipefail
+
+session="${1:?usage: tmux-ssh-agent-link <session-name>}"
+
+sock=$(tmux show-environment -t "$session" SSH_AUTH_SOCK | sed -n 's/^SSH_AUTH_SOCK=//p')
+
+case "$sock" in
+  */tsshd-*/agent.* | */ssh-*/agent.*)
+    if [[ -S "$sock" ]]; then
+      ln -sfn "$sock" "$HOME/.ssh/agent.sock"
+    fi
+    ;;
+esac

--- a/ssh/Brewfile
+++ b/ssh/Brewfile
@@ -1,2 +1,3 @@
 brew 'mosh'
+brew 'tsshd'
 cask 'secretive'

--- a/ssh/agent.zsh
+++ b/ssh/agent.zsh
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+
+# Inside tmux, point SSH_AUTH_SOCK at the stable symlink that the client-attached
+# hook keeps repointed to the connected device's forwarded agent. This keeps
+# ssh-add -l and direct agent consumers in sync with the device used for signing
+# (git signing here is GPG, so this does not affect it). The -S guard means local
+# shells, where the link is absent or dangling, keep their default agent.
+if [[ -n $TMUX && -S ~/.ssh/agent.sock ]]; then
+  export SSH_AUTH_SOCK=~/.ssh/agent.sock
+fi

--- a/ssh/config
+++ b/ssh/config
@@ -1,3 +1,9 @@
+# Use a live forwarded agent (a connected device, via tsshd/ssh) when present;
+# the tmux client-attached hook keeps ~/.ssh/agent.sock pointed at it. Falls
+# back to Secretive (Host * in ~/.ssh/config.local) when no device is connected.
+Match exec "test -S ~/.ssh/agent.sock"
+  IdentityAgent ~/.ssh/agent.sock
+
 Host *
   IgnoreUnknown AddKeysToAgent,UseKeychain
   AddKeysToAgent yes

--- a/tmux/agent/agent.conf
+++ b/tmux/agent/agent.conf
@@ -1,0 +1,6 @@
+# Forwarded-agent symlink. On attach, repoint ~/.ssh/agent.sock at the
+# connecting client's forwarded SSH agent (carried in by update-environment's
+# SSH_AUTH_SOCK). IdentityAgent (ssh/config) follows this link, so git on this
+# Mac signs with the connected device's key. -ga appends so the existing
+# client-attached hook in responsive/responsive.conf is preserved.
+set-hook -ga client-attached 'run-shell -b "tmux-ssh-agent-link #{session_name}"'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -17,6 +17,7 @@ source-file ~/.config/tmux/core/core.conf
 source-file ~/.config/tmux/core/unbinds.conf
 source-file ~/.config/tmux/navigation/navigation.conf
 source-file ~/.config/tmux/session/session.conf
+source-file ~/.config/tmux/agent/agent.conf
 source-file ~/.config/tmux/search/search.conf
 source-file ~/.config/tmux/appearance/appearance.conf
 source-file ~/.config/tmux/responsive/responsive.conf


### PR DESCRIPTION
Lets remote git on a Mac sign with a connected device's key. Connect from a phone over tsshd with agent forwarding and git here uses the phone's 1Password key, gated by the phone's biometric prompt. The key never lands on the Mac and signing dies the instant you disconnect. At the Mac, Secretive is unchanged.

The blocker was not the transport. Machine-local `~/.ssh/config.local` pins `IdentityAgent` to Secretive for `Host *`, and when `IdentityAgent` is set ssh ignores `SSH_AUTH_SOCK` entirely. So a forwarded agent was never consulted. `ssh -G github.com` confirmed `forwardagent no` and an `identityagent` pointing at Secretive.

Mosh can't carry this. It bootstraps over ssh then detaches to UDP, so the forwarded socket dies with the ssh channel. tsshd is the mosh-like UDP roaming that explicitly fixed that gap, and a tsshd session forwards the phone's agent intact. `ssh/Brewfile` adds `tsshd`.

## How It Works

`ssh/config` gets a `Match exec "test -S ~/.ssh/agent.sock"` block before `Host *`. First match wins, so a live socket selects the device agent and the Secretive `Host *` in `config.local` stays the fallback when the socket is absent or dangling. No machine-specific path enters the repo.

`~/.ssh/agent.sock` is a stable symlink that a tmux `client-attached` hook repoints at the attaching client's forwarded socket. tmux's `update-environment` already imports the client's `SSH_AUTH_SOCK` on attach, so `bin/tmux-ssh-agent-link` reads it from the session env and relinks. It only repoints when the path matches a real forwarded agent (`*/tsshd-*/agent.*` or `*/ssh-*/agent.*`) and the socket is live. That filter is the safety: a local or Mosh attach carries the empty `launchd` agent (or no variable), so it's ignored and never clobbers a good link. The hook uses `-ga` to append, preserving the existing `client-attached` hook in `responsive/responsive.conf`.

`ssh/agent.zsh` points `SSH_AUTH_SOCK` at the symlink inside tmux so `ssh-add -l` and direct agent consumers reflect the connected device. Commit signing here is GPG, so this doesn't touch signing. It's guarded by `-S`, no subshell, to keep within the startup-perf rules.

## Verification

Static checks done locally:

- `ssh -G` against throwaway configs: live socket resolves `identityagent` to the symlink; a dangling socket falls back to Secretive.
- The real `ssh/config` parses and falls back to Secretive on this machine (no device connected).
- The path filter accepts `tsshd-*/agent.*` and `ssh-*/agent.*` and rejects the launchd/empty cases.
- `shellcheck` clean on `bin/tmux-ssh-agent-link`.

Live end-to-end (push from a phone-forwarded session, disconnect fallback, second-device reattach) is exercised after `dotfiles dev enable` with a device connected.

## Deferred

- A tsshd firewall allow analogous to `ssh/mosh.zsh`. tsshd connected without it this session, so it's only needed if a machine blocks the UDP listener.
- Per-host scoping of the forwarded agent. It currently serves all hosts when live, matching the not-per-repo goal.
