### PR TITLE
wt-prune: exact PR state + interactive sweep

### DIFF
--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -286,7 +286,7 @@ main () {
       if (( do_remove )); then
         for lbl in "${selected[@]}"; do
           [[ -z "$lbl" ]] && continue
-          if wt remove --foreground --force --force-delete "${handle_of[$lbl]}" </dev/null >/dev/null 2>&1; then
+          if (( dry_run )) || wt remove --foreground --force --force-delete "${handle_of[$lbl]}" </dev/null >/dev/null 2>&1; then
             (( worktrees++ ))
           fi
         done

--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -170,8 +170,9 @@ main () {
       # dry-run counts everything it lists, since it removes nothing).
 
       # Merged upstream: the work landed, so drop worktree and branch even when
-      # dirty. The leftovers are cruft.
-      if [[ "$pr_st" == MERGED ]]; then
+      # dirty. The leftovers are cruft. Never the current worktree: you cannot
+      # remove the checkout you are standing in.
+      if [[ "$pr_st" == MERGED && "$is_current" != true ]]; then
         if (( dry_run )) || wt remove --foreground --force --force-delete "$branch" </dev/null >/dev/null 2>&1; then
           (( worktrees++ )); seen[$branch]=1
         fi

--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -2,20 +2,29 @@
 # wt prune [args]: per-repo worktree prune, summarized to one line.
 #
 # Integration pass: `wt step prune` removes worktrees integrated into the
-# default branch (including squash merges, via patch-id). Forge pass: removes
-# worktrees whose branch was merged on the remote (gh/glab), catching PRs merged
-# remotely even when the local default branch is stale.
+# default branch (including squash merges, via patch-id). Forge pass: for each
+# branch that survives, resolves the exact PR/MR state (gh/glab) and removes it
+# when merged, or when closed with the tip backed up on a remote and a clean
+# tree. Resolving per survivor (not a capped bulk list) catches PRs that merged
+# outside the recent window.
 #
 # Age pass (--before [DURATION], default 1mo): removes old, clean worktree
 # directories that aren't integrated anywhere, to clear out stale checkouts. It
 # keeps the branch (so committed work is recoverable) and skips worktrees with
 # uncommitted changes, relying on `wt remove`'s own guards.
 #
+# Interactive (-i / --interactive, standalone only): after the auto passes,
+# present the ambiguous remainder as a `gum` multi-select checklist annotated by
+# recoverability, and remove only the selections.
+#
 # Prints one summary line ("N worktrees, M branches") or nothing when there's
 # nothing to remove. Honors --dry-run: counts what would be removed without
 # removing. For per-branch detail, run `wt step prune --dry-run` directly.
 
 set -uo pipefail
+# Suppress zsh's default of echoing a parameter when `local`/`typeset` re-declares
+# one that already holds a value (e.g. `branch`, reused across both read loops).
+setopt typeset_silent
 
 # Convert a duration like 2w / 30d / 1mo into seconds. Returns nonzero on a
 # spec it doesn't understand so callers can fall back to a default.
@@ -31,6 +40,21 @@ parse_duration () {
   esac
 }
 
+# Resolve the exact PR/MR state for a branch on the forge. Prints
+# "STATE\tNUMBER" (e.g. "MERGED\t142"), or nothing when no PR exists. gh is the
+# tested path; glab mirrors it (newest MR wins) but is untested.
+pr_state () {
+  local branch=$1 host=$2
+  if [[ "$host" == *gitlab* ]]; then
+    glab mr list --source-branch "$branch" --state all --output json 2>/dev/null \
+      | jq -r 'if length > 0
+               then ((.[0].state | ascii_upcase | if . == "OPENED" then "OPEN" else . end)) + "\t" + (.[0].iid | tostring)
+               else empty end'
+  else
+    gh pr view "$branch" --json state,number --jq '"\(.state)\t\(.number)"' 2>/dev/null
+  fi
+}
+
 main () {
   # wt subcommands occasionally flush stray bookkeeping to stdout mid-run, which
   # would corrupt our single summary line (and the `wt all` table). Detach the
@@ -40,7 +64,7 @@ main () {
   exec {stdout_fd}>&1
   exec 1>&2
 
-  local dry_run=0 before_enabled=0
+  local dry_run=0 before_enabled=0 interactive=0
   integer before_secs=0
   local -a passthrough
   integer i=1
@@ -50,6 +74,9 @@ main () {
       --dry-run)
         dry_run=1
         passthrough+=("$a")
+        ;;
+      -i|--interactive)
+        interactive=1
         ;;
       --before)
         before_enabled=1
@@ -70,6 +97,13 @@ main () {
     esac
     (( i++ ))
   done
+
+  # Interactive is standalone-only: it drives a `gum` checklist on the terminal,
+  # so it cannot run under the `wt all` xargs fan-out or with a non-TTY stderr.
+  if (( interactive )) && [[ -n "${WT_ALL:-}" || ! -t 2 ]]; then
+    print -r -- "wt prune -i: interactive mode requires a terminal and cannot run under wt all" >&2
+    return 1
+  fi
 
   # Count from a dry-run probe. A dry-run always lists the candidates, whether
   # or not this is a real run. Real-mode JSON reports only what it actually
@@ -94,8 +128,9 @@ main () {
   # parallel fan-out and the nightly job.
   (( dry_run )) || wt step prune "${probe_args[@]}" --yes --foreground </dev/null >/dev/null 2>&1
 
-  # Linked-worktree pass over a single `wt list`: forge-merged removals, plus
-  # the age pass when --before is set.
+  # Linked-worktree pass over a single `wt list`: exact forge-state removals,
+  # plus the age pass (non-interactive) or candidate collection for the
+  # interactive checklist under -i.
   local list_json
   list_json=$(wt list --format=json 2>/dev/null)
 
@@ -106,33 +141,65 @@ main () {
   [[ -n "$list_json" && "$list_json" != "[]" ]] \
     && has_linked=$(jq -r 'any(.[]; .kind == "worktree" and (.is_main | not))' <<<"$list_json")
 
+  # Candidates deferred to the interactive checklist, split so recoverable
+  # (on-remote) entries sort ahead of local-only ones. Parallel arrays hold the
+  # handle passed to `wt remove` and the raw tab-separated display row.
+  local -a rec_handles rec_rows loc_handles loc_rows
+
   if [[ "$has_linked" == true ]]; then
     local remote_host
     remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
 
-    local -a merged_branches
-    if [[ "$remote_host" == *gitlab* ]]; then
-      merged_branches=("${(@f)$(glab mr list --state merged --output json 2>/dev/null | jq -r '.[].source_branch')}")
-    else
-      merged_branches=("${(@f)$(gh pr list --state merged --json headRefName --jq '.[].headRefName' 2>/dev/null)}")
-    fi
-
     integer now=0
     (( before_enabled )) && now=$(date +%s)
-    local branch is_main ts clean
-    while IFS=$'\t' read -r branch is_main ts clean; do
+    local branch is_main ts clean onremote is_current wtpath pr_out pr_st pr_num
+    while IFS=$'\t' read -r branch is_main ts clean onremote is_current wtpath; do
       [[ "$is_main" == true ]] && continue
       [[ -n "${seen[$branch]:-}" ]] && continue
+
+      # Resolve the exact PR/MR state for this survivor. The integration pass
+      # already cleared branches merged into the local default; a squash-merged
+      # PR still shows local commits ahead of main, so only the forge state
+      # proves it landed. This runs once per survivor, not once per PR ever.
+      pr_out=$(pr_state "$branch" "$remote_host")
+      IFS=$'\t' read -r pr_st pr_num <<<"$pr_out"
 
       # Removals read stdin from /dev/null: the loop's stdin is the jq pipe, and
       # a `wt remove` that pauses on a prompt would otherwise consume it. We
       # count only confirmed removals so the summary matches what was removed (a
       # dry-run counts everything it lists, since it removes nothing).
 
-      # Merged on the remote: safe to drop the worktree and the branch.
-      if (( ${merged_branches[(Ie)$branch]} )); then
+      # Merged upstream: the work landed, so drop worktree and branch even when
+      # dirty. The leftovers are cruft.
+      if [[ "$pr_st" == MERGED ]]; then
         if (( dry_run )) || wt remove --foreground --force --force-delete "$branch" </dev/null >/dev/null 2>&1; then
           (( worktrees++ )); seen[$branch]=1
+        fi
+        continue
+      fi
+
+      # Closed without merging is weaker than merged, so guard it: remove only
+      # when the tip is on a remote (recoverable), the tree is clean (no
+      # only-local work), and this is not the current worktree.
+      if [[ "$pr_st" == CLOSED && "$onremote" == onremote && "$clean" == clean && "$is_current" != true ]]; then
+        if (( dry_run )) || wt remove --foreground --force --force-delete "$branch" </dev/null >/dev/null 2>&1; then
+          (( worktrees++ )); seen[$branch]=1
+        fi
+        continue
+      fi
+
+      # Interactive: defer the ambiguous remainder to the checklist instead of
+      # the age pass. Never offer the current worktree.
+      if (( interactive )); then
+        [[ "$is_current" == true ]] && continue
+        local dir=${wtpath:t} pr_disp="-" remote_disp="LOCAL-ONLY"
+        [[ -n "$pr_st" ]] && pr_disp="${pr_st}#${pr_num}"
+        [[ "$onremote" == onremote ]] && remote_disp="onremote"
+        local row="$dir"$'\t'"$branch"$'\t'"$pr_disp"$'\t'"$remote_disp"$'\t'"$clean"
+        if [[ "$onremote" == onremote ]]; then
+          rec_handles+=("$branch"); rec_rows+=("$row")
+        else
+          loc_handles+=("$branch"); loc_rows+=("$row")
         fi
         continue
       fi
@@ -151,8 +218,79 @@ main () {
       | [ .branch,
           (.is_main | tostring),
           (.commit.timestamp | tostring),
-          (if (.working_tree.staged or .working_tree.modified or .working_tree.untracked or .working_tree.renamed or .working_tree.deleted) then "dirty" else "clean" end)
+          (if (.working_tree.staged or .working_tree.modified or .working_tree.untracked or .working_tree.renamed or .working_tree.deleted) then "dirty" else "clean" end),
+          (if .remote and ((.remote.ahead // 1) == 0) then "onremote" else "local" end),
+          (.is_current | tostring),
+          .path
         ] | @tsv' <<<"$list_json")
+
+    # Detached worktrees (agent-*/wf_*) have no branch and no PR, so they never
+    # auto-remove; offer them in the checklist, removed by path.
+    if (( interactive )); then
+      local dpath dclean
+      while IFS=$'\t' read -r dpath dclean; do
+        loc_handles+=("$dpath")
+        loc_rows+=("${dpath:t}"$'\t'"detached"$'\t'"-"$'\t'"LOCAL-ONLY"$'\t'"$dclean")
+      done < <(jq -r '
+        .[]
+        | select(.kind == "worktree" and (.branch // "") == "" and (.is_main | not) and (.is_current | not))
+        | [ .path,
+            (if (.working_tree.staged or .working_tree.modified or .working_tree.untracked or .working_tree.renamed or .working_tree.deleted) then "dirty" else "clean" end)
+          ] | @tsv' <<<"$list_json")
+    fi
+  fi
+
+  # Interactive sweep: present the ambiguous remainder as a multi-select
+  # checklist. Selecting nothing (or declining the local-only confirm) removes
+  # nothing, so this doubles as a safe preview.
+  if (( interactive )); then
+    local -a handles=("${rec_handles[@]}" "${loc_handles[@]}")
+    local -a rows=("${rec_rows[@]}" "${loc_rows[@]}")
+    if (( ${#handles} > 0 )); then
+      local labels_str
+      labels_str=$(printf '%s\n' "${rows[@]}" | column -t -s $'\t')
+      local -a labels
+      labels=("${(@f)labels_str}")
+
+      # Map each aligned label back to its removal handle. Labels are unique
+      # because worktree dir names are.
+      local -A handle_of localonly_of
+      integer idx
+      for (( idx = 1; idx <= ${#labels}; idx++ )); do
+        handle_of[${labels[idx]}]=${handles[idx]}
+        [[ "${rows[idx]}" == *$'\t'LOCAL-ONLY$'\t'* ]] && localonly_of[${labels[idx]}]=1
+      done
+
+      local selected_str
+      selected_str=$(printf '%s\n' "${labels[@]}" \
+        | gum choose --no-limit --header "Select worktrees to remove (esc/none keeps all)")
+      local -a selected
+      selected=("${(@f)selected_str}")
+
+      integer sel_count=0 localonly_count=0
+      local lbl
+      for lbl in "${selected[@]}"; do
+        [[ -z "$lbl" ]] && continue
+        (( sel_count++ ))
+        [[ -n "${localonly_of[$lbl]:-}" ]] && (( localonly_count++ ))
+      done
+
+      # A local-only selection has no remote backup, so gate the whole batch
+      # behind an explicit confirm that names the at-risk count.
+      local do_remove=1
+      if (( localonly_count > 0 )); then
+        gum confirm "Remove $sel_count worktrees — $localonly_count have no remote copy?" || do_remove=0
+      fi
+
+      if (( do_remove )); then
+        for lbl in "${selected[@]}"; do
+          [[ -z "$lbl" ]] && continue
+          if wt remove --foreground --force --force-delete "${handle_of[$lbl]}" </dev/null >/dev/null 2>&1; then
+            (( worktrees++ ))
+          fi
+        done
+      fi
+    fi
   fi
 
   (( worktrees == 0 && branches == 0 )) && return


### PR DESCRIPTION
`wt prune` accumulated a backlog of worktrees it never removed. The forge pass ran `gh pr list --state merged` at gh's default limit of 30. With 495 merged PRs in this repo (and 854 in another I checked), any worktree whose PR merged outside that recent window stayed invisible and survived forever, even though it was fully merged. Squash-merges compound this: they leave local commits ahead of `main`, so the integration pass's patch-id match also misses them. Only the PR state proves they landed.

Everything past merged had no exit either: closed-but-not-merged PRs, pushed branches with no PR, and truly local-only checkouts all piled up with no way to clear them.

## Exact Per-Branch PR State

Replaces the capped bulk `merged` list with a per-surviving-branch `pr_state` lookup (`gh pr view`; glab mirrored but untested). The survivor loop already iterates the branches that outlived the integration pass, so the call count scales with that small, shrinking set rather than PR history.

The auto-remove rules are organized around recoverability. The question is whether the commits exist somewhere other than this local checkout:

- MERGED removes the worktree and branch regardless of dirty. The work landed, so the leftovers are cruft.
- CLOSED removes only when the tip is on a remote (recoverable), the tree is clean, and it is not the current worktree. Closed is a weaker signal than merged, so it gets the guard.
- Everything else falls through to the age pass, or to the interactive checklist under `-i`.

This runs in the normal and nightly (`wt all prune --before`) flows, so the merged backlog clears without interaction. A new `onremote` signal (a tracking remote exists and the local tip is not ahead of it) and `is_current` come from the same `wt list` jq extraction.

## Interactive Sweep (`-i` / `--interactive`)

For the genuinely-ambiguous remainder, `-i` presents a `gum choose --no-limit` checklist after the auto passes. It is standalone-only, refused under `WT_ALL` or a non-TTY stderr, since it cannot run inside the `wt all` fan-out. Candidates include detached `agent-*`/`wf_*` worktrees, removed by path. Rows are annotated `<dir> <branch|detached> <PR> <onremote|LOCAL-ONLY> <clean|dirty>` and sorted recoverable-first so `LOCAL-ONLY` lines stand out at the bottom. Any selected local-only entry gates the whole batch behind a `gum confirm` naming the no-remote-copy count. Selecting nothing (or declining) removes nothing, so the checklist doubles as a safe preview.

## Two Zsh Footguns Found While Testing

- The survivor loop originally read the worktree path into a variable named `path`, which is zsh's special array tied to `$PATH`. Declaring `local ... path` blanked `PATH`, so the process-substitution `jq` became "command not found" and the loop silently read nothing. The forge pass detected zero. Renamed to `wtpath`.
- Re-declaring an already-set `local` (`branch` is reused across both read loops) makes zsh echo `name=value` to stderr, which would corrupt the single summary line. Added `setopt typeset_silent`.

## Testing

Exercised end-to-end in this repo against live worktrees. A real prune covers clearing merged-but-missed worktrees whose PRs sit far outside the old limit-30 window, including squash-merges, plus removing a closed-but-on-remote-clean worktree while preserving an open-PR worktree and the current worktree. Under `-i` in a real terminal, coverage spans the recoverability annotations (`LOCAL-ONLY dirty` versus `onremote`), the escape/no-selection safe-preview path, and the local-only confirm gate driving an actual removal on accept. The mechanical contracts stay intact: `--dry-run` emits the one-line summary, the `WT_ALL` tab-separated output is unchanged, and `wt all prune` renders its table.

Out of scope, deliberately: cross-repo interactive (`wt all prune -i`), since the fan-out is non-interactive by design; and rewriting this bash prototype in another language.
