### PR TITLE
worktrunk: working nightly prune job, failure surfacing

### DIFF
--- a/bin/worktree-prune
+++ b/bin/worktree-prune
@@ -1,0 +1,27 @@
+#!/usr/bin/env zsh
+# shellcheck shell=bash
+# Nightly worktree prune across all repos.
+# Runs `wt all prune --before`, creates a Things task on failure.
+
+set -e
+set -o pipefail
+
+DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
+
+source "${0:A:h}/../scripts/lib/report-failure.sh"
+
+PRUNE_LOG=$(mktemp)
+trap 'rm -f "$PRUNE_LOG"' EXIT
+
+gum log --level info "Running worktree prune"
+if ! "$DOTFILES_HOME/bin/wt-all" prune --before 2>&1 | tee "$PRUNE_LOG"; then
+  gum log --level error "worktree prune failed"
+
+  revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  output=$(tail -n 100 "$PRUNE_LOG" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')
+  report_failure "worktree-prune" "Nightly worktree prune failed" "wt all prune --before" "$output" "$revision"
+  exit 1
+fi
+
+report_success "worktree-prune"
+gum log --level info "Worktree prune completed successfully"

--- a/bin/wt-all
+++ b/bin/wt-all
@@ -26,11 +26,11 @@ export PATH="${self:h}:$PATH"
 # Internal per-repo worker, invoked in parallel by xargs.
 if [[ "${1:-}" == --worker ]]; then
   cmd=("${(@f)$(<"$WT_ALL_DIR/.cmd")}")
-  out=$(wt -C "$2" "${cmd[@]}" 2>/dev/null)
-  rc=$?
   # Percent-encode '/' so distinct repo paths map to distinct temp files; a
   # plain '/'->'_' swap collides a nested path with an underscore in a name.
   key="${2//\%/%25}"; key="${key//\//%2F}"
+  out=$(wt -C "$2" "${cmd[@]}" 2>"$WT_ALL_DIR/$key.err")
+  rc=$?
   print -r -- "$out" > "$WT_ALL_DIR/$key"
   (( rc )) && : > "$WT_ALL_DIR/$key.failed"
   print   # one tick per completion drives the progress counter
@@ -81,12 +81,17 @@ main () {
 
   local base="${PROJECTS:-$HOME/src}/"
   integer active=0 worktrees=0 branches=0
-  local -a rows failed
+  local -a rows failed failed_errs
   local repo key disp out
   for repo in "${repos[@]}"; do
     key="${repo//\%/%25}"; key="${key//\//%2F}"
     disp="${repo#$base}"
-    [[ -e "$dir/$key.failed" ]] && { failed+=("$disp"); continue; }
+    if [[ -e "$dir/$key.failed" ]]; then
+      failed+=("$disp")
+      [[ -s "$dir/$key.err" ]] \
+        && failed_errs+=("$disp:"$'\n'"$(tail -n 20 "$dir/$key.err" | sed 's/^/  /')")
+      continue
+    fi
     out="$(<"$dir/$key")"
     [[ -z "$out" ]] && continue
     (( active++ ))
@@ -119,7 +124,10 @@ main () {
 
   print
   gum log --level info "${(j: · :)summary}"
-  (( ${#failed} )) && gum log --level warn "failed: ${(j:, :)failed}"
+  if (( ${#failed} )); then
+    gum log --level warn "failed: ${(j:, :)failed}"
+    (( ${#failed_errs} )) && print -rl -- "${failed_errs[@]}"
+  fi
 
   (( ${#failed} == 0 ))
 }

--- a/macos/com.user.worktree-prune.plist
+++ b/macos/com.user.worktree-prune.plist
@@ -10,7 +10,7 @@
         <string>/bin/zsh</string>
         <string>-l</string>
         <string>-c</string>
-        <string>wt all prune --before</string>
+        <string>$HOME/.dotfiles/bin/worktree-prune</string>
     </array>
 
     <key>StartCalendarInterval</key>

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -43,6 +43,8 @@ install_launch_agent() {
     gum log --level info "$description launchd agent installed"
   else
     gum log --level error "$description launchd agent failed to load; run: launchctl bootstrap gui/$UID $plist_dst"
+    launchd_failed=1
+    return 1
   fi
 }
 
@@ -77,3 +79,7 @@ if [[ ! -L "$HOME/.dotfiles" ]]; then
   setup_claude_upgrade
   setup_worktree_prune
 fi
+
+# Exit nonzero if any agent failed to load, so the failure is not swallowed by
+# a zero exit. install_launch_agent already logs which one and how to recover.
+exit "${launchd_failed:-0}"

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -16,6 +16,7 @@ install_launch_agent() {
   local description="$2"
   local plist_src="$ZSH/macos/$plist_name"
   local plist_dst="$HOME/Library/LaunchAgents/$plist_name"
+  local label="${plist_name%.plist}"
 
   if [[ ! -f "$plist_src" ]]; then
     gum log --level warn "$description plist not found, skipping"
@@ -26,21 +27,29 @@ install_launch_agent() {
 
   mkdir -p "$HOME/Library/LaunchAgents"
 
-  launchctl unload "$plist_dst" 2>/dev/null || true
+  launchctl bootout "gui/$UID/$label" 2>/dev/null || true
 
   cp "$plist_src" "$plist_dst"
 
-  if launchctl load "$plist_dst" 2>/dev/null; then
+  # bootout of a running service is asynchronous; an immediate bootstrap can
+  # race the teardown and fail, so retry briefly.
+  local _attempt
+  for _attempt in 1 2 3 4 5; do
+    launchctl bootstrap "gui/$UID" "$plist_dst" 2>/dev/null && break
+    sleep 0.5
+  done
+
+  if launchctl print "gui/$UID/$label" >/dev/null 2>&1; then
     gum log --level info "$description launchd agent installed"
   else
-    gum log --level warn "failed to load $description launchd agent; may need re-login"
+    gum log --level error "$description launchd agent failed to load; run: launchctl bootstrap gui/$UID $plist_dst"
   fi
 }
 
 setup_dotfiles_upgrade() {
   # Remove old sync job (replaced by upgrade job which includes sync)
   local old_sync_plist="$HOME/Library/LaunchAgents/com.user.dotfiles-sync.plist"
-  launchctl unload "$old_sync_plist" 2>/dev/null || true
+  launchctl bootout "gui/$UID/com.user.dotfiles-sync" 2>/dev/null || true
   rm -f "$old_sync_plist"
 
   install_launch_agent com.user.dotfiles-upgrade.plist "nightly dotfiles upgrade"
@@ -52,8 +61,7 @@ setup_worktree_prune() {
 
 setup_claude_upgrade() {
   # Remove old plist that pointed to ~/.claude-repo/bin/claude-upgrade
-  local old_plist="$HOME/Library/LaunchAgents/com.user.claude-upgrade.plist"
-  launchctl unload "$old_plist" 2>/dev/null || true
+  launchctl bootout "gui/$UID/com.user.claude-upgrade" 2>/dev/null || true
 
   install_launch_agent com.user.claude-upgrade.plist "nightly Claude upgrade"
 }

--- a/scripts/lib/report-failure.sh
+++ b/scripts/lib/report-failure.sh
@@ -48,7 +48,9 @@ report_failure() {
 
   local status_file prior
   status_file=$(report_status_file "$job")
-  prior=$(cat "$status_file" 2>/dev/null)
+  # `|| true` keeps a missing latch (first-ever failure) from killing
+  # `set -e` callers before the to-do is filed.
+  prior=$(cat "$status_file" 2>/dev/null || true)
   echo failed >"$status_file"
 
   if [[ "$prior" == "failed" ]]; then
@@ -78,9 +80,11 @@ report_failure() {
 '"$output"'
 ```'
 
+  # printf avoids echo's trailing newline, which lands in the to-do title as
+  # an encoded %0A.
   local encoded_notes encoded_title
-  encoded_notes=$(echo "$notes" | jq -sRr @uri)
-  encoded_title=$(echo "$title" | jq -sRr @uri)
+  encoded_notes=$(printf '%s' "$notes" | jq -sRr @uri)
+  encoded_title=$(printf '%s' "$title" | jq -sRr @uri)
 
   open "things:///add?title=${encoded_title}&notes=${encoded_notes}&when=today"
 


### PR DESCRIPTION
The nightly prune plist added in #496 was never actually installed. The installer's deprecated `launchctl load` path had silently stopped loading agents, so neither `com.user.worktree-prune` nor `com.user.dotfiles-upgrade` was loaded in launchd. Separately, `wt all` swallowed each worker's stderr, so a failed repo gave no reason in the nightly log.

The `wt prune` safety and output work that originally shared this branch landed first in #522 (exact PR-state resolution, safe-subset removal, interactive `-i` mode). This branch is rebased onto that, so it now carries only the nightly-job and failure-surfacing changes.

## Changes

`bin/worktree-prune` is a new nightly wrapper modeled on `bin/dotfiles-upgrade`. It runs `wt all prune --before` and files a Things to-do through `report-failure.sh` on failure. The plist runs it instead of calling `wt` directly, so failures are no longer invisible.

`bin/wt-all` now captures each worker's stderr and prints it for failed repos under the summary. The nightly log and the Things to-do say why a repo failed.

`macos/install.sh` replaces `launchctl unload`/`load` with `bootout`/`bootstrap`. `bootout` teardown is asynchronous, so an immediate `bootstrap` can race it (observed with the running theme-sync agent). The installer retries briefly, then verifies with `launchctl print` and errors loudly instead of the soft "may need re-login".

`scripts/lib/report-failure.sh` had two bugs found while exercising the wrapper. Reading a missing latch file returned nonzero and killed `set -e` callers before the first-ever failure was filed, so a brand-new job could never create its to-do. And `echo | jq @uri` encoded a trailing newline into to-do titles as `%0A`.

## Verification

Exercised the wrapper's failure path (`DOTFILES_HOME=/nonexistent`) through to the Things to-do and the `failed` latch, which surfaced the latch-read bug. Then ran the success path with a real `wt all prune --before` sweep covering the fan-out table and the latch reset.

Ran `macos/install.sh` against the live launchd session. It covers bootout/bootstrap of a running agent (theme-sync) and loading the previously unloaded agents, verified with `launchctl print`.

## References

- #496
- #522
