### PR TITLE
git: ignore .claude/.cc-writes

### DIFF
--- a/git/ignore
+++ b/git/ignore
@@ -14,6 +14,7 @@ coverage
 # Local settings for Claude Code
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+**/.claude/.cc-writes/
 CLAUDE.local.md
 
 # Temporary files


### PR DESCRIPTION
Ignores `.claude/.cc-writes/` in the repo source (`git/ignore`).

Claude keeps adding this pattern to my user-level global ignore. That file symlinks to the installed dotfiles copy, so the edit lands as an untracked change that never makes it into version control. Tracking the pattern in the repo means it survives a sync and Claude has nothing left to re-add.
