### PR TITLE
ssh: fix tssh client formula to trzsz-ssh

### DIFF
--- a/ssh/Brewfile
+++ b/ssh/Brewfile
@@ -1,4 +1,4 @@
 brew 'mosh'
-brew 'tssh'
+brew 'trzsz-ssh'
 brew 'tsshd'
 cask 'secretive'


### PR DESCRIPTION
The `tssh` binary (Highly OpenSSH-compatible client with extended features, from trzsz) is packaged in homebrew-core as `trzsz-ssh`, not `tssh`. The `tssh` formula is a different, conflicting tool (luanruisong/tssh, "SSH Lightweight management tools") that installs the same binary name.

`tsshd` is left as-is since that's trzsz's own server component.