### PR TITLE
tmux/usage: fix -CC new-window hang from after-new-window hook

### DIFF
--- a/tmux/usage/usage.conf
+++ b/tmux/usage/usage.conf
@@ -1,6 +1,12 @@
 # Usage tracking — passive hook-based logging to $XDG_DATA_HOME/tmux/usage.jsonl
 set-hook -g session-created  'run-shell -b "tmux-usage-log session-created #{session_name}"'
-set-hook -g after-new-window 'run-shell -b "tmux-usage-log window-created #{window_index}"'
+# window-linked, not after-new-window: after-new-window runs inside the issuing
+# client's command queue, so under -CC its run-shell reply (%begin/%end) lands
+# between the new-window command and the %window-add notification. A strict
+# control client (RootShell) mis-parses that mid-handshake block and never
+# renders the new pane. window-linked fires once per new window outside that
+# queue, logging without disturbing the handshake.
+set-hook -g window-linked    'run-shell -b "tmux-usage-log window-created #{window_index}"'
 set-hook -g after-split-window 'run-shell -b "tmux-usage-log pane-created #{pane_index}"'
 set-hook -g after-select-window 'run-shell -b "tmux-usage-log window-selected #{window_index}"'
 set-hook -g pane-focus-in    'run-shell -b "tmux-usage-log pane-focused #{pane_index}"'


### PR DESCRIPTION
Fixes a hang where new tmux windows created over `tmux -CC` control mode (from
the RootShell client via `tssh`) never render a shell: the window appears, but
the pane stays blank.

The cause is the `after-new-window` usage-logging hook. `after-new-window` runs
inside the issuing client's command queue, so under `-CC` its `run-shell` reply
(a `%begin`/`%end` block) is emitted to the control client *between* the
`new-window` command and the `%window-add` notification. A tolerant control
client (iTerm2) ignores that mid-handshake block, but a stricter one (RootShell)
mis-parses it and never renders the new pane.

The fix moves `window-created` logging to the `window-linked` hook, which fires
once per new window but outside the issuing client's command queue, so its
`run-shell` emits no block into the control stream. `window-linked` also fires
for a session's first window and on `move-window`/`link-window`. For a passive
usage log that broader "a window now exists" semantics is fine.

## How it was diagnosed

The usage hooks were the suspected culprit, but the hooks alone don't reproduce
the hang on a generic `-CC` client. They fire correctly and every pane renders,
even under the full config, with interactive login shells, and under zero-gap
window-creation contention. RootShell isn't installable locally, so I bisected
on the one protocol artifact the hooks *do* introduce: a `%begin`/`%end` block
landing in the new-window handshake.

A throwaway `-CC` harness on a dedicated socket showed, per `new-window`:

- With the hooks: one `flags=0` block before each `%window-add`.
- Hooks unset: zero.
- Single-hook bisection: only `after-new-window` injects it. `pane-focus-in`,
  `window-renamed`, and `after-select-window` fire *after* `%window-add`.
- Guarding the hook (`if-shell` on `#{client_control_mode}`) or detaching the
  child (`setsid`) does **not** remove the block. It's tmux echoing the hook's
  command dispatch, not the child process. Only moving off `after-new-window`
  removes it.

## Verification

On the harness, after the change: zero handshake blocks per new window (down
from one), and `window-created` still logs with the correct index on both a
control-mode and a normal attach. The live server on this machine is already
patched so the change can be confirmed in real RootShell + `tssh -CC`.
