### PR TITLE
claude: guard trust-worktree `~/.claude.json` rewrite with a mutex

### DIFF
--- a/claude/trust-worktree
+++ b/claude/trust-worktree
@@ -19,6 +19,26 @@ if [ ! -f "$config" ]; then
   exit 0
 fi
 
+# Serialize read → check → write behind a portable mkdir mutex (macOS ships no
+# flock). This closes hook-vs-hook races (concurrent worktree creates, nightly
+# upgrade racing a manual create) that would otherwise lose an update by writing
+# back a stale snapshot. It cannot fully close hook-vs-Claude, since Claude Code
+# does not take this lock, but it shrinks that window to a single jq read+write.
+lockdir="${config}.lock"
+
+attempt=0
+until mkdir "$lockdir" 2>/dev/null; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 5 ]; then
+    # Could not acquire the lock. Skip rather than deadlock or clobber. Worst
+    # case is one folder-trust prompt in the new worktree, which is benign.
+    exit 0
+  fi
+  sleep 0.1
+done
+trap 'rmdir "$lockdir" 2>/dev/null' EXIT
+
+# Re-read inside the lock so the check and the write see the same state.
 is_trusted=$(jq -r --arg path "$primary_path" '.projects[$path].hasTrustDialogAccepted // false' "$config")
 
 if [ "$is_trusted" != "true" ]; then


### PR DESCRIPTION
## What

`claude/trust-worktree` copies workspace trust from a primary worktree to a new one by rewriting `~/.claude.json`. It read the file, checked trust, then rewrote the whole file from that snapshot:

```sh
is_trusted=$(jq ... "$config")      # read
already_trusted=$(jq ... "$config") # read
jq '...' "$config" > tmp; mv tmp "$config"  # write from the snapshot
```

Any Claude Code or concurrent-hook write landing between the read and the `mv` is silently clobbered. This is a classic lost update on a hot file.

## Change

Wrap read → check → write in a portable `mkdir` mutex (macOS ships no `flock`) and re-read the trusted state inside the lock:

- `mkdir "$lockdir"` is atomic. Bounded retry (5 × `sleep 0.1`), then `exit 0` on contention rather than deadlocking. Worst case is one benign folder-trust prompt in the new worktree.
- `trap 'rmdir "$lockdir"' EXIT` frees the lock on any exit, including a crash.

Scope: this closes hook-vs-hook races (concurrent worktree creates, nightly upgrade racing a manual create) and shrinks the hook-vs-Claude window to a single `jq` read+write. It cannot fully close hook-vs-Claude, since Claude Code does not take this lock. Kept minimal, with no CAS retry loop.

## Context

This came out of investigating frequent org-managed-settings re-prompts on the work machine. The hook was **exonerated** as their cause (org approval lives in `~/.claude/remote-settings.json` / `policy-limits.json`, which the hook never touches) and is **not obsolete** (native worktree trust inheritance covers only Claude Code's own `.claude/worktrees/`, not Worktrunk worktrees). This PR only addresses the latent race the investigation surfaced.

## Verification

`shellcheck claude/trust-worktree` is clean and `sh -n` parses, so it stays POSIX `sh`.

The race is exercised by seeding a config with `{primary: trusted}` and firing two copies in parallel, one adding worktree B and one adding worktree C, repeated across many rounds. The old script reliably drops one of the two writes under this load. The mutex version preserves both, and the same harness run against the old script demonstrates that it actually discriminates the lost update rather than passing vacuously.

Normal single-run behavior is also covered: a trusted primary granting trust to a new path, a second run on that path as a no-op, an untrusted primary writing nothing, and the lock dir being released on exit.
