### PR TITLE
git,github: add aliases from history analysis

### DIFF
--- a/git/aliases.zsh
+++ b/git/aliases.zsh
@@ -2,11 +2,17 @@
 
 alias g='git'
 
+alias ga='git add'
 alias gb='git branch'
 alias gc='git commit'
 alias gco='git checkout'
+alias gd='git diff'
+alias gf='git fetch'
+alias gl='git log'
 alias gp='git push'
 alias gr='git rebase'
+alias grs='git reset'
 alias gs='git status'
+alias gsw='git switch'
 
 alias lg='lazygit'

--- a/github/aliases.zsh
+++ b/github/aliases.zsh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+
+alias ghm='gh pr merge'
+alias ghd='gh pr diff'
+alias ghv='gh pr view'


### PR DESCRIPTION
Adds aliases for the commands I type most in full, grounded in atuin frequency data (this machine's 10k-command history, all-time).

The git family had a tight convention (`g gb gc gco gp gr gs`) with obvious gaps. These six subcommands were typed out with no alias: `git add` (188), `git switch` (73), `git fetch` (67), `git diff` (61), `git reset` (45), `git log` (44). They get `ga gsw gf gd grs gl`. All names are collision-free against the existing set (`gr` stays rebase). `gsw` is deliberate: `git switch` (73) and `git restore` (26) show a migration away from `checkout`, so it earns a short alias going forward alongside the existing `gco`.

`gh pr` is my most-typed multiword command (125 uses in 6 months: `merge` 57, `diff` 22, `view` 14). It gets a new `github/aliases.zsh`, since the topic had no aliases file, with `ghm ghd ghv`.

The `gh` ones are plain zsh aliases rather than `gh alias set`. `zsh/completion.zsh` sets `no_complete_aliases`, so a command-position alias inherits its expansion's completion. `ghm --<TAB>` still offers `gh pr merge` flags, the same mechanism that already makes `gco <TAB>` complete branches. The existing native `co: pr checkout` in `~/.config/gh/config.yml` is untouched.

Aliases are eager-loaded by the `$ZSH/**/*.zsh` glob in `zsh/.zshrc` (only `path.zsh` and `completion.zsh` are excluded), so they cost nothing at startup and a fresh shell resolves them.

Verified by sourcing both files in a fresh zsh. `whence -w` reports each as an alias, `alias ga ghm` expands to `git add` and `gh pr merge`, and `zsh -n` passes on both files.
