### PR TITLE
sync: guard success-path checkout in git_review_open_pr

### DIFF
--- a/scripts/lib/git-diff-review.sh
+++ b/scripts/lib/git-diff-review.sh
@@ -77,7 +77,10 @@ git_review_open_pr() {
     return 1
   fi
 
-  git -C "$repo_dir" checkout "$base"
+  if ! git -C "$repo_dir" checkout "$base"; then
+    gum log --level error "Failed to return to $base - change is safe on $branch"
+    return 1
+  fi
   gum log --level info "PR opened: $pr_url"
   notify "$title" "Opened PR for local changes"
 }


### PR DESCRIPTION
Guards the final `checkout "$base"` on the success path of `git_review_open_pr`. Every other step in the function already returns 1 on failure, but the checkout that returns the base branch to a clean state was left unguarded.

The reason it matters: `git_review_dirty` calls `git_review_open_pr ... || return 1`, which suppresses `set -e` for the whole function body. So a failed final checkout would fall through to `notify` and return 0, reporting "clean to continue" while the PR branch is still checked out. The caller would then run `git_sync` against the wrong branch. The `--ff-only` pull would likely catch it, but the function's documented contract would be silently broken. Now a failed checkout logs and returns 1, and the message notes the change is safe on the pushed branch.

Follow-up to #532, addressing greptile r3546818963.
