### PR TITLE
mobile: gh delta pager, narrow bell chip

### DIFF
--- a/github/gh.zsh
+++ b/github/gh.zsh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+
+# Page gh output through delta so `gh pr diff` gets the same formatting as
+# `git diff`. delta passes non-diff content through unchanged.
+export GH_PAGER=delta

--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -10,7 +10,9 @@ set -g status-left "#{?#{E:@resp_is_narrow},#{E:@resp_sl_narrow},#{E:@catppuccin
 source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"
 
 # Leading space keeps the bell pill from touching the last window entry.
-set -g status-right "#{?#{==:#(_tmux-bell-count),0},, #{E:@catppuccin_status_bell}}"
+# Narrow clients swap the catppuccin pill for the transparent-friendly chip
+# defined in responsive.conf.
+set -g status-right "#{?#{==:#(_tmux-bell-count),0},, #{?#{E:@resp_is_narrow},#{E:@resp_sr_narrow},#{E:@catppuccin_status_bell}}}"
 
 # Narrow window list: capture catppuccin's generated pill formats and wrap them
 # in the per-client narrowness predicate (narrow branches live in

--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -53,6 +53,11 @@ set -g @resp_chip_bg '#{?#{||:#{window_bell_flag},#{window_activity_flag}},#{@th
 set -g @resp_chip_fg '#{?#{||:#{window_bell_flag},#{window_activity_flag}},#{@thm_crust},#{@thm_overlay_1}}'
 set -g @resp_ws_narrow '#[fg=#{E:@resp_chip_bg}]#[fg=#{E:@resp_chip_fg},bg=#{E:@resp_chip_bg}]#I#[fg=#{E:@resp_chip_bg},bg=default]#[default]'
 
+# Bell indicator for the narrow status-right (the catppuccin pill's baked-in
+# mantle caps clash with the transparent narrow bar). Same chip technique as
+# @resp_ws_narrow. status.conf gates it behind a nonzero bell count.
+set -g @resp_sr_narrow '#[fg=#{@thm_yellow}]#[fg=#{@thm_crust},bg=#{@thm_yellow}] #(_tmux-bell-count)#[fg=#{@thm_yellow},bg=default]#[default]'
+
 # Current window: rounded pill with index block + name + zoom flag. The name is
 # window_name, the working directory under automatic-rename and the manual name
 # otherwise. pane_title is too noisy at this width. window_name is spelled out


### PR DESCRIPTION
Two fixes for working over tssh from narrow clients (Rootshell on iOS/iPadOS).

`gh` had no pager configured, so `gh pr diff` dumped raw diffs through `less` with no formatting. `github/gh.zsh` now exports `GH_PAGER=delta`, giving PR diffs the same rendering as `git diff`. delta passes non-diff content through unchanged, so other paged `gh` output is unaffected.

On narrow clients the status-right bell indicator rendered the catppuccin pill, whose baked-in mantle cap colors clash with the transparent narrow bar. `@resp_sr_narrow` is a rounded yellow chip built the same way as the narrow window chips, and `status.conf` picks it behind the existing narrowness predicate while keeping the count gate. Formats self-heal on redraw, so no hook changes: the indicator adapts live when a client of a different width attaches. The `MouseUp1StatusRight` binding is untouched, so the chip stays tappable.

A width-adaptive delta config (narrower line-number layout on small clients) was considered and rejected. Any width decision made when the pager starts is a snapshot, and neither delta nor `less` re-renders on resize, so attaching mid-view from a different-width client would still render wrong.

Verified on the live server by sourcing both modules from the worktree, triggering a bell in a background window of a detached lab session, and expanding status-right in both modes: wide renders the unchanged catppuccin pill and narrow (forced via a session-scoped `@resp_narrow` override) renders the capped chip. Verified `gh pr diff` output renders through delta with catppuccin-latte styling.

https://claude.ai/code/session_01FYJiB2eFr1QL7SQusLmRe9
