### PR TITLE
worktrunk: centralize worktree placement outside repo trees

### DIFF
--- a/git/config.local.example
+++ b/git/config.local.example
@@ -3,3 +3,12 @@
   email = AUTHOREMAIL
 [credential]
   helper = GIT_CREDENTIAL_HELPER
+
+# Per-org identity, selected by remote URL rather than worktree path. When you
+# onboard an org, uncomment and point `path` at a private identity file (e.g.
+# ~/.config/git/identity-anthropic with its own [user] email/signingkey). Two
+# patterns cover the HTTPS and SSH remote forms (SSH uses `github.com:owner`).
+# [includeIf "hasconfig:remote.*.url:https://github.com/anthropic/**"]
+#   path = ~/.config/git/identity-anthropic
+# [includeIf "hasconfig:remote.*.url:git@github.com:anthropic/**"]
+#   path = ~/.config/git/identity-anthropic

--- a/worktrunk/config.toml
+++ b/worktrunk/config.toml
@@ -1,3 +1,5 @@
+worktree-path = "~/src/.worktrees/{{ owner }}/{{ repo }}/{{ branch | sanitize }}"
+
 [[pre-start]]
 claude-trust = "claude-trust-worktree '{{ primary_worktree_path }}' '{{ worktree_path }}'"
 


### PR DESCRIPTION
Moves Worktrunk worktrees out of every repo tree and into a hidden central location, so `ls ~/src` shows only real repos instead of a sibling directory per branch.

The framing started as "nest worktrees under a gitignored `.worktrees/` inside each repo," but the real driver behind wanting a path tree was per-org git identity (a different email per organization). That need isn't exercised today: `git/config` sets a single global `bvdrucker@gmail.com` and there is no `includeIf` anywhere. So the path tree was preserving optionality for something unused, while nesting kept a genuine hazard: any non-gitignore-aware walker that writes (a raw `find`, a formatter over `**` with dotglob, a `sed -i` sweep) can corrupt sibling worktrees sitting in the tree you run tools against.

Centralizing outside the repo removes that hazard without nesting. Identity, when a second one ever arrives, moves to selection by remote URL rather than by directory.

## Placement

`worktree-path = "~/src/.worktrees/{{ owner }}/{{ repo }}/{{ branch | sanitize }}"`. A `dotfiles` branch `cp-stdin` now resolves to `~/src/.worktrees/bendrucker/dotfiles/cp-stdin`. The dot-prefixed `~/src/.worktrees/` stays hidden from `ls ~/src` while keeping worktrees in the workspace. `{{ owner }}` disambiguates same-named forks (e.g. multiple `browserify-shim` remotes) and gives a future path-based sandbox an org-scoped root to key on. A remoteless repo yields an empty owner segment (`…/.worktrees//repo/…`). Git tolerates it, and it's cosmetic.

Migration is lazy by design: the template only affects new `wt switch --create`. The existing sibling worktrees keep working through git's worktree registration and drain as their PRs merge. Nothing is relocated.

## Identity by Remote (Documented, Not Activated)

`git/config.local.example` now carries a commented `includeIf "hasconfig:remote.*.url:…"` block. This is the mechanism that makes centralized placement safe to adopt without giving up per-org identity: identity follows the remote in any worktree, anywhere on disk. Two patterns cover the HTTPS and SSH remote forms (SSH uses `github.com:owner`, not a slash). It's left commented because no second identity exists yet. Activating it now would be speculative. `hasconfig` needs git 2.36+; this machine runs 2.50.1.

## Testing

Verified the template locally. The Claude Code harness injects `WORKTRUNK_WORKTREE_PATH` to force worktrees into `.worktrees/` for isolation, and that env var overrides the config file, so the config change had to be exercised with it unset (it isn't set in a normal interactive shell). With it unset, `wt switch --create wt-place-check` produced `~/src/.worktrees/bendrucker/dotfiles/wt-place-check` and both `pre-start` hooks (`claude-trust`, `claude-settings`) ran against the new path. `git worktree list` confirmed the existing siblings were untouched. Cleaned up the throwaway worktree afterward.
