### PR TITLE
sync: interactive diff review with discard / open-PR / skip

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -7,6 +7,7 @@ CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
 source "${0:A:h}/../scripts/lib/git-sync.sh"
 source "${0:A:h}/../scripts/lib/report-failure.sh"
 source "${0:A:h}/../scripts/lib/sync-notify.sh"
+source "${0:A:h}/../scripts/lib/git-diff-review.sh"
 
 revert_cosmetic_json_changes() {
   local changed_files
@@ -29,24 +30,6 @@ revert_cosmetic_json_changes() {
   done <<< "$changed_files"
 }
 
-render_diff() {
-  local changed_files
-  changed_files=$(git diff HEAD --name-only 2>/dev/null)
-
-  [[ -z "$changed_files" ]] && return
-
-  local f head_sorted working_sorted
-  while IFS= read -r f; do
-    [[ -f "$f" ]] || continue
-    if [[ "$f" == *.json ]]; then
-      head_sorted=$(git show "HEAD:$f" 2>/dev/null | jq -S . 2>/dev/null) &&
-        working_sorted=$(jq -S . "$f" 2>/dev/null) &&
-        { diff -u --label "a/$f" --label "b/$f" <(echo "$head_sorted") <(echo "$working_sorted") || true; continue; }
-    fi
-    git diff HEAD -- "$f" 2>/dev/null
-  done <<< "$changed_files"
-}
-
 sync_repo() {
   gum log --level info "Syncing Claude repository..."
 
@@ -54,24 +37,7 @@ sync_repo() {
 
   revert_cosmetic_json_changes
 
-  local git_status
-  git_status=$(git status --porcelain 2>/dev/null)
-  if [[ -n "$git_status" ]]; then
-    gum log --level info "Local changes in $CLAUDE_REPO_HOME:"
-    echo "$git_status"
-    gum log --level info "Diff:"
-    render_diff
-
-    if gum confirm "Discard local changes and continue?" --default=no; then
-      gum log --level info "Discarding local changes..."
-      git reset --hard HEAD
-      git clean -fd
-    else
-      gum log --level error "Local changes present - skipping sync"
-      notify "Claude Upgrade" "Skipped: local changes present"
-      return 1
-    fi
-  fi
+  git_review_dirty "$CLAUDE_REPO_HOME" "Claude Upgrade" || return 1
 
   local new_rev sync_rc=0
   new_rev=$(git_sync_notify "$CLAUDE_REPO_HOME" "Claude Upgrade") || sync_rc=$?

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -10,6 +10,9 @@ DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 source "${0:A:h}/../scripts/lib/git-sync.sh"
 source "${0:A:h}/../scripts/lib/report-failure.sh"
 source "${0:A:h}/../scripts/lib/sync-notify.sh"
+source "${0:A:h}/../scripts/lib/git-diff-review.sh"
+
+git_review_dirty "$DOTFILES_HOME" "Dotfiles Sync" || exit 1
 
 sync_rc=0
 new_rev=$(git_sync_notify "$DOTFILES_HOME" "Dotfiles Sync") || sync_rc=$?

--- a/scripts/lib/git-diff-review.sh
+++ b/scripts/lib/git-diff-review.sh
@@ -92,9 +92,9 @@ git_review_dirty() {
   fi
 
   gum log --level info "Local changes in $repo_dir:"
-  echo "$tree"
+  echo "$tree" >&2
   gum log --level info "Diff:"
-  render_diff "$repo_dir"
+  render_diff "$repo_dir" >&2
 
   if [[ ! -t 0 ]]; then
     gum log --level error "Local changes present - skipping sync"

--- a/scripts/lib/git-diff-review.sh
+++ b/scripts/lib/git-diff-review.sh
@@ -1,0 +1,124 @@
+# shellcheck shell=bash
+# Sourceable interactive handler for a dirty working tree before a sync.
+# Requires report-failure.sh (notify) and git-sync.sh (git_default_branch) to be
+# sourced first. gum and gh must be on PATH.
+#
+# render_diff [repo_dir]
+#   Print the diff of tracked changes against HEAD. JSON files are normalized
+#   with `jq -S` so cosmetic key reordering doesn't show as noise; everything
+#   else falls back to plain `git diff HEAD`.
+#
+# git_review_open_pr <repo_dir> <title>
+#   Capture the working-tree changes (tracked and untracked) onto a fresh branch,
+#   push it, and open a draft PR with `gh`, then return the base branch to a clean
+#   state so the caller can fast-forward it. Returns nonzero if any step fails,
+#   leaving the base branch checked out.
+#
+# git_review_dirty <repo_dir> <title>
+#   If the tree is clean, return 0. Otherwise render the diff and, on a TTY,
+#   prompt to discard, open a PR, or skip. Without a TTY (launchd) it skips.
+#   Returns 0 when the tree is clean to continue syncing (discard or PR), 1 to
+#   abort the sync (skip).
+
+render_diff() {
+  local repo_dir="${1:-.}"
+  (
+    cd "$repo_dir" || return
+    local changed_files
+    changed_files=$(git diff HEAD --name-only 2>/dev/null)
+    [[ -z "$changed_files" ]] && return
+
+    local f head_sorted working_sorted
+    while IFS= read -r f; do
+      [[ -f "$f" ]] || continue
+      if [[ "$f" == *.json ]]; then
+        head_sorted=$(git show "HEAD:$f" 2>/dev/null | jq -S . 2>/dev/null) &&
+          working_sorted=$(jq -S . "$f" 2>/dev/null) &&
+          { diff -u --label "a/$f" --label "b/$f" <(echo "$head_sorted") <(echo "$working_sorted") || true; continue; }
+      fi
+      git diff HEAD -- "$f" 2>/dev/null
+    done <<< "$changed_files"
+  )
+}
+
+git_review_open_pr() {
+  local repo_dir="$1" title="$2"
+
+  local base branch host
+  base=$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null || git_default_branch "$repo_dir")
+  host=$(hostname -s)
+  branch="sync/local-changes-$(date +%Y%m%d-%H%M%S)"
+
+  gum log --level info "Opening a PR for local changes on $branch..."
+
+  if ! git -C "$repo_dir" checkout -b "$branch"; then
+    gum log --level error "Failed to create $branch"
+    return 1
+  fi
+
+  if ! git -C "$repo_dir" add -A ||
+     ! git -C "$repo_dir" commit -m "sync: local changes captured on $host"; then
+    gum log --level error "Failed to commit local changes"
+    git -C "$repo_dir" checkout "$base"
+    return 1
+  fi
+
+  if ! gum spin --show-error --title "Pushing $branch" -- \
+    git -C "$repo_dir" push -u origin "$branch"; then
+    gum log --level error "Failed to push $branch - change is committed locally on $branch"
+    git -C "$repo_dir" checkout "$base"
+    return 1
+  fi
+
+  local pr_url
+  if ! pr_url=$(cd "$repo_dir" && gh pr create --draft --base "$base" --head "$branch" --fill 2>&1); then
+    gum log --level error "Failed to create PR: $pr_url"
+    git -C "$repo_dir" checkout "$base"
+    return 1
+  fi
+
+  git -C "$repo_dir" checkout "$base"
+  gum log --level info "PR opened: $pr_url"
+  notify "$title" "Opened PR for local changes"
+}
+
+git_review_dirty() {
+  local repo_dir="$1" title="$2"
+
+  local tree
+  tree=$(git -C "$repo_dir" status --porcelain 2>/dev/null)
+  if [[ -z "$tree" ]]; then
+    return 0
+  fi
+
+  gum log --level info "Local changes in $repo_dir:"
+  echo "$tree"
+  gum log --level info "Diff:"
+  render_diff "$repo_dir"
+
+  if [[ ! -t 0 ]]; then
+    gum log --level error "Local changes present - skipping sync"
+    notify "$title" "Skipped: local changes present"
+    return 1
+  fi
+
+  local choice
+  choice=$(gum choose --header "Local changes present. What now?" \
+    "Discard and sync" "Open a PR and sync" "Skip sync") || choice="Skip sync"
+
+  case "$choice" in
+    "Discard and sync")
+      gum log --level info "Discarding local changes..."
+      git -C "$repo_dir" reset --hard HEAD
+      git -C "$repo_dir" clean -fd
+      ;;
+    "Open a PR and sync")
+      git_review_open_pr "$repo_dir" "$title" || return 1
+      ;;
+    *)
+      gum log --level error "Local changes present - skipping sync"
+      notify "$title" "Skipped: local changes present"
+      return 1
+      ;;
+  esac
+}

--- a/scripts/spec/dotfiles_sync_spec.sh
+++ b/scripts/spec/dotfiles_sync_spec.sh
@@ -62,13 +62,13 @@ GUM
     The stderr should include "Already up to date"
   End
 
-  # The other side of the case block: a guard failure (git_sync returns 1) must
-  # surface as a nonzero exit.
+  # A dirty working tree is caught by git_review_dirty before the sync. Without a
+  # TTY (as here) it renders the diff, notifies, and aborts with a nonzero exit.
   It "exits 1 when the working tree is dirty"
     touch "$repo/dirty"
     git -C "$repo" add dirty
     When call run_sync
     The status should equal 1
-    The stderr should include "has local changes"
+    The stderr should include "Local changes present"
   End
 End


### PR DESCRIPTION
`dotfiles sync` used to hard-abort on any local diff. `git_sync` checks the working tree, logs "has local changes - skipping sync", and returns without showing what changed or offering to act on it. `claude-upgrade` already had the nicer path: render the diff, prompt to discard. This brings the same capability to `dotfiles sync` and adds a third choice both paths gain: open a PR with the change.

That third option covers the case the manual dance was always for. Most local diffs at sync time are either transient churn I want gone, or a real edit I meant to commit back to the repo. Discarding handles the first. "Open a PR" handles the second without dropping out of the sync to branch, commit, push, and `gh pr create` by hand.

## Design

`render_diff` moves out of `claude-upgrade` into a new `scripts/lib/git-diff-review.sh`, joined by `git_review_dirty` (the shared dispatcher) and `git_review_open_pr`. Both `bin/dotfiles-sync` and `bin/claude-upgrade` source the lib and call `git_review_dirty` before the fast-forward. `git_sync` itself stays pure and non-interactive. Callers still own the dirty handling ahead of it, same as before.

The open-PR path is mechanical, no LLM: create `sync/local-changes-<timestamp>`, commit tracked and untracked changes, push, `gh pr create --draft --fill`, then check the base branch back out clean so the sync fast-forwards on top. The committed change stays on the pushed branch as the PR. The base returns to a pristine state. I went with `gh` over a dispatched agent because the change already exists in the tree. There's nothing to author but the commit message and PR body, and `--fill` covers those from the commit.

Interactivity is gated on `[[ -t 0 ]]`. Without a TTY, as in the 3am launchd upgrade, it keeps today's behavior exactly: render the diff, notify "Skipped: local changes present", abort. The discard and open-PR prompts only ever appear when a human is driving. `claude-upgrade` opens its PR against the `.claude-repo`, which is the sanctioned way to change that repo anyway.

## Testing

Drove all four branches against a throwaway repo with a local bare origin, stubbing `gum`/`gh`/`notify`: clean tree returns 0 and continues; dirty tree with no TTY renders the diff and skips with a notification; discard leaves the tree clean; open-PR branches, commits both tracked and untracked files, pushes to origin, and checks the base back out clean. Confirmed the `jq -S` JSON normalization ignores key reordering and surfaces only real value changes (the sandbox blocks the process-substitution `diff`, so that one assertion ran outside it).
