### PR TITLE
claude: add Peekaboo for accessibility-tree GUI automation

### DIFF
--- a/claude/Brewfile
+++ b/claude/Brewfile
@@ -1,6 +1,9 @@
+tap 'steipete/tap'
+
 cask 'claude'
 cask 'claude-code@latest'
 cask 'claude-devtools'
 cask 'commander'
 brew 'agent-browser'
 brew 'ast-grep'
+brew 'steipete/tap/peekaboo'

--- a/claude/README.md
+++ b/claude/README.md
@@ -46,3 +46,9 @@ The agent is dispatched detached and its id is logged. Monitoring and attach hap
 ### Curation
 
 `CLAUDE_AGENTS_ADD_DIR` (colon-separated) passes tool-access directories as repeated `--add-dir` to both the launcher's dispatch and the popup.
+
+## Computer Use
+
+Claude Code's built-in `computer-use` MCP drives the macOS GUI with screenshots and mouse/keyboard input. [Peekaboo](https://github.com/steipete/peekaboo) is the accessibility-tree fallback for cases where screenshot perception is brittle or too costly: `peekaboo see` snapshots the AX tree with element IDs, then `peekaboo click`/`type` target those IDs. Call it from any agent via the CLI.
+
+Both need **Screen Recording** and **Accessibility** granted in System Settings > Privacy & Security. They fail silently without them.


### PR DESCRIPTION
Adds [Peekaboo](https://github.com/steipete/peekaboo) to the `claude` topic so agents have accessibility-tree perception for macOS GUI automation, alongside a short README note on the permission requirement.

This is the tooling half of a "computer use" project (let agents drive the Mac GUI for authorized auth clicks, native/Raycast app testing, and screen awareness). I scoped it down by trialing Claude Code's built-in `computer-use` MCP live: its action layer (mouse/keyboard/batch) and screenshot perception cover the common cases well, and the per-app allowlist correctly refused a click that would have landed on an ungranted overlay window. What it lacks is accessibility-tree perception, so screenshot pixel-clicking gets brittle on dense or layered native UIs. Peekaboo fills exactly that gap: `peekaboo see` snapshots the AX tree with element IDs, then `click`/`type` target IDs instead of coordinates.

Installing the Peekaboo CLI is enough. I deliberately did not register its MCP server: with the built-in MCP handling actions and the CLI callable from any agent via Bash for advanced perception, the MCP wrapper would only re-expose the same binary. `mcp-server-macos-use` was also dropped (Swift source build, no formula, overlaps Peekaboo).

Verified the aggregated root `Brewfile` discovers both the new `steipete/tap` tap and the `steipete/tap/peekaboo` formula (so `scripts/install-trust` taps and trusts it), and that `assert_unique_package` does not trip.
