### PR TITLE
docs: document architecture and patterns in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Linux-friendly, outside of [`macos/`](macos/) and a [`Brewfile`](Brewfile) for d
 Highlights include:
 
 * zsh with the minimal [pure](https://github.com/sindresorhus/pure) prompt
-* Sub-second shell startup, [enforced by CI](#startup-performance-is-ci-gated)
+* Sub-second shell startup, [enforced by CI](#startup-budget)
 * Sane defaults for programming languages I use
 
 ## Installing
@@ -20,24 +20,24 @@ scripts/bootstrap
 
 ## How it works
 
-Everything is organized into **topic** directories: [`git/`](git/), [`zsh/`](zsh/), [`tmux/`](tmux/), and so on. A topic is just a directory that follows a few naming conventions. The bootstrap and startup scripts glob for those conventions across every topic, so adding a new tool means creating a directory and dropping in the right files. Nothing has to be registered in a central list.
+Everything is organized into **topic** directories: [`git/`](git/), [`zsh/`](zsh/), [`tmux/`](tmux/), and so on. A topic is a directory that follows a few naming conventions. Bootstrap and startup glob for those conventions across every topic. Adding a tool means creating a directory and dropping in the right files, with no central list to register in.
 
 ### Topic conventions
 
-A file's name determines how and when it loads. These are the conventions a topic can use:
+A file's name determines how and when it loads:
 
 | File | Purpose |
 | --- | --- |
 | `path.zsh` | Sourced first, from `.zshenv`, to set up `$PATH`. |
 | `*.zsh` | Sourced at interactive shell startup. Aliases, functions, options. |
-| `completion.zsh` | Sourced lazily after the first prompt renders (see [startup performance](#startup-performance-is-ci-gated)). |
+| `completion.zsh` | Sourced lazily after the first prompt (see [startup budget](#startup-budget)). |
 | `symlinks.conf` | Declares config files to symlink into `$HOME` or `~/.config`. |
 | `Brewfile` | Homebrew packages for the topic. |
 | `mise.toml` | Pinned language/tool versions, merged into mise's config. |
 | `install.sh` | Non-symlink setup: plugin managers, system config. Run by `scripts/install`. |
 | `.shellspec` | Opts the topic into [integration tests](#topic-integration-tests) that run in CI. |
 
-Separately, the repo-root [`bin/`](bin/) holds executables that go on `$PATH` (`dotfiles-upgrade`, `bench-startup`, and friends). The rest of this section documents the machinery behind these conventions.
+The repo-root [`bin/`](bin/) holds executables that go on `$PATH`, like `dotfiles-upgrade` and `bench-startup`.
 
 ### Shell startup
 
@@ -70,22 +70,22 @@ _load_deferred_completions() {
 add-zsh-hook precmd _load_deferred_completions
 ```
 
-### Startup performance is CI-gated
+### Startup budget
 
-The deferral only pays off if regressions can't creep back, so [CI benchmarks startup](.github/workflows/test.yml) with [hyperfine](https://github.com/sharkdp/hyperfine) and **fails the build if median startup exceeds one second**:
+[CI benchmarks startup](.github/workflows/test.yml) with [hyperfine](https://github.com/sharkdp/hyperfine) and **fails the build if median startup exceeds one second**:
 
 ```sh
 hyperfine --warmup 3 --runs 10 --shell=none 'zsh -i -c exit'
 # median > 1.0s → exit 1
 ```
 
-The same job dumps a per-file [`zprof`](https://zsh.sourceforge.io/Doc/Release/Zsh-Modules.html#The-zsh_002fzprof-Module) self-time table into the run summary so regressions are easy to attribute. A few rules keep startup fast, documented in [`CLAUDE.md`](CLAUDE.md):
+The same job dumps a per-file [`zprof`](https://zsh.sourceforge.io/Doc/Release/Zsh-Modules.html#The-zsh_002fzprof-Module) self-time table into the run summary. A few rules keep startup fast, documented in [`CLAUDE.md`](CLAUDE.md):
 
 * **No subshell forks during startup.** Each `$(...)` costs ~15-50ms. `brew --prefix` is banned in favor of the already-exported `$HOMEBREW_PREFIX`.
 * **`compinit -C`** skips the completion security audit on every startup. The full audit runs during the nightly upgrade instead.
 * **Completions defer** via the `precmd` hook above. Because the deferral filter matches `completion.zsh` exactly, a file named `completions.zsh` (plural) would load eagerly and bypass it. CI [greps for that mistake](.github/workflows/test.yml) and fails.
 
-`bin/bench-startup` measures the current worktree locally, or compares two worktrees head-to-head.
+`bin/bench-startup` measures the current worktree, or compares two.
 
 ### Declarative symlinks
 
@@ -102,7 +102,7 @@ ignore:$XDG_CONFIG_HOME/git/ignore
 
 ### Homebrew aggregation
 
-The root [`Brewfile`](Brewfile) recursively evaluates every topic `Brewfile`, so `brew bundle` from the repo root installs everything:
+The root [`Brewfile`](Brewfile) recursively evaluates every topic `Brewfile`. `brew bundle` from the repo root installs everything:
 
 ```ruby
 Dir.glob(File.join(File.dirname(__FILE__), '*', '**', 'Brewfile')) do |brewfile|
@@ -110,9 +110,9 @@ Dir.glob(File.join(File.dirname(__FILE__), '*', '**', 'Brewfile')) do |brewfile|
 end
 ```
 
-Passing `binding` means topic Brewfiles inherit the root's overridden `brew`/`cask`/`mas` methods, which layer on a couple of behaviors:
+Passing `binding` means topic Brewfiles inherit the root's overridden `brew`/`cask`/`mas` methods, which add two behaviors:
 
-* **Duplicate detection.** `brew bundle` installs in parallel. A package declared in two Brewfiles races on the Homebrew lock and aborts with a cryptic error. An `assert_unique_package` guard catches the duplicate first and raises a clear error instead.
+* **Duplicate detection.** `brew bundle` installs in parallel. A package declared in two Brewfiles races on the Homebrew lock and aborts with a cryptic error. An `assert_unique_package` guard fails fast on the duplicate instead.
 * **CI trims GUIs.** When `$CI` is set, `cask` and `mas` skip their installs so runners don't pull slow GUI apps.
 
 A `~/Brewfile.local` is evaluated last, if present, for machine-specific packages that shouldn't live in the repo.
@@ -126,11 +126,11 @@ Each language topic pins its versions in a `mise.toml` and links it into [mise](
 mise.toml:$XDG_CONFIG_HOME/mise/conf.d/go.toml
 ```
 
-mise merges everything in `conf.d/` automatically, so each topic owns its own runtime versions without a shared config file. Versions are pinned exactly (never `latest`) so [Renovate](https://github.com/renovatebot/renovate) can track and bump them.
+mise merges everything in `conf.d/` automatically. Each topic owns its runtime versions without a shared config file. Versions are pinned exactly (never `latest`) so [Renovate](https://github.com/renovatebot/renovate) can track and bump them.
 
 ### Dev mode and testing
 
-Symlinks point at the installed copy in `~/.dotfiles`. Edits in a development clone don't take effect until synced. To make immediate testing possible, the active root is resolved through a layer of indirection on every shell in [`zsh/active-root.zsh`](zsh/active-root.zsh), with this precedence:
+Symlinks point at the installed copy in `~/.dotfiles`. Edits in a development clone don't take effect until synced. To test edits without syncing, the active root is resolved on every shell in [`zsh/active-root.zsh`](zsh/active-root.zsh), with this precedence:
 
 ```text
 $DOTFILES_USE_DEV                  (throwaway test subshell)
@@ -144,11 +144,11 @@ Three commands drive it:
 * `dotfiles dev enable` persistently repoints every symlink to the checkout and sets the flag. `dotfiles dev disable` restores the installed copy.
 * `dotfiles status` shows which root is active and its revision.
 
-Writing the flag file and re-running `install-symlinks` happen in a single step. The flag and the on-disk links can never disagree.
+Writing the flag file and re-running `install-symlinks` happen in one step.
 
 ### Sync and upgrade
 
-A launchd agent ([`macos/com.user.dotfiles-upgrade.plist`](macos/com.user.dotfiles-upgrade.plist)) runs [`bin/dotfiles-upgrade`](bin/dotfiles-upgrade) nightly. It syncs from the remote, reruns `scripts/install`, and cleans up stale packages. On failure it strips ANSI codes from the log and files a Things task with the error. A broken upgrade surfaces as a to-do instead of drifting silently.
+A launchd agent ([`macos/com.user.dotfiles-upgrade.plist`](macos/com.user.dotfiles-upgrade.plist)) runs [`bin/dotfiles-upgrade`](bin/dotfiles-upgrade) nightly. It syncs from the remote, reruns `scripts/install`, and cleans up stale packages. On failure it files a Things task with the error.
 
 `dotfiles sync` runs the same pull by hand. It refuses to sync a dirty tree, fast-forwards only, and updates submodules.
 
@@ -163,7 +163,7 @@ for spec in */.shellspec; do
 done
 ```
 
-Because bootstrap runs before them, [these specs](git/spec/) verify the installed config through its symlinks, catching breakage that a static check would miss.
+Because bootstrap runs before them, [these specs](git/spec/) verify the installed config through its symlinks.
 
 ### Bootstrap vs. install
 
@@ -172,7 +172,7 @@ Two entry points split one-time setup from the repeatable reconcile step:
 * [`scripts/bootstrap`](scripts/bootstrap) is the **one-time** fresh-machine path: install Homebrew, prompt for git identity, init submodules, then hand off to `dotf`, which runs install.
 * [`scripts/install`](scripts/install) is the **idempotent** core, safe to rerun nightly: `brew bundle` → install mise runtimes → install symlinks → run each topic's `install.sh` → sync the theme.
 
-The nightly upgrade and the dev-mode relink both lean on `install`, which is why it has to stay safe to run repeatedly.
+The nightly upgrade and the dev-mode relink both call `install`.
 
 ## Prior art
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Linux friendly, outside of [`macos/`](macos/) and a [`Brewfile`](Brewfile) for d
 Highlights include:
 
 * zsh with the minimal [pure](https://github.com/sindresorhus/pure) prompt
+* Sub-second shell startup, [enforced by CI](#startup-performance-is-ci-gated)
 * Sane defaults for programming languages I use
 
 ## Installing
@@ -17,22 +18,165 @@ cd ~/.dotfiles
 scripts/bootstrap
 ```
 
-## Usage
+## How it works
 
-The project is organized into logical "topic" folders. Scripts are organized into topic folders according to functionality (e.g. HTTP utilities in `http/`) and may be organized by type (aliases, functions, etc.) within a topic folder.
+Everything is organized into **topic** directories: [`git/`](git/), [`zsh/`](zsh/), [`tmux/`](tmux/), and so on. A topic is just a directory that follows a few naming conventions. The bootstrap and startup scripts glob for those conventions across every topic, so adding a new tool means creating a directory and dropping in the right files. Nothing has to be registered in a central list.
 
-- **bin/**: Anything in `bin/` will get added to `$PATH`.
-- **./\**/Brewfile**: Defines packages to install via Homebrew, including Homebrew Cask for GUIs.
-- **\*/\*.zsh**: Any files ending in `.zsh` are loaded.
-- **\*/path.zsh**: Any file named `path.zsh` is loaded first and is
-  expected to setup `$PATH` or similar.
-- **\*/completion.zsh**: Any file named `completion.zsh` is loaded
-  last and is expected to setup autocomplete.
-- **\*/\*.symlink**: Any files ending in `*.symlink` get symlinked into `$HOME` by `script/bootstrap`.
+### Topic conventions
+
+A file's name determines how and when it loads. These are the conventions a topic can use:
+
+| File | Purpose |
+| --- | --- |
+| `path.zsh` | Sourced first, from `.zshenv`, to set up `$PATH`. |
+| `*.zsh` | Sourced at interactive shell startup. Aliases, functions, options. |
+| `completion.zsh` | Sourced lazily after the first prompt renders (see [startup performance](#startup-performance-is-ci-gated)). |
+| `symlinks.conf` | Declares config files to symlink into `$HOME` or `~/.config`. |
+| `Brewfile` | Homebrew packages for the topic. |
+| `mise.toml` | Pinned language/tool versions, merged into mise's config. |
+| `install.sh` | Non-symlink setup: plugin managers, system config. Run by `scripts/install`. |
+| `.shellspec` | Opts the topic into [integration tests](#topic-integration-tests) that run in CI. |
+| `bin/` | Executables at the repo root, added to `$PATH`. |
+
+The rest of this section documents the machinery behind those conventions.
+
+### Shell startup
+
+zsh startup is a glob-driven loader split across two files, following zsh's own load order:
+
+1. [`zsh/.zshenv`](zsh/.zshenv) (symlinked to `~/.zshenv`) runs on **every** shell, interactive or not. It resolves which dotfiles root is active (see [dev mode](#dev-mode-and-testing)), runs `brew shellenv`, sources every `path.zsh`, then forces the repo's own `bin/` to the front of `$PATH`:
+
+   ```zsh
+   for file in $ZSH/**/path.zsh; do source $file; done
+   typeset -gU path
+   path=("$ZSH/bin" "$HOME/.local/bin" $path)
+   ```
+
+2. [`zsh/.zshrc`](zsh/.zshrc) (symlinked into `$ZDOTDIR`) runs on interactive shells. It globs every topic's `.zsh` files and sources all of them **except** the path and completion files, which are handled separately:
+
+   ```zsh
+   config_files=($ZSH/**/*.zsh)
+   for file in ${${config_files:#*/path.zsh}:#*/completion.zsh}; do
+     source $file
+   done
+   ```
+
+Completions are the expensive part of startup, so they don't run before the first prompt. `.zshrc` registers a one-shot `precmd` hook that sources every `completion.zsh` after the prompt is already interactive, then removes itself:
+
+```zsh
+_load_deferred_completions() {
+  add-zsh-hook -d precmd _load_deferred_completions
+  for file in $ZSH/**/completion.zsh; do source $file; done
+}
+add-zsh-hook precmd _load_deferred_completions
+```
+
+### Startup performance is CI-gated
+
+Deferred completions only matter if regressions can't sneak back in, so [CI benchmarks startup](.github/workflows/test.yml) with [hyperfine](https://github.com/sharkdp/hyperfine) and **fails the build if median startup exceeds one second**:
+
+```sh
+hyperfine --warmup 3 --runs 10 --shell=none 'zsh -i -c exit'
+# median > 1.0s → exit 1
+```
+
+The same job dumps a per-file [`zprof`](https://zsh.sourceforge.io/Doc/Release/Zsh-Modules.html#The-zsh_002fzprof-Module) self-time table into the run summary so regressions are easy to attribute. A few rules keep startup fast, documented in [`CLAUDE.md`](CLAUDE.md):
+
+* **No subshell forks during startup.** Each `$(...)` costs ~15-50ms. `brew --prefix` is banned in favor of the already-exported `$HOMEBREW_PREFIX`.
+* **`compinit -C`** skips the completion security audit on every startup. The full audit runs during the nightly upgrade instead.
+* **Completions defer** via the `precmd` hook above. Because the deferral filter matches `completion.zsh` exactly, a file named `completions.zsh` (plural) would load eagerly and bypass it. CI [greps for that mistake](.github/workflows/test.yml) and fails.
+
+`bin/bench-startup` measures the current worktree locally, or compares two worktrees head-to-head.
+
+### Declarative symlinks
+
+Config files are linked into place from per-topic [`symlinks.conf`](git/symlinks.conf) files in `source:target` format, one per line. Targets expand `~` and `$XDG_CONFIG_HOME`:
+
+```
+# git/symlinks.conf
+config:$XDG_CONFIG_HOME/git/config
+ignore:$XDG_CONFIG_HOME/git/ignore
+```
+
+[`scripts/install-symlinks`](scripts/install-symlinks) globs every `symlinks.conf`, creates the links, and validates each source exists. It also **prunes**: any symlink under `$HOME` or `~/.config` that points into the dotfiles repo but is no longer declared gets removed. Deleting a line from `symlinks.conf` is enough to clean up the stale link on the next install.
+
+### Homebrew aggregation
+
+The root [`Brewfile`](Brewfile) recursively evaluates every topic `Brewfile`, so `brew bundle` from the repo root installs everything:
+
+```ruby
+Dir.glob(File.join(File.dirname(__FILE__), '*', '**', 'Brewfile')) do |brewfile|
+  eval(IO.read(brewfile), binding)
+end
+```
+
+Passing `binding` means topic Brewfiles inherit the root's overridden `brew`/`cask`/`mas` methods, which layer on a couple of behaviors:
+
+* **Duplicate detection.** `brew bundle` installs in parallel, so a package declared in two Brewfiles races on the Homebrew lock and aborts with a cryptic error. An `assert_unique_package` guard raises a clear error instead.
+* **CI trims GUIs.** When `$CI` is set, `cask` and `mas` become no-ops so runners skip slow app installs.
+
+A `~/Brewfile.local` is evaluated last, if present, for machine-specific packages that shouldn't live in the repo.
+
+### Language versions with mise
+
+Each language topic pins its versions in a `mise.toml` and links it into [mise](https://mise.jdx.dev/)'s drop-in config directory through its `symlinks.conf`, namespaced by topic:
+
+```
+# go/symlinks.conf
+mise.toml:$XDG_CONFIG_HOME/mise/conf.d/go.toml
+```
+
+mise merges everything in `conf.d/` automatically, so each topic owns its own runtime versions without a shared config file. Versions are pinned exactly (never `latest`) so [Renovate](https://github.com/renovatebot/renovate) can track and bump them.
+
+### Dev mode and testing
+
+Symlinks point at the installed copy in `~/.dotfiles`, not a development checkout, so edits in a clone don't take effect until synced. To test changes immediately, the active root is a layer of indirection resolved on every shell in [`zsh/active-root.zsh`](zsh/active-root.zsh), with this precedence:
+
+```
+$DOTFILES_USE_DEV                  (throwaway test subshell)
+  > ~/.dotfiles-dev-mode flag file (persistent dev mode)
+    > $DOTFILES_HOME               (the installed copy)
+```
+
+Three commands drive it:
+
+* `dotfiles test` starts a subshell that loads the current checkout, session-only.
+* `dotfiles dev enable` persistently repoints every symlink to the checkout and sets the flag. `dotfiles dev disable` restores the installed copy.
+* `dotfiles status` shows which root is active and its revision.
+
+Writing the flag file and re-running `install-symlinks` happen in a single step, so the flag and the on-disk links can never disagree.
+
+### Sync and upgrade
+
+A launchd agent ([`macos/com.user.dotfiles-upgrade.plist`](macos/com.user.dotfiles-upgrade.plist)) runs [`bin/dotfiles-upgrade`](bin/dotfiles-upgrade) nightly. It syncs from the remote, reruns `scripts/install`, and cleans up stale packages. On failure it strips ANSI codes from the log and files a Things task with the error, so a broken upgrade surfaces as a to-do rather than silent drift.
+
+`dotfiles sync` runs the same pull by hand. It refuses to sync a dirty tree, fast-forwards only, and updates submodules.
+
+### Topic integration tests
+
+Tests run against the real post-bootstrap state, not a mock. A topic opts in by containing a `.shellspec` file, and [CI discovers them](.github/workflows/test.yml) with a glob:
+
+```bash
+for spec in */.shellspec; do
+  dir="${spec%/.shellspec}"
+  (cd "$dir" && shellspec) || exit 1
+done
+```
+
+Because the bootstrap job runs first, [these specs](git/spec/) verify the installed config through its symlinks, catching breakage that a static check would miss.
+
+### Bootstrap vs. install
+
+Two entry points split first-run setup from repeatable reconcile:
+
+* [`scripts/bootstrap`](scripts/bootstrap) is the **one-time** fresh-machine path: install Homebrew, prompt for git identity, init submodules, then hand off to install.
+* [`scripts/install`](scripts/install) is the **idempotent** core, safe to rerun nightly: `brew bundle` → install mise runtimes → install symlinks → run each topic's `install.sh` → sync the theme.
+
+The nightly upgrade and the dev-mode relink both lean on `install`, which is why it has to stay safe to run repeatedly.
 
 ## Prior Art
 
-* [holman](https://github.com/holman/dotfiles): Boostrap/install scripts, initial ZSH config, colorization
+* [holman](https://github.com/holman/dotfiles): Bootstrap/install scripts, initial ZSH config, colorization
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > My dotfiles for configuring macOS
 
-Linux friendly, outside of [`macos/`](macos/) and a [`Brewfile`](Brewfile) for dependency management. I use this repo for both home and work.
+Linux-friendly, outside of [`macos/`](macos/) and a [`Brewfile`](Brewfile) for dependency management. I use this repo for both home and work.
 
 Highlights include:
 
@@ -36,9 +36,8 @@ A file's name determines how and when it loads. These are the conventions a topi
 | `mise.toml` | Pinned language/tool versions, merged into mise's config. |
 | `install.sh` | Non-symlink setup: plugin managers, system config. Run by `scripts/install`. |
 | `.shellspec` | Opts the topic into [integration tests](#topic-integration-tests) that run in CI. |
-| `bin/` | Executables at the repo root, added to `$PATH`. |
 
-The rest of this section documents the machinery behind those conventions.
+Separately, the repo-root [`bin/`](bin/) holds executables that go on `$PATH` (`dotfiles-upgrade`, `bench-startup`, and friends). The rest of this section documents the machinery behind these conventions.
 
 ### Shell startup
 
@@ -61,7 +60,7 @@ zsh startup is a glob-driven loader split across two files, following zsh's own 
    done
    ```
 
-Completions are the expensive part of startup, so they don't run before the first prompt. `.zshrc` registers a one-shot `precmd` hook that sources every `completion.zsh` after the prompt is already interactive, then removes itself:
+Completions are the expensive part of startup. They don't run before the first prompt. `.zshrc` registers a one-shot `precmd` hook that sources every `completion.zsh` after the prompt is already interactive, then removes itself:
 
 ```zsh
 _load_deferred_completions() {
@@ -73,7 +72,7 @@ add-zsh-hook precmd _load_deferred_completions
 
 ### Startup performance is CI-gated
 
-Deferred completions only matter if regressions can't sneak back in, so [CI benchmarks startup](.github/workflows/test.yml) with [hyperfine](https://github.com/sharkdp/hyperfine) and **fails the build if median startup exceeds one second**:
+The deferral only pays off if regressions can't creep back, so [CI benchmarks startup](.github/workflows/test.yml) with [hyperfine](https://github.com/sharkdp/hyperfine) and **fails the build if median startup exceeds one second**:
 
 ```sh
 hyperfine --warmup 3 --runs 10 --shell=none 'zsh -i -c exit'
@@ -92,13 +91,14 @@ The same job dumps a per-file [`zprof`](https://zsh.sourceforge.io/Doc/Release/Z
 
 Config files are linked into place from per-topic [`symlinks.conf`](git/symlinks.conf) files in `source:target` format, one per line. Targets expand `~` and `$XDG_CONFIG_HOME`:
 
-```
+```ini
 # git/symlinks.conf
 config:$XDG_CONFIG_HOME/git/config
+delta-catppuccin.gitconfig:$XDG_CONFIG_HOME/git/delta-catppuccin.gitconfig
 ignore:$XDG_CONFIG_HOME/git/ignore
 ```
 
-[`scripts/install-symlinks`](scripts/install-symlinks) globs every `symlinks.conf`, creates the links, and validates each source exists. It also **prunes**: any symlink under `$HOME` or `~/.config` that points into the dotfiles repo but is no longer declared gets removed. Deleting a line from `symlinks.conf` is enough to clean up the stale link on the next install.
+[`scripts/install-symlinks`](scripts/install-symlinks) globs every `symlinks.conf`, creates the links, and validates each source exists. It also **prunes**: a symlink that points into the dotfiles repo but is no longer declared gets removed. Dropping a line from `symlinks.conf` is enough to unlink the file it used to manage.
 
 ### Homebrew aggregation
 
@@ -112,8 +112,8 @@ end
 
 Passing `binding` means topic Brewfiles inherit the root's overridden `brew`/`cask`/`mas` methods, which layer on a couple of behaviors:
 
-* **Duplicate detection.** `brew bundle` installs in parallel, so a package declared in two Brewfiles races on the Homebrew lock and aborts with a cryptic error. An `assert_unique_package` guard raises a clear error instead.
-* **CI trims GUIs.** When `$CI` is set, `cask` and `mas` become no-ops so runners skip slow app installs.
+* **Duplicate detection.** `brew bundle` installs in parallel. A package declared in two Brewfiles races on the Homebrew lock and aborts with a cryptic error. An `assert_unique_package` guard catches the duplicate first and raises a clear error instead.
+* **CI trims GUIs.** When `$CI` is set, `cask` and `mas` skip their installs so runners don't pull slow GUI apps.
 
 A `~/Brewfile.local` is evaluated last, if present, for machine-specific packages that shouldn't live in the repo.
 
@@ -121,7 +121,7 @@ A `~/Brewfile.local` is evaluated last, if present, for machine-specific package
 
 Each language topic pins its versions in a `mise.toml` and links it into [mise](https://mise.jdx.dev/)'s drop-in config directory through its `symlinks.conf`, namespaced by topic:
 
-```
+```ini
 # go/symlinks.conf
 mise.toml:$XDG_CONFIG_HOME/mise/conf.d/go.toml
 ```
@@ -130,9 +130,9 @@ mise merges everything in `conf.d/` automatically, so each topic owns its own ru
 
 ### Dev mode and testing
 
-Symlinks point at the installed copy in `~/.dotfiles`, not a development checkout, so edits in a clone don't take effect until synced. To test changes immediately, the active root is a layer of indirection resolved on every shell in [`zsh/active-root.zsh`](zsh/active-root.zsh), with this precedence:
+Symlinks point at the installed copy in `~/.dotfiles`. Edits in a development clone don't take effect until synced. To make immediate testing possible, the active root is resolved through a layer of indirection on every shell in [`zsh/active-root.zsh`](zsh/active-root.zsh), with this precedence:
 
-```
+```text
 $DOTFILES_USE_DEV                  (throwaway test subshell)
   > ~/.dotfiles-dev-mode flag file (persistent dev mode)
     > $DOTFILES_HOME               (the installed copy)
@@ -140,21 +140,21 @@ $DOTFILES_USE_DEV                  (throwaway test subshell)
 
 Three commands drive it:
 
-* `dotfiles test` starts a subshell that loads the current checkout, session-only.
+* `dotfiles test` replaces the current shell with one that loads the checkout, session-only.
 * `dotfiles dev enable` persistently repoints every symlink to the checkout and sets the flag. `dotfiles dev disable` restores the installed copy.
 * `dotfiles status` shows which root is active and its revision.
 
-Writing the flag file and re-running `install-symlinks` happen in a single step, so the flag and the on-disk links can never disagree.
+Writing the flag file and re-running `install-symlinks` happen in a single step. The flag and the on-disk links can never disagree.
 
 ### Sync and upgrade
 
-A launchd agent ([`macos/com.user.dotfiles-upgrade.plist`](macos/com.user.dotfiles-upgrade.plist)) runs [`bin/dotfiles-upgrade`](bin/dotfiles-upgrade) nightly. It syncs from the remote, reruns `scripts/install`, and cleans up stale packages. On failure it strips ANSI codes from the log and files a Things task with the error, so a broken upgrade surfaces as a to-do rather than silent drift.
+A launchd agent ([`macos/com.user.dotfiles-upgrade.plist`](macos/com.user.dotfiles-upgrade.plist)) runs [`bin/dotfiles-upgrade`](bin/dotfiles-upgrade) nightly. It syncs from the remote, reruns `scripts/install`, and cleans up stale packages. On failure it strips ANSI codes from the log and files a Things task with the error. A broken upgrade surfaces as a to-do instead of drifting silently.
 
 `dotfiles sync` runs the same pull by hand. It refuses to sync a dirty tree, fast-forwards only, and updates submodules.
 
 ### Topic integration tests
 
-Tests run against the real post-bootstrap state, not a mock. A topic opts in by containing a `.shellspec` file, and [CI discovers them](.github/workflows/test.yml) with a glob:
+Tests run against the real post-bootstrap state. A topic opts in by containing a `.shellspec` file, and [CI discovers them](.github/workflows/test.yml) with a glob:
 
 ```bash
 for spec in */.shellspec; do
@@ -163,18 +163,18 @@ for spec in */.shellspec; do
 done
 ```
 
-Because the bootstrap job runs first, [these specs](git/spec/) verify the installed config through its symlinks, catching breakage that a static check would miss.
+Because bootstrap runs before them, [these specs](git/spec/) verify the installed config through its symlinks, catching breakage that a static check would miss.
 
 ### Bootstrap vs. install
 
-Two entry points split first-run setup from repeatable reconcile:
+Two entry points split one-time setup from the repeatable reconcile step:
 
-* [`scripts/bootstrap`](scripts/bootstrap) is the **one-time** fresh-machine path: install Homebrew, prompt for git identity, init submodules, then hand off to install.
+* [`scripts/bootstrap`](scripts/bootstrap) is the **one-time** fresh-machine path: install Homebrew, prompt for git identity, init submodules, then hand off to `dotf`, which runs install.
 * [`scripts/install`](scripts/install) is the **idempotent** core, safe to rerun nightly: `brew bundle` → install mise runtimes → install symlinks → run each topic's `install.sh` → sync the theme.
 
 The nightly upgrade and the dev-mode relink both lean on `install`, which is why it has to stay safe to run repeatedly.
 
-## Prior Art
+## Prior art
 
 * [holman](https://github.com/holman/dotfiles): Bootstrap/install scripts, initial ZSH config, colorization
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ cd ~/.dotfiles
 scripts/bootstrap
 ```
 
-## How it works
+## How It Works
 
 Everything is organized into **topic** directories: [`git/`](git/), [`zsh/`](zsh/), [`tmux/`](tmux/), and so on. A topic is a directory that follows a few naming conventions. Bootstrap and startup glob for those conventions across every topic. Adding a tool means creating a directory and dropping in the right files, with no central list to register in.
 
-### Topic conventions
+### Topic Conventions
 
 A file's name determines how and when it loads:
 
@@ -39,7 +39,7 @@ A file's name determines how and when it loads:
 
 The repo-root [`bin/`](bin/) holds executables that go on `$PATH`, like `dotfiles-upgrade` and `bench-startup`.
 
-### Shell startup
+### Shell Startup
 
 zsh startup is a glob-driven loader split across two files, following zsh's own load order:
 
@@ -70,7 +70,7 @@ _load_deferred_completions() {
 add-zsh-hook precmd _load_deferred_completions
 ```
 
-### Startup budget
+### Startup Budget
 
 [CI benchmarks startup](.github/workflows/test.yml) with [hyperfine](https://github.com/sharkdp/hyperfine) and **fails the build if median startup exceeds one second**:
 
@@ -87,7 +87,7 @@ The same job dumps a per-file [`zprof`](https://zsh.sourceforge.io/Doc/Release/Z
 
 `bin/bench-startup` measures the current worktree, or compares two.
 
-### Declarative symlinks
+### Declarative Symlinks
 
 Config files are linked into place from per-topic [`symlinks.conf`](git/symlinks.conf) files in `source:target` format, one per line. Targets expand `~` and `$XDG_CONFIG_HOME`:
 
@@ -100,7 +100,7 @@ ignore:$XDG_CONFIG_HOME/git/ignore
 
 [`scripts/install-symlinks`](scripts/install-symlinks) globs every `symlinks.conf`, creates the links, and validates each source exists. It also **prunes**: a symlink that points into the dotfiles repo but is no longer declared gets removed. Dropping a line from `symlinks.conf` is enough to unlink the file it used to manage.
 
-### Homebrew aggregation
+### Homebrew Aggregation
 
 The root [`Brewfile`](Brewfile) recursively evaluates every topic `Brewfile`. `brew bundle` from the repo root installs everything:
 
@@ -117,7 +117,7 @@ Passing `binding` means topic Brewfiles inherit the root's overridden `brew`/`ca
 
 A `~/Brewfile.local` is evaluated last, if present, for machine-specific packages that shouldn't live in the repo.
 
-### Language versions with mise
+### Language Versions with mise
 
 Each language topic pins its versions in a `mise.toml` and links it into [mise](https://mise.jdx.dev/)'s drop-in config directory through its `symlinks.conf`, namespaced by topic:
 
@@ -128,7 +128,7 @@ mise.toml:$XDG_CONFIG_HOME/mise/conf.d/go.toml
 
 mise merges everything in `conf.d/` automatically. Each topic owns its runtime versions without a shared config file. Versions are pinned exactly (never `latest`) so [Renovate](https://github.com/renovatebot/renovate) can track and bump them.
 
-### Dev mode and testing
+### Dev Mode and Testing
 
 Symlinks point at the installed copy in `~/.dotfiles`. Edits in a development clone don't take effect until synced. To test edits without syncing, the active root is resolved on every shell in [`zsh/active-root.zsh`](zsh/active-root.zsh), with this precedence:
 
@@ -146,13 +146,13 @@ Three commands drive it:
 
 Writing the flag file and re-running `install-symlinks` happen in one step.
 
-### Sync and upgrade
+### Sync and Upgrade
 
 A launchd agent ([`macos/com.user.dotfiles-upgrade.plist`](macos/com.user.dotfiles-upgrade.plist)) runs [`bin/dotfiles-upgrade`](bin/dotfiles-upgrade) nightly. It syncs from the remote, reruns `scripts/install`, and cleans up stale packages. On failure it files a Things task with the error.
 
 `dotfiles sync` runs the same pull by hand. It refuses to sync a dirty tree, fast-forwards only, and updates submodules.
 
-### Topic integration tests
+### Topic Integration Tests
 
 Tests run against the real post-bootstrap state. A topic opts in by containing a `.shellspec` file, and [CI discovers them](.github/workflows/test.yml) with a glob:
 
@@ -165,7 +165,7 @@ done
 
 Because bootstrap runs before them, [these specs](git/spec/) verify the installed config through its symlinks.
 
-### Bootstrap vs. install
+### Bootstrap vs. Install
 
 Two entry points split one-time setup from the repeatable reconcile step:
 
@@ -174,7 +174,7 @@ Two entry points split one-time setup from the repeatable reconcile step:
 
 The nightly upgrade and the dev-mode relink both call `install`.
 
-## Prior art
+## Prior Art
 
 * [holman](https://github.com/holman/dotfiles): Bootstrap/install scripts, initial ZSH config, colorization
 


### PR DESCRIPTION
The README hadn't kept up with the repo. Its "Usage" section still described a `*.symlink` convention that was replaced by declarative `symlinks.conf` files, and it documented none of the patterns that make this setup worth copying from.

Rewrites the body around a "How it works" section aimed at someone browsing the repo for ideas, not an index of topics that rots as topics come and go. It documents the durable machinery instead: the topic-directory model and its file conventions, the glob-driven two-phase shell startup, the sub-second startup budget that CI enforces, declarative symlinks with stale-link pruning, Homebrew and mise aggregation across topics, the active-root indirection behind dev mode, the nightly sync/upgrade agent, `.shellspec` integration tests, and the bootstrap-vs-install split.

Every referenced path and link points at a file that exists in the tree, and the prose was run through the repo's writing-trope audit.
