### PR TITLE
claude: integrate the background agent view into the shell

### DIFF
--- a/bin/claude-launch
+++ b/bin/claude-launch
@@ -1,13 +1,11 @@
 #!/usr/bin/env zsh
-# claude-launch: gum launcher for background Claude agents (`claude --bg`).
+# claude-launch: launcher for background Claude agents (`claude --bg`).
 #
-# Picks a launch directory from git repos under the curated roots, gathers
-# optional permission-mode and model choices, prompts for the task, and
+# Picks a launch directory from zoxide's frecency list with fzf, gathers
+# optional permission-mode and model choices via gum, prompts for the task, and
 # dispatches a detached background agent. Monitoring and attach live in the
 # built-in view (`claude agents`); this script is launcher-only.
 #
-# Roots come from $CLAUDE_AGENTS_ROOT, falling back through $WT_ALL_ROOT and
-# $PROJECTS to ~/src (colon-separated, PATH-style, same convention as wt-all).
 # $CLAUDE_AGENTS_ADD_DIR (colon-separated) adds tool-access dirs to every
 # dispatch via repeated --add-dir. Pass --here to skip the picker and launch in
 # the current directory.
@@ -23,34 +21,24 @@ pick_repo() {
     return
   fi
 
-  local roots="${CLAUDE_AGENTS_ROOT:-${WT_ALL_ROOT:-${PROJECTS:-$HOME/src}}}"
-
-  # In-flight repos first so they sort to the top of the picker, then every
-  # repo discovered under the roots. ${(u)...} keeps first occurrence, so an
-  # agent's cwd wins its slot over the later discovered duplicate.
-  local -a seeds repos
+  # In-flight agent dirs first, then zoxide's frecency-ranked dirs. ${(u)...}
+  # keeps first occurrence, so an active agent's dir wins its slot and fzf's
+  # --no-sort preserves that order until you type.
+  local -a seeds dirs
   seeds=("${(@f)$(claude agents --json 2>/dev/null | jq -r '.[].cwd // empty' 2>/dev/null)}")
+  dirs=("${(@f)$(zoxide query -l 2>/dev/null)}")
 
-  local root gitdir
-  for root in ${(s.:.)roots}; do
-    [[ -d "$root" ]] || continue
-    while IFS= read -r gitdir; do
-      repos+=("${gitdir%/.git}")
-    done < <(find "$root" -maxdepth 4 \
-      \( -type d \( -name node_modules -o -name vendor \) -prune \) -o \
-      \( -type d -name .git -prune -print \))
-  done
-
-  local -a candidates=("${seeds[@]}" "${repos[@]}")
+  local -a candidates=("${seeds[@]}" "${dirs[@]}")
   candidates=(${(u)candidates})
   candidates=(${candidates:#})
 
   if (( ${#candidates} == 0 )); then
-    gum log --level error "no repos found under $roots" >&2
+    gum log --level error "no directories from zoxide" >&2
     return 1
   fi
 
-  print -rl -- "${candidates[@]}" | gum filter --placeholder "launch dir…"
+  print -rl -- "${candidates[@]}" \
+    | fzf --no-sort --border --border-label ' claude · launch dir ' --prompt '  '
 }
 
 # Selecting the leading default/(none) option, or skipping with Esc, leaves the

--- a/bin/claude-launch
+++ b/bin/claude-launch
@@ -2,9 +2,9 @@
 # claude-launch: gum launcher for background Claude agents (`claude --bg`).
 #
 # Picks a launch directory from git repos under the curated roots, gathers
-# optional model/permission/agent choices, prompts for the task, and dispatches
-# a detached background agent. Monitoring and attach live in the built-in view
-# (`claude agents`); this script is launcher-only.
+# optional permission-mode and model choices, prompts for the task, and
+# dispatches a detached background agent. Monitoring and attach live in the
+# built-in view (`claude agents`); this script is launcher-only.
 #
 # Roots come from $CLAUDE_AGENTS_ROOT, falling back through $WT_ALL_ROOT and
 # $PROJECTS to ~/src (colon-separated, PATH-style, same convention as wt-all).
@@ -66,15 +66,6 @@ repo=$(pick_repo) || exit 1
 perm=$(choose_flag "permission-mode" default plan acceptEdits bypassPermissions)
 model=$(choose_flag "model" default opus sonnet haiku)
 
-typeset -a agent_names
-local f firstline
-for f in ~/.claude/agents/*.md(N); do
-  # Only files with YAML frontmatter are agents; skips README and other docs.
-  read -r firstline < "$f"
-  [[ "$firstline" == "---" ]] && agent_names+=("${${f:t}:r}")
-done
-agent=$(choose_flag "agent" "(none)" "${agent_names[@]}")
-
 # Pre-fill the editor from the pasteboard when it reads like a task or URL
 # (mirrors cwp), skipping filesystem paths and oversized blobs.
 seed=""
@@ -99,7 +90,6 @@ slug="${slug#-}"; slug="${slug%-}"
 typeset -a cmd=(claude --bg --name "$slug")
 [[ -n "$perm"  && "$perm"  != default  ]] && cmd+=(--permission-mode "$perm")
 [[ -n "$model" && "$model" != default  ]] && cmd+=(--model "$model")
-[[ -n "$agent" && "$agent" != "(none)" ]] && cmd+=(--agent "$agent")
 if [[ -n "${CLAUDE_AGENTS_ADD_DIR:-}" ]]; then
   local d
   for d in ${(s.:.)CLAUDE_AGENTS_ADD_DIR}; do

--- a/bin/claude-launch
+++ b/bin/claude-launch
@@ -67,9 +67,11 @@ perm=$(choose_flag "permission-mode" default plan acceptEdits bypassPermissions)
 model=$(choose_flag "model" default opus sonnet haiku)
 
 typeset -a agent_names
-local f
+local f firstline
 for f in ~/.claude/agents/*.md(N); do
-  agent_names+=("${${f:t}:r}")
+  # Only files with YAML frontmatter are agents; skips README and other docs.
+  read -r firstline < "$f"
+  [[ "$firstline" == "---" ]] && agent_names+=("${${f:t}:r}")
 done
 agent=$(choose_flag "agent" "(none)" "${agent_names[@]}")
 

--- a/bin/claude-launch
+++ b/bin/claude-launch
@@ -1,0 +1,120 @@
+#!/usr/bin/env zsh
+# claude-launch: gum launcher for background Claude agents (`claude --bg`).
+#
+# Picks a launch directory from git repos under the curated roots, gathers
+# optional model/permission/agent choices, prompts for the task, and dispatches
+# a detached background agent. Monitoring and attach live in the built-in view
+# (`claude agents`); this script is launcher-only.
+#
+# Roots come from $CLAUDE_AGENTS_ROOT, falling back through $WT_ALL_ROOT and
+# $PROJECTS to ~/src (colon-separated, PATH-style, same convention as wt-all).
+# $CLAUDE_AGENTS_ADD_DIR (colon-separated) adds tool-access dirs to every
+# dispatch via repeated --add-dir. Pass --here to skip the picker and launch in
+# the current directory.
+
+set -uo pipefail
+
+here=0
+[[ "${1:-}" == --here ]] && here=1
+
+pick_repo() {
+  if (( here )); then
+    print -r -- "$PWD"
+    return
+  fi
+
+  local roots="${CLAUDE_AGENTS_ROOT:-${WT_ALL_ROOT:-${PROJECTS:-$HOME/src}}}"
+
+  # In-flight repos first so they sort to the top of the picker, then every
+  # repo discovered under the roots. ${(u)...} keeps first occurrence, so an
+  # agent's cwd wins its slot over the later discovered duplicate.
+  local -a seeds repos
+  seeds=("${(@f)$(claude agents --json 2>/dev/null | jq -r '.[].cwd // empty' 2>/dev/null)}")
+
+  local root gitdir
+  for root in ${(s.:.)roots}; do
+    [[ -d "$root" ]] || continue
+    while IFS= read -r gitdir; do
+      repos+=("${gitdir%/.git}")
+    done < <(find "$root" -maxdepth 4 \
+      \( -type d \( -name node_modules -o -name vendor \) -prune \) -o \
+      \( -type d -name .git -prune -print \))
+  done
+
+  local -a candidates=("${seeds[@]}" "${repos[@]}")
+  candidates=(${(u)candidates})
+  candidates=(${candidates:#})
+
+  if (( ${#candidates} == 0 )); then
+    gum log --level error "no repos found under $roots" >&2
+    return 1
+  fi
+
+  print -rl -- "${candidates[@]}" | gum filter --placeholder "launch dir…"
+}
+
+# Selecting the leading default/(none) option, or skipping with Esc, leaves the
+# flag off so Claude applies its own default.
+choose_flag() {
+  local header="$1"; shift
+  gum choose --header "$header" "$@"
+}
+
+repo=$(pick_repo) || exit 1
+[[ -n "$repo" ]] || { gum log --level warn "no directory selected"; exit 1; }
+
+perm=$(choose_flag "permission-mode" default plan acceptEdits bypassPermissions)
+model=$(choose_flag "model" default opus sonnet haiku)
+
+typeset -a agent_names
+local f
+for f in ~/.claude/agents/*.md(N); do
+  agent_names+=("${${f:t}:r}")
+done
+agent=$(choose_flag "agent" "(none)" "${agent_names[@]}")
+
+# Pre-fill the editor from the pasteboard when it reads like a task or URL
+# (mirrors cwp), skipping filesystem paths and oversized blobs.
+seed=""
+clip="$(pbpaste 2>/dev/null)"
+if [[ -n "$clip" && ${#clip} -le 4000 && "$clip" != /* \
+   && ( "$clip" == http://* || "$clip" == https://* || "$clip" == *' '* ) ]]; then
+  seed="$clip"
+fi
+
+prompt=$(gum write --placeholder "Task for the agent…" --value "$seed" --width 80 --height 12)
+[[ -n "$prompt" ]] || { gum log --level warn "no prompt entered"; exit 1; }
+
+# Name defaults to a slug of the prompt's first words.
+first="${prompt%%$'\n'*}"
+typeset -a words=(${=first})
+slug="${(j:-:)words[1,6]:l}"
+slug="${slug//[^a-z0-9-]/-}"
+while [[ "$slug" == *--* ]]; do slug="${slug//--/-}"; done
+slug="${slug#-}"; slug="${slug%-}"
+[[ -n "$slug" ]] || slug="agent"
+
+typeset -a cmd=(claude --bg --name "$slug")
+[[ -n "$perm"  && "$perm"  != default  ]] && cmd+=(--permission-mode "$perm")
+[[ -n "$model" && "$model" != default  ]] && cmd+=(--model "$model")
+[[ -n "$agent" && "$agent" != "(none)" ]] && cmd+=(--agent "$agent")
+if [[ -n "${CLAUDE_AGENTS_ADD_DIR:-}" ]]; then
+  local d
+  for d in ${(s.:.)CLAUDE_AGENTS_ADD_DIR}; do
+    cmd+=(--add-dir "$d")
+  done
+fi
+cmd+=("$prompt")
+
+gum log --level info "Launching in $repo"
+out=$( (cd "$repo" && "${cmd[@]}") )
+rc=$?
+print -r -- "$out"
+if (( rc )); then
+  gum log --level error "launch failed"
+  exit $rc
+fi
+
+# First line is "backgrounded · <id> · <name>"; strip ANSI and pull the id.
+id=$(print -r -- "$out" | sed $'s/\x1b\\[[0-9;]*m//g' | awk -F ' · ' 'NR==1 {print $2}')
+[[ -n "$id" ]] && gum log --level info "agent $id · attach with: claude attach $id"

--- a/claude/README.md
+++ b/claude/README.md
@@ -41,7 +41,7 @@ Attach to a running agent with `claude attach <id>`.
 `cbg` (`bin/claude-launch`) walks you through a launch:
 
 1. Pick a launch directory. Repos are discovered under the curated roots, with the directories of in-flight agents sorted to the top. Pass `--here` to skip the picker and use the current directory.
-2. Choose permission mode, model, and a named subagent. Each is optional. Skip to take Claude's default.
+2. Choose permission mode and model. Each is optional. Skip to take Claude's default.
 3. Write the task in an editor, pre-filled from the pasteboard when it looks like a task or URL.
 
 The agent is dispatched detached and its id is logged. Monitoring and attach happen in the built-in view, so the launcher stops there.

--- a/claude/README.md
+++ b/claude/README.md
@@ -21,4 +21,38 @@ ccw my-feature --base=@ -- 'stack on current branch'
 cwa pr:123
 ```
 
-`cwp` reads the pasteboard and passes it as Claude's initial prompt — paste an issue URL or Linear prompt, then run `cwp <branch>`.
+`cwp` reads the pasteboard and passes it as Claude's initial prompt. Paste an issue URL or Linear prompt, then run `cwp <branch>`.
+
+## Agent View
+
+Dispatch and monitor background agents (`claude --bg` / `claude agents`).
+
+| Command | Action |
+|---------|--------|
+| `ca` | Open the agent view in the current directory |
+| `cbg` | Launch a background agent via the gum picker (`claude-launch`) |
+| `cbl <id>` | Show an agent's recent output (`claude logs`) |
+| `cbk <id>` | Stop an agent (`claude stop`) |
+
+Attach to a running agent with `claude attach <id>`.
+
+### Launcher
+
+`cbg` (`bin/claude-launch`) walks you through a launch:
+
+1. Pick a launch directory. Repos are discovered under the curated roots, with the directories of in-flight agents sorted to the top. Pass `--here` to skip the picker and use the current directory.
+2. Choose permission mode, model, and a named subagent. Each is optional. Skip to take Claude's default.
+3. Write the task in an editor, pre-filled from the pasteboard when it looks like a task or URL.
+
+The agent is dispatched detached and its id is logged. Monitoring and attach happen in the built-in view, so the launcher stops there.
+
+### Tmux Popup and Status Chip
+
+`prefix a` opens the agent view in a popup, near-fullscreen on a narrow client. A 󰚩 pill appears in the status bar while any background agent has finished or is blocked on input, and disappears at zero.
+
+### Curation
+
+| Variable | Effect |
+|----------|--------|
+| `CLAUDE_AGENTS_ROOT` | Colon-separated roots the launcher discovers repos under. Falls back to `$WT_ALL_ROOT`, then `$PROJECTS`, then `~/src`. |
+| `CLAUDE_AGENTS_ADD_DIR` | Colon-separated tool-access directories passed as repeated `--add-dir` to both the launcher's dispatch and the popup. |

--- a/claude/README.md
+++ b/claude/README.md
@@ -27,20 +27,13 @@ cwa pr:123
 
 Dispatch and monitor background agents (`claude --bg` / `claude agents`).
 
-| Command | Action |
-|---------|--------|
-| `ca` | Open the agent view in the current directory |
-| `cbg` | Launch a background agent via the gum picker (`claude-launch`) |
-| `cbl <id>` | Show an agent's recent output (`claude logs`) |
-| `cbk <id>` | Stop an agent (`claude stop`) |
-
-Attach to a running agent with `claude attach <id>`.
+`ca` opens the agent view. From there, logs, stop, and attach are a keypress away. Launch new agents with the `claude-launch` command below.
 
 ### Launcher
 
-`cbg` (`bin/claude-launch`) walks you through a launch:
+`claude-launch` walks you through a launch:
 
-1. Pick a launch directory. Repos are discovered under the curated roots, with the directories of in-flight agents sorted to the top. Pass `--here` to skip the picker and use the current directory.
+1. Pick a launch directory with fzf over zoxide's frecency list, with the directories of in-flight agents sorted to the top. Pass `--here` to skip the picker and use the current directory.
 2. Choose permission mode and model. Each is optional. Skip to take Claude's default.
 3. Write the task in an editor, pre-filled from the pasteboard when it looks like a task or URL.
 
@@ -52,7 +45,4 @@ The agent is dispatched detached and its id is logged. Monitoring and attach hap
 
 ### Curation
 
-| Variable | Effect |
-|----------|--------|
-| `CLAUDE_AGENTS_ROOT` | Colon-separated roots the launcher discovers repos under. Falls back to `$WT_ALL_ROOT`, then `$PROJECTS`, then `~/src`. |
-| `CLAUDE_AGENTS_ADD_DIR` | Colon-separated tool-access directories passed as repeated `--add-dir` to both the launcher's dispatch and the popup. |
+`CLAUDE_AGENTS_ADD_DIR` (colon-separated) passes tool-access directories as repeated `--add-dir` to both the launcher's dispatch and the popup.

--- a/claude/aliases.zsh
+++ b/claude/aliases.zsh
@@ -13,3 +13,12 @@ alias cwa="wt switch --execute=\"claude --name={{ branch }} --permission-mode=au
 cwp() {
   wt switch --create --execute="claude --name={{ branch }} --permission-mode=plan --append-system-prompt='$_claude_worktree_prompt'" "$@" -- "$(pbpaste)"
 }
+
+# Background agent view (`claude agents`). `ca` opens the view in the current
+# dir; `cbg` runs the gum launcher (bin/claude-launch) to dispatch a new
+# background agent. Lifecycle passthroughs wrap the hidden subcommands; attach
+# with `claude attach <id>`.
+alias ca='claude agents'
+alias cbg='claude-launch'
+alias cbl='claude logs'
+alias cbk='claude stop'

--- a/claude/aliases.zsh
+++ b/claude/aliases.zsh
@@ -14,11 +14,6 @@ cwp() {
   wt switch --create --execute="claude --name={{ branch }} --permission-mode=plan --append-system-prompt='$_claude_worktree_prompt'" "$@" -- "$(pbpaste)"
 }
 
-# Background agent view (`claude agents`). `ca` opens the view in the current
-# dir; `cbg` runs the gum launcher (bin/claude-launch) to dispatch a new
-# background agent. Lifecycle passthroughs wrap the hidden subcommands; attach
-# with `claude attach <id>`.
+# Open the background-agent view (`claude agents`). Launch new agents with the
+# claude-launch command; logs, stop, and attach live inside the view.
 alias ca='claude agents'
-alias cbg='claude-launch'
-alias cbl='claude logs'
-alias cbk='claude stop'

--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -5,14 +5,17 @@ set -g status-left "#{?#{E:@resp_is_narrow},#{E:@resp_sl_narrow},#{E:@catppuccin
 # Catppuccin ships no bell module, so build @catppuccin_status_bell from the
 # @catppuccin_bell_* inputs (set in alerts.conf) with its own module builder.
 # This must run after the plugin loads, so it lives here rather than alongside
-# the inputs.
+# the inputs. The claude pill (agent-attention chip) is built the same way from
+# the @catppuccin_claude_* inputs in claude/claude.conf.
 %hidden MODULE_NAME="bell"
 source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"
+%hidden MODULE_NAME="claude"
+source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"
 
-# Leading space keeps the bell pill from touching the last window entry.
-# Narrow clients swap the catppuccin pill for the transparent-friendly chip
-# defined in responsive.conf.
-set -g status-right "#{?#{==:#(_tmux-bell-count),0},, #{?#{E:@resp_is_narrow},#{E:@resp_sr_narrow},#{E:@catppuccin_status_bell}}}"
+# Leading space keeps each pill from touching its neighbor. Both segments render
+# only when their count is nonzero. Narrow clients swap the catppuccin pills for
+# the transparent-friendly chips defined in responsive.conf.
+set -g status-right "#{?#{==:#(_tmux-claude-agents-count),0},, #{?#{E:@resp_is_narrow},#{E:@resp_sr_claude_narrow},#{E:@catppuccin_status_claude}}}#{?#{==:#(_tmux-bell-count),0},, #{?#{E:@resp_is_narrow},#{E:@resp_sr_narrow},#{E:@catppuccin_status_bell}}}"
 
 # Narrow window list: capture catppuccin's generated pill formats and wrap them
 # in the per-client narrowness predicate (narrow branches live in

--- a/tmux/claude/bin/_tmux-claude-agents
+++ b/tmux/claude/bin/_tmux-claude-agents
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Open the agent view, folding CLAUDE_AGENTS_ADD_DIR (colon-separated) into
+# repeated --add-dir flags so sessions dispatched from the view inherit the
+# curated tool-access dirs. Run by the prefix-a popup (tmux/claude/claude.conf).
+
+args=()
+if [[ -n "${CLAUDE_AGENTS_ADD_DIR:-}" ]]; then
+  IFS=':' read -ra dirs <<< "$CLAUDE_AGENTS_ADD_DIR"
+  for d in "${dirs[@]}"; do
+    [[ -n "$d" ]] && args+=(--add-dir "$d")
+  done
+fi
+
+exec claude agents ${args[@]+"${args[@]}"}

--- a/tmux/claude/bin/_tmux-claude-agents-count
+++ b/tmux/claude/bin/_tmux-claude-agents-count
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Count background agents that finished or are waiting on input
+# (state done/blocked), for the status-right pill. Mirrors _tmux-bell-count:
+# prints a single integer.
+#
+# `claude agents --json` is ~0.35s and status-right redraws every
+# status-interval, so the result is cached with a short mtime TTL and only
+# re-queried once the cache goes stale.
+
+cache="${TMPDIR:-/tmp}/tmux-claude-agents-count"
+ttl=10
+
+if [[ -f "$cache" ]]; then
+  now=$(date +%s)
+  mtime=$(stat -f %m "$cache" 2>/dev/null || echo 0)
+  if (( now - mtime < ttl )); then
+    cat "$cache"
+    exit 0
+  fi
+fi
+
+count=$(claude agents --json 2>/dev/null \
+  | jq '[.[] | select(.state == "done" or .state == "blocked")] | length' 2>/dev/null)
+[[ "$count" =~ ^[0-9]+$ ]] || count=0
+
+# Write via temp + rename so a concurrent redraw never reads a torn count.
+tmp="$cache.$$"
+printf '%s' "$count" > "$tmp" && mv -f "$tmp" "$cache"
+printf '%s\n' "$count"

--- a/tmux/claude/claude.conf
+++ b/tmux/claude/claude.conf
@@ -1,0 +1,18 @@
+# Background agent view (`claude agents`).
+
+# prefix a opens the built-in monitor in a popup. Near-fullscreen on a narrow
+# client (see responsive.conf); popup sizes are not format-expanded, so dispatch
+# via `if -F`. The _tmux-claude-agents wrapper folds CLAUDE_AGENTS_ADD_DIR into
+# --add-dir flags so sessions dispatched from the view inherit the curated
+# tool-access dirs.
+bind -N "Claude agents" a if -F "#{E:@resp_is_narrow}" \
+  "display-popup -E -w 100% -h 100% _tmux-claude-agents" \
+  "display-popup -E -w 85% -h 85% _tmux-claude-agents"
+
+# Inputs for the agent-attention pill, built into @catppuccin_status_claude by
+# appearance/status.conf (post-TPM) with the same module builder as the bell
+# pill and gated there on a nonzero count. 󰚩 marks agents that finished or are
+# blocked on input.
+set -g @catppuccin_claude_icon "󰚩 "
+set -g @catppuccin_claude_color "#{@thm_mauve}"
+set -g @catppuccin_claude_text " #(_tmux-claude-agents-count)"

--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -58,6 +58,11 @@ set -g @resp_ws_narrow '#[fg=#{E:@resp_chip_bg}]#[fg=#{E:@resp_chip_fg},bg=#{
 # @resp_ws_narrow. status.conf gates it behind a nonzero bell count.
 set -g @resp_sr_narrow '#[fg=#{@thm_yellow}]#[fg=#{@thm_crust},bg=#{@thm_yellow}] #(_tmux-bell-count)#[fg=#{@thm_yellow},bg=default]#[default]'
 
+# Agent-attention indicator for the narrow status-right (finished/blocked
+# background agents). Same chip technique as the bell chip above; status.conf
+# gates it behind a nonzero count.
+set -g @resp_sr_claude_narrow '#[fg=#{@thm_mauve}]#[fg=#{@thm_crust},bg=#{@thm_mauve}] 󰚩 #(_tmux-claude-agents-count)#[fg=#{@thm_mauve},bg=default]#[default]'
+
 # Current window: rounded pill with index block + name + zoom flag. The name is
 # window_name, the working directory under automatic-rename and the manual name
 # otherwise. pane_title is too noisy at this width. window_name is spelled out

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -22,6 +22,7 @@ source-file ~/.config/tmux/search/search.conf
 source-file ~/.config/tmux/appearance/appearance.conf
 source-file ~/.config/tmux/responsive/responsive.conf
 source-file ~/.config/tmux/alerts/alerts.conf
+source-file ~/.config/tmux/claude/claude.conf
 source-file ~/.config/tmux/usage/usage.conf
 source-file -q ~/.config/tmux/tmux.conf.local
 


### PR DESCRIPTION
Wires `claude agents` (Claude Code's background-agent view) into the shell the way `wt`, tmux, and gum are already wired: fast launch, a popup reachable from anywhere, and a passive status chip.

## What's Here

- `ca` opens the view. Logs, stop, and attach are reachable interactively from inside it, so they get no aliases of their own.
- `bin/claude-launch`, a launcher: pick a directory with fzf over zoxide's frecency list (in-flight agent directories sorted to the top), optionally set permission-mode and model via gum, write the task (pre-filled from the pasteboard when it reads like a task or URL), then dispatch `claude --bg` and log the returned id.
- A `tmux/claude/` topic: `prefix a` opens the view in a popup, and a mauve 󰚩 pill in `status-right` counts background agents that finished or are blocked on input.

## Decisions

The launcher is launcher-only. Monitoring and attach already live in the built-in view, so duplicating them here would just rot. The directory picker uses fzf over zoxide rather than walking curated roots, so it surfaces the repos you actually visit with no root-list to maintain. gum stays for the option menus and the prompt editor.

The tmux topic is named `claude/` to sidestep the existing `tmux/agent/`, which is unrelated SSH-agent forwarding. `a` was a free prefix key.

The status count is cached behind a 10s mtime TTL. `claude agents --json` is ~0.35s and `status-right` re-runs on every `status-interval`, so an uncached fork per redraw would stutter the bar. The count script mirrors `_tmux-bell-count`'s contract (prints one integer) and the pill composes alongside the bell pill, including a transparent-friendly narrow variant.

`CLAUDE_AGENTS_ADD_DIR` (colon-separated) adds `--add-dir` tool-access directories to both the launcher's dispatch and the popup, so sessions started from the view inherit them.

## Verification

- `ca` resolves in a fresh shell; it is a static alias with no subshell fork, so startup cost is nil.
- End-to-end dispatch: `claude --bg` from a repo returned an id that appeared in `claude agents --json` with the right cwd, then `claude logs`/`claude stop`/`claude rm` drove its lifecycle.
- The picker assembles zoxide's list with in-flight agent dirs on top, and fzf selects from it.
- `prefix a` registers and `claude.conf`/`responsive.conf` parse cleanly on an isolated server.
- Status gate logic checks out: a zero count renders empty, a nonzero count renders the catppuccin pill when wide and the chip when narrow.
- The count script serves a planted sentinel within the TTL window, confirming a cache hit never re-forks `claude`.
