### PR TITLE
atuin: manage config as a topic with CLI completion

### DIFF
--- a/atuin/Brewfile
+++ b/atuin/Brewfile
@@ -1,0 +1,1 @@
+brew 'atuin'

--- a/atuin/completion.zsh
+++ b/atuin/completion.zsh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+
+# atuin init (in zsh/completion.zsh) sets up widgets and keybindings but not
+# completion for the atuin CLI itself. No fzf load-order dependency here.
+if (( $+commands[atuin] )); then
+  eval "$(atuin gen-completions --shell zsh)"
+fi

--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -1,0 +1,9 @@
+## Managed by the dotfiles atuin/ topic. Full option reference:
+## https://docs.atuin.sh/configuration/config/
+
+## Put the selected command on the prompt (enter runs, tab edits).
+enter_accept = true
+
+[sync]
+## Use the sync v2 record store.
+records = true

--- a/atuin/symlinks.conf
+++ b/atuin/symlinks.conf
@@ -1,0 +1,1 @@
+config.toml:$XDG_CONFIG_HOME/atuin/config.toml

--- a/zsh/Brewfile
+++ b/zsh/Brewfile
@@ -1,4 +1,3 @@
-brew 'atuin'
 brew 'highlight'
 brew 'pure'
 brew 'zsh'

--- a/zsh/completion.zsh
+++ b/zsh/completion.zsh
@@ -11,7 +11,8 @@ zstyle ':completion:*' insert-tab pending
 
 compdef _dotfiles dotfiles
 
-# loads after `fzf --zsh` (system topic) so atuin keeps ctrl-r;
+# atuin config and packaging live in the atuin/ topic. The init stays here
+# because it must load after `fzf --zsh` (system topic) so atuin keeps ctrl-r.
 # up/down arrows stay on history-substring-search
 if (( $+commands[atuin] )); then
   eval "$(atuin init zsh --disable-up-arrow)"


### PR DESCRIPTION
atuin's binary and shell init were already in the repo, but its config was a 14 KB generated file at `~/.config/atuin/config.toml`. That file was untracked, so a fresh machine wouldn't reproduce `enter_accept` or the sync record store. This gives atuin a proper topic.

- Tracks a curated `atuin/config.toml` (only the non-default settings: `enter_accept`, `[sync] records`) via `atuin/symlinks.conf`. The other ~200 lines of the generated file were commented defaults, so nothing behavioral is lost.
- Moves `brew 'atuin'` from `zsh/Brewfile` into `atuin/Brewfile`.
- Adds `atuin/completion.zsh` running `atuin gen-completions --shell zsh`, so `atuin <tab>` completes subcommands. The `init` wires up `ctrl-r`. Subcommand completion is a separate `gen-completions` step.

The `init` line stays in `zsh/completion.zsh` rather than moving into the topic: deferred completion files load alphabetically by path, and it must load after `system/completion.zsh` (`fzf --zsh`) so atuin's `ctrl-r` binding wins over fzf's. The comment there now points at the topic and explains the exception. `gen-completions` has no such ordering dependency, so it lives in the topic.

Verified locally: `scripts/install-symlinks` against a throwaway `XDG_CONFIG_HOME` creates the `config.toml` symlink into the topic, `atuin stats` loads the curated config without error, and `gen-completions` emits a valid `#compdef atuin`.
