### PR TITLE
tmux: make theme switching race-free via catppuccin reset

### DIFF
--- a/theme/bin/theme-sync-tmux
+++ b/theme/bin/theme-sync-tmux
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # Apply the active catppuccin flavor to a running tmux server.
 # Self-gates: exits 0 without work if the server is already on the right flavor,
-# or if no tmux server is running.
+# or if no tmux server (or no catppuccin plugin) is present.
+#
+# The retheme itself is a single tmux invocation sourcing retheme.conf, so it
+# executes as one contiguous command block in the server and serializes with
+# the client theme hooks (tmux/appearance/appearance.conf) instead of
+# interleaving with them.
 set -euo pipefail
 
 bin_dir="$(cd "$(dirname "$0")" && pwd)"
@@ -10,39 +15,12 @@ flavor="$("$bin_dir/theme-flavor")"
 # No tmux server, nothing to sync. Next `tmux` will pick up the flavor at startup.
 tmux list-sessions >/dev/null 2>&1 || exit 0
 
+# Plugin not installed yet (fresh bootstrap): nothing to retheme.
+plugin_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins/tmux"
+[[ -f "$plugin_dir/catppuccin_tmux.conf" ]] || exit 0
+
 current=$(tmux show -gv @catppuccin_flavor 2>/dev/null || echo "")
 [[ "$current" == "$flavor" ]] && exit 0
 
-plugin_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins/tmux"
-tmux_config="${XDG_CONFIG_HOME:-$HOME/.config}/tmux"
-
-for f in "$plugin_dir/catppuccin_options_tmux.conf" \
-         "$plugin_dir/catppuccin_tmux.conf"; do
-  if [[ ! -f "$f" ]]; then
-    echo "theme-sync-tmux: missing $f" >&2
-    exit 1
-  fi
-done
-
-# Unset @thm_* and @catppuccin_* variables so -ogq (only-if-unset) defaults can re-apply
-while IFS= read -r var; do
-  tmux set -gu "$var"
-done < <(tmux show -g | awk '/^@(thm_|catppuccin_)/{print $1}')
-
-# Unset @_ctp_* variables (not matched by the pattern above)
-tmux set -gu @_ctp_status_bg 2>/dev/null || true
-
-tmux set -g @catppuccin_flavor "$flavor"
-
-# appearance.conf must be sourced before the catppuccin confs, matching startup
-# order in tmux.conf. catppuccin_tmux.conf reads @catppuccin_window_status_style
-# (set to "rounded" by appearance.conf) when it builds the window-status formats.
-# Sourcing appearance.conf afterward leaves the style unset during the rebuild, so
-# the defaults apply and window pills render with square "basic" separators.
-tmux source-file "$tmux_config/appearance/appearance.conf"
-tmux source-file "$plugin_dir/catppuccin_options_tmux.conf"
-tmux source-file "$plugin_dir/catppuccin_tmux.conf"
-tmux source-file "$tmux_config/alerts/alerts.conf"
-
-# Re-evaluate post-TPM status (catppuccin module variables changed)
-tmux source-file "$tmux_config/appearance/status.conf"
+exec tmux set -g @catppuccin_flavor "$flavor" \; \
+  source-file "${XDG_CONFIG_HOME:-$HOME/.config}/tmux/appearance/retheme.conf"

--- a/tmux/appearance/appearance.conf
+++ b/tmux/appearance/appearance.conf
@@ -30,10 +30,23 @@ set -g @catppuccin_window_text " #{E:@resp_winname}"
 set -g @catppuccin_window_current_text " #{E:@resp_winname}"
 
 # Sync catppuccin flavor when the terminal reports a theme switch (OSC 2031),
-# which fires only on an actual light/dark flip. Fallback to the
-# watch-theme-change (dark-notify) daemon. theme-sync-tmux self-gates either way.
-set-hook -g client-dark-theme  'run-shell -b "$ZSH/theme/bin/theme-sync-tmux"'
-set-hook -g client-light-theme 'run-shell -b "$ZSH/theme/bin/theme-sync-tmux"'
+# which fires only on an actual light/dark flip, once per reporting client.
+# The retheme runs inline as tmux commands so concurrent triggers (multiple
+# clients, the dark-notify watcher) serialize in the server; the `if -F` gate
+# makes redundant fires no-ops. Flips with no reporting client attached are
+# covered by the watch-theme-change (dark-notify) daemon via theme-sync-tmux.
+set-hook -g client-dark-theme {
+  if -F '#{!=:#{@catppuccin_flavor},mocha}' {
+    set -g @catppuccin_flavor "mocha"
+    source-file ~/.config/tmux/appearance/retheme.conf
+  }
+}
+set-hook -g client-light-theme {
+  if -F '#{!=:#{@catppuccin_flavor},latte}' {
+    set -g @catppuccin_flavor "latte"
+    source-file ~/.config/tmux/appearance/retheme.conf
+  }
+}
 
 # Status bar
 set -g status-position bottom

--- a/tmux/appearance/retheme.conf
+++ b/tmux/appearance/retheme.conf
@@ -1,0 +1,26 @@
+# Re-apply the active catppuccin flavor to a running server. The caller sets
+# @catppuccin_flavor first, then sources this file.
+#
+# Everything here is a tmux config command, so the whole sequence executes as
+# one contiguous block inside the server. Concurrent triggers (per-client
+# theme hooks, the dark-notify watcher) serialize instead of interleaving.
+# Interleaved re-themes corrupted state in two ways: status.conf's capture
+# guard is evaluated at parse time but the capture executes later, letting the
+# window-status wrapper capture itself (window tabs then render as an empty
+# string), and a concurrent unset of @catppuccin_flavor made the plugin's
+# palette source-file error out mid-retheme.
+#
+# @catppuccin_reset is the plugin's supported way to switch flavors on a live
+# server: catppuccin_options_tmux.conf unsets the palette and option variables
+# so the new flavor's -o defaults re-apply.
+set -g @catppuccin_reset "true"
+source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/catppuccin_options_tmux.conf"
+
+# The reset also wipes our custom @catppuccin_* inputs; re-apply them before
+# the plugin builds the window formats from them.
+source-file ~/.config/tmux/appearance/appearance.conf
+source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/catppuccin_tmux.conf"
+source-file ~/.config/tmux/alerts/alerts.conf
+
+# Rebuild the post-plugin status wiring (window-status wrappers, bell module).
+source-file ~/.config/tmux/appearance/status.conf

--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -7,6 +7,11 @@ set -g status-left "#{?#{E:@resp_is_narrow},#{E:@resp_sl_narrow},#{E:@catppuccin
 # This must run after the plugin loads, so it lives here rather than alongside
 # the inputs.
 %hidden MODULE_NAME="bell"
+# The builder sets these with -o and bakes the palette's hex values, and
+# @catppuccin_reset doesn't cover module variables, so a re-theme would keep
+# the old flavor's colors. Unset them so every build re-bakes.
+set -Ugq @catppuccin_status_bell_icon_fg
+set -Ugq @catppuccin_status_bell_text_fg
 source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"
 
 # Leading space keeps the bell pill from touching the last window entry.


### PR DESCRIPTION
Fixes the window tabs occasionally vanishing from the status bar after a light/dark flip, until a manual reload brought them back.

## Root Cause

A theme flip runs `theme-sync-tmux` concurrently: once from the dark-notify watcher and once per theme-reporting client via the `client-dark-theme`/`client-light-theme` hooks. Each run made ~40 serial `tmux` calls (a glob unset loop plus five `source-file`s), so two runs interleaved freely. Two distinct corruptions fall out:

- `status.conf` guards its capture of catppuccin's window formats with a `%if`, but tmux evaluates `%if` at parse time while the guarded `set` executes later. A concurrent run can install the responsive wrapper in that gap, so the capture stores the wrapper into `@resp_wsf_wide`. That self-reference renders every window tab as an empty string. That's the disappearing-tabs state, and it persists until the next flip or reload recaptures a clean format.
- One run's unset loop removes `@catppuccin_flavor` while another is sourcing `catppuccin_tmux.conf`. The palette path expands to `catppuccin__tmux.conf`, the source errors, and `set -e` kills that run mid-retheme, leaving a half-themed server (the stale-colors variant of the glitch).

Both reproduce on a throwaway `tmux -L` server: racing two copies of the old flow corrupts the capture within a few flips, and the rendered tab expands to `[]`.

## Fix

The retheme is now a single contiguous block of tmux config commands (`tmux/appearance/retheme.conf`). Contiguous blocks serialize inside the server, so concurrent triggers queue instead of interleaving:

- The client theme hooks set the flavor and source `retheme.conf` directly, gated by `if -F` so redundant per-client fires are no-ops. No external process is involved.
- `theme-sync-tmux` shrinks to a self-gate plus one `tmux set ... \; source-file retheme.conf` invocation, kept for flips that happen while no theme-reporting client is attached (dark-notify path) and for boot-time correction.
- The hand-rolled unset loop is gone. `retheme.conf` uses the plugin's own `@catppuccin_reset`, the documented mechanism for switching flavors on a live server. The plugin's reset list skips the status-module variables it bakes with `-o`, so `status.conf` unsets the two bell-module colors before rebuilding that module; everything else we set survives the reset as render-time `@thm_*` references or gets re-applied by re-sourcing `appearance.conf`.

This also came out of a look at upstreaming the rest of the theme sync stack: nvim already rides catppuccin's `flavour = "auto"`, and delta/fzf/btop have no upstream mechanism that can select catppuccin flavors, so their small atomic sync scripts stay. tmux was the only racy piece.

## Testing

On a throwaway `tmux -L themelab` server booted from this config (paths rewritten to a temp copy, `theme-flavor` stubbed): a single retheme flips the palette, re-captures the wide window formats with the new flavor's baked colors, and re-bakes the bell module. A race gauntlet of 10 alternating flips, each firing three concurrent triggers (two `theme-sync-tmux` runs plus a hook-body invocation), ends every round with the correct palette, an intact wrapper, a non-self-referential capture, and a non-empty rendered tab. A lone re-source of `status.conf` remains idempotent. The live server was left untouched; this takes effect after merge and `dotfiles sync`.
