### PR TITLE
tmux: serialize rethemes with a lock, fix bell module build

### DIFF
--- a/theme/bin/theme-sync-tmux
+++ b/theme/bin/theme-sync-tmux
@@ -3,10 +3,12 @@
 # Self-gates: exits 0 without work if the server is already on the right flavor,
 # or if no tmux server (or no catppuccin plugin) is present.
 #
-# The retheme itself is a single tmux invocation sourcing retheme.conf, so it
-# executes as one contiguous command block in the server and serializes with
-# the client theme hooks (tmux/appearance/appearance.conf) instead of
-# interleaving with them.
+# Every retheme trigger funnels through this script (the client theme hooks,
+# the dark-notify watcher, server boot), and a filesystem lock serializes
+# them: tmux interleaves commands from concurrent clients, so unserialized
+# re-themes corrupt the window formats mid-build (the plugin assembles them
+# with a chain of appends) or capture the window-status wrapper into itself,
+# which renders every window tab empty.
 set -euo pipefail
 
 bin_dir="$(cd "$(dirname "$0")" && pwd)"
@@ -15,12 +17,42 @@ flavor="$("$bin_dir/theme-flavor")"
 # No tmux server, nothing to sync. Next `tmux` will pick up the flavor at startup.
 tmux list-sessions >/dev/null 2>&1 || exit 0
 
-# Plugin not installed yet (fresh bootstrap): nothing to retheme.
+# Plugin not installed yet (fresh bootstrap): nothing to retheme. A partial
+# checkout (one conf present, the other missing) would half-apply the theme
+# and then wedge the flavor gate below, so that case stays a loud failure.
 plugin_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins/tmux"
-[[ -f "$plugin_dir/catppuccin_tmux.conf" ]] || exit 0
+plugin_confs=("$plugin_dir/catppuccin_options_tmux.conf" "$plugin_dir/catppuccin_tmux.conf")
+[[ -f "${plugin_confs[0]}" || -f "${plugin_confs[1]}" ]] || exit 0
+for f in "${plugin_confs[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    echo "theme-sync-tmux: missing $f" >&2
+    exit 1
+  fi
+done
 
+# mkdir is the portable atomic lock. A retheme takes well under a second, so
+# a holder that outlives the wait is dead or wedged; steal its lock.
+lock="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/theme-sync-tmux.lock"
+mkdir -p "$(dirname "$lock")"
+acquire() {
+  local _
+  for _ in $(seq 1 100); do
+    mkdir "$lock" 2>/dev/null && return 0
+    sleep 0.1
+  done
+  return 1
+}
+if ! acquire; then
+  rmdir "$lock" 2>/dev/null || true
+  mkdir "$lock" 2>/dev/null || exit 1
+fi
+trap 'rmdir "$lock" 2>/dev/null' EXIT
+
+# Gate under the lock so queued triggers see the winner's flavor and no-op.
+# Read globally on purpose: a stray session-scoped @catppuccin_flavor would
+# shadow a format-based `if -F` gate.
 current=$(tmux show -gv @catppuccin_flavor 2>/dev/null || echo "")
 [[ "$current" == "$flavor" ]] && exit 0
 
-exec tmux set -g @catppuccin_flavor "$flavor" \; \
+tmux set -g @catppuccin_flavor "$flavor" \; \
   source-file "${XDG_CONFIG_HOME:-$HOME/.config}/tmux/appearance/retheme.conf"

--- a/tmux/appearance/appearance.conf
+++ b/tmux/appearance/appearance.conf
@@ -31,22 +31,15 @@ set -g @catppuccin_window_current_text " #{E:@resp_winname}"
 
 # Sync catppuccin flavor when the terminal reports a theme switch (OSC 2031),
 # which fires only on an actual light/dark flip, once per reporting client.
-# The retheme runs inline as tmux commands so concurrent triggers (multiple
-# clients, the dark-notify watcher) serialize in the server; the `if -F` gate
-# makes redundant fires no-ops. Flips with no reporting client attached are
-# covered by the watch-theme-change (dark-notify) daemon via theme-sync-tmux.
-set-hook -g client-dark-theme {
-  if -F '#{!=:#{@catppuccin_flavor},mocha}' {
-    set -g @catppuccin_flavor "mocha"
-    source-file ~/.config/tmux/appearance/retheme.conf
-  }
-}
-set-hook -g client-light-theme {
-  if -F '#{!=:#{@catppuccin_flavor},latte}' {
-    set -g @catppuccin_flavor "latte"
-    source-file ~/.config/tmux/appearance/retheme.conf
-  }
-}
+# The hook runs theme-sync-tmux instead of trusting the reporting client's
+# theme: macOS appearance stays authoritative, so a dark phone terminal
+# attaching to a latte server can't flip it. The script self-gates and holds
+# a lock while retheming, so concurrent fires (multiple clients, the
+# dark-notify watcher) serialize instead of interleaving. Flips with no
+# reporting client attached are covered by the watch-theme-change
+# (dark-notify) daemon.
+set-hook -g client-dark-theme  'run-shell -b "$ZSH/theme/bin/theme-sync-tmux"'
+set-hook -g client-light-theme 'run-shell -b "$ZSH/theme/bin/theme-sync-tmux"'
 
 # Status bar
 set -g status-position bottom

--- a/tmux/appearance/modules/bell.conf
+++ b/tmux/appearance/modules/bell.conf
@@ -1,0 +1,13 @@
+# Build @catppuccin_status_bell from the @catppuccin_bell_* inputs with
+# catppuccin's module builder. Each module build lives in its own file:
+# %hidden resolves while the file parses, so two MODULE_NAME assignments in
+# one file would both build under the last name.
+%hidden MODULE_NAME="bell"
+
+# The builder sets these with -o and bakes the palette's hex values, and
+# @catppuccin_reset doesn't cover module variables, so a re-theme would keep
+# the old flavor's colors. Unset them so every build re-bakes.
+set -Ugq @catppuccin_status_bell_icon_fg
+set -Ugq @catppuccin_status_bell_text_fg
+
+source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"

--- a/tmux/appearance/modules/claude.conf
+++ b/tmux/appearance/modules/claude.conf
@@ -1,0 +1,13 @@
+# Build @catppuccin_status_claude (the agent-attention pill) from the
+# @catppuccin_claude_* inputs with catppuccin's module builder. Each module
+# build lives in its own file: %hidden resolves while the file parses, so two
+# MODULE_NAME assignments in one file would both build under the last name.
+%hidden MODULE_NAME="claude"
+
+# The builder sets these with -o and bakes the palette's hex values, and
+# @catppuccin_reset doesn't cover module variables, so a re-theme would keep
+# the old flavor's colors. Unset them so every build re-bakes.
+set -Ugq @catppuccin_status_claude_icon_fg
+set -Ugq @catppuccin_status_claude_text_fg
+
+source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"

--- a/tmux/appearance/retheme.conf
+++ b/tmux/appearance/retheme.conf
@@ -1,20 +1,23 @@
-# Re-apply the active catppuccin flavor to a running server. The caller sets
-# @catppuccin_flavor first, then sources this file.
-#
-# Everything here is a tmux config command, so the whole sequence executes as
-# one contiguous block inside the server. Concurrent triggers (per-client
-# theme hooks, the dark-notify watcher) serialize instead of interleaving.
-# Interleaved re-themes corrupted state in two ways: status.conf's capture
-# guard is evaluated at parse time but the capture executes later, letting the
-# window-status wrapper capture itself (window tabs then render as an empty
-# string), and a concurrent unset of @catppuccin_flavor made the plugin's
-# palette source-file error out mid-retheme.
+# Re-apply the active catppuccin flavor to a running server. Sourced only by
+# theme-sync-tmux, which sets @catppuccin_flavor first and holds the retheme
+# lock. tmux interleaves commands from concurrent clients, so unserialized
+# re-themes corrupt state: the plugin assembles the window formats with a
+# chain of appends, and status.conf's capture can grab another retheme's
+# wrapper (window tabs then render as an empty string). Route any new retheme
+# trigger through theme-sync-tmux, never at this file directly.
 #
 # @catppuccin_reset is the plugin's supported way to switch flavors on a live
 # server: catppuccin_options_tmux.conf unsets the palette and option variables
 # so the new flavor's -o defaults re-apply.
 set -g @catppuccin_reset "true"
 source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/catppuccin_options_tmux.conf"
+
+# The plugin's module builder bakes fg colors with -o (set-if-unset) and the
+# reset skips module variables, so the session pill would keep the old
+# flavor's hex forever. Unset them so the rebuild re-bakes; the custom
+# text_fg override re-applies below before the builder's -o default runs.
+set -Ugq @catppuccin_status_session_icon_fg
+set -Ugq @catppuccin_status_session_text_fg
 
 # The reset also wipes our custom @catppuccin_* inputs; re-apply them before
 # the plugin builds the window formats from them.

--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -29,6 +29,13 @@ set -g status-right "#{?#{==:#(_tmux-claude-agents-count),0},, #{?#{E:@resp_is_n
 # the capture sees the fresh pill format. The guard makes a lone re-source of
 # this file idempotent: once window-status-format holds our wrapper, don't
 # capture the wrapper into the "wide" slot.
+#
+# The guard's %if is evaluated at parse time while the capture executes
+# later, so sourcing this file concurrently with a retheme can capture the
+# wrapper into itself, which renders every window tab as an empty string.
+# Every retheme therefore goes through theme-sync-tmux, which serializes
+# under a lock; route any new trigger through it rather than sourcing this
+# file (or the plugin confs) from a separate path.
 %if "#{==:#{m:*@resp_wsf_wide*,#{window-status-format}},0}"
 set -gF @resp_wsf_wide  "#{window-status-format}"
 set -gF @resp_wscf_wide "#{window-status-current-format}"

--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -2,20 +2,13 @@
 # indicator (defined in responsive.conf).
 set -g status-left "#{?#{E:@resp_is_narrow},#{E:@resp_sl_narrow},#{E:@catppuccin_status_session}#[bg=default] }"
 
-# Catppuccin ships no bell module, so build @catppuccin_status_bell from the
-# @catppuccin_bell_* inputs (set in alerts.conf) with its own module builder.
-# This must run after the plugin loads, so it lives here rather than alongside
-# the inputs. The claude pill (agent-attention chip) is built the same way from
-# the @catppuccin_claude_* inputs in claude/claude.conf.
-%hidden MODULE_NAME="bell"
-# The builder sets these with -o and bakes the palette's hex values, and
-# @catppuccin_reset doesn't cover module variables, so a re-theme would keep
-# the old flavor's colors. Unset them so every build re-bakes.
-set -Ugq @catppuccin_status_bell_icon_fg
-set -Ugq @catppuccin_status_bell_text_fg
-source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"
-%hidden MODULE_NAME="claude"
-source -F "${TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf"
+# Catppuccin ships no bell or claude module, so build them from our inputs
+# with its module builder. These must run after the plugin loads, so they
+# live here rather than alongside the inputs. One file per module: %hidden
+# MODULE_NAME resolves at parse time, so assigning it twice in one file
+# builds both modules under the last name.
+source-file ~/.config/tmux/appearance/modules/bell.conf
+source-file ~/.config/tmux/appearance/modules/claude.conf
 
 # Leading space keeps each pill from touching its neighbor. Both segments render
 # only when their count is nonzero. Narrow clients swap the catppuccin pills for


### PR DESCRIPTION
Follow-up to #527, which merged mid-review. A code review of that change confirmed four findings, and verifying the fixes surfaced a fifth bug that had shipped separately in #526.

## Serialization Actually Requires a Lock

Re-testing #527's race fix at higher concurrency disproved its core premise: tmux interleaves command queues from concurrent clients, so even a retheme issued as a single `tmux` invocation can corrupt another's format build. A 3-way race gauntlet still captured the window-status wrapper into itself (blank tabs) in half the rounds. Every trigger now funnels through `theme-sync-tmux`, which serializes rethemes with an `mkdir` lock; stale locks are stolen after ~10s. A 5-way, 20-round gauntlet on a throwaway `tmux -L` server passes every round with correct palette, intact wrapper, and rendered tabs.

## Other Review Findings

- The hooks in #527 set the server flavor from the reporting client's theme, so a dark phone terminal attaching to a latte server would retheme the desktop. The hooks run `theme-sync-tmux` again: the flavor always comes from macOS appearance via `theme-flavor`, and the client mismatch stays cosmetic as `status.conf` documents.
- The plugin-presence guard checked only one of the two confs `retheme.conf` sources. A partial checkout would half-apply the theme and wedge the flavor gate until the next opposite flip (verified: a failure inside a sourced file does not stop the remaining commands). The guard is silent when the plugin isn't installed yet and loud when only one file exists.
- The plugin's module builder bakes fg colors with `-o` (set-if-unset) and `@catppuccin_reset` skips module variables, so builder-baked colors survived rethemes. The session module's `icon_fg` (invisible today only because the session icon is empty) and our own bell/claude modules now unset those before each build.
- I kept the shell-side global flavor read rather than folding the gate into a server-side `if -F`: option inheritance would let a stray session-scoped `@catppuccin_flavor` shadow the gate, and the lock already closes the check-then-act window.

## Bell Module Fix

The bell pill has been silently broken since #526. `%hidden` resolves while a file parses, but `source-file` executes later, so the two `MODULE_NAME` assignments #526 added to `status.conf` both built under `claude` and `@catppuccin_status_bell` was never created. This reproduces on a lab server running unmodified main. Each module build now lives in its own file (`tmux/appearance/modules/`), matching how catppuccin scopes its own modules; both pills build at boot and re-bake on every flip.

## Testing

All on a throwaway `tmux -L themelab` server booted from this config with `theme-flavor` stubbed: single retheme correctness (palette, recaptured window formats, re-baked bell/claude modules), the 5-way and 3-way race gauntlets above, empty and partial plugin-checkout guard behavior, stale-lock steal and release, and idempotence of a lone `status.conf` re-source. The live server was untouched; this takes effect after merge and `dotfiles sync`.
