### PR TITLE
ci: clear stale openssl symlink and backup before bundle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,14 @@ jobs:
       run: sudo apt-get install -y zsh
     - name: Overwrite conflicting formulae
       if: ${{ runner.os == 'macOS' }}
-      run: brew link --overwrite openssl@3 || true
+      # The runner's stale bin/openssl points into the openssl@1.1 keg, and the
+      # cached Homebrew Backup dir holds a same-inode bin/openssl. Both survive
+      # the actions cache, so brew bundle's openssl@3 upgrade fails to back up
+      # and relink the symlink every run. Clear both, then relink openssl@3.
+      run: |
+        rm -f /opt/homebrew/bin/openssl
+        rm -rf ~/Library/Caches/Homebrew/Backup
+        brew link --overwrite openssl@3 || true
     - name: Print Homebrew configuration
       run: brew config
     - name: Cache mise installs


### PR DESCRIPTION
The macOS bootstrap job fails at `brew bundle` while upgrading `openssl@3` (3.6.2 to 3.6.3), which a Brewfile dependency pulls in:

```
same file: /opt/homebrew/bin/openssl and .../Homebrew/Backup/bin/openssl
Could not symlink bin/openssl ... is a symlink belonging to openssl@1.1
Upgrading openssl has failed!
`brew bundle` failed! 1 Brewfile dependency failed to install
```

Two pieces of runner state cause it, and both survive the actions Homebrew cache, so the failure repeats every run. The runner's `/opt/homebrew/bin/openssl` symlink points into the `openssl@1.1` keg, so Homebrew refuses to relink it for `openssl@3`. And the cached `~/Library/Caches/Homebrew/Backup` already holds a same-inode `bin/openssl`, so the upgrade's backup step hits `same file` before it even gets there.

The existing "Overwrite conflicting formulae" step ran `brew link --overwrite openssl@3`, which does not clear either. This removes the stale symlink and the poisoned backup first, then relinks `openssl@3` so the in-bundle upgrade can back up and replace the symlink cleanly.

Verified on this branch: the macOS bootstrap job now gets through `brew bundle`, including the `openssl@3` 3.6.3 upgrade that was failing.
