### PR TITLE
claude: fix agents popup crash and always-on status pill

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -41,7 +41,7 @@ The agent is dispatched detached and its id is logged. Monitoring and attach hap
 
 ### Tmux Popup and Status Chip
 
-`prefix a` opens the agent view in a popup, near-fullscreen on a narrow client. A 󰚩 pill appears in the status bar while a background agent is waiting on your input, and disappears once none are.
+`prefix a` opens the agent view in a popup, near-fullscreen on a narrow client. A 󰚩 pill appears in the status bar while a background agent is waiting on your input, and disappears when none remain.
 
 ### Curation
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -41,7 +41,7 @@ The agent is dispatched detached and its id is logged. Monitoring and attach hap
 
 ### Tmux Popup and Status Chip
 
-`prefix a` opens the agent view in a popup, near-fullscreen on a narrow client. A 󰚩 pill appears in the status bar while any background agent has finished or is blocked on input, and disappears at zero.
+`prefix a` opens the agent view in a popup, near-fullscreen on a narrow client. A 󰚩 pill appears in the status bar while a background agent is waiting on your input, and disappears once none are.
 
 ### Curation
 

--- a/tmux/appearance/status.conf
+++ b/tmux/appearance/status.conf
@@ -12,8 +12,10 @@ source-file ~/.config/tmux/appearance/modules/claude.conf
 
 # Leading space keeps each pill from touching its neighbor. Both segments render
 # only when their count is nonzero. Narrow clients swap the catppuccin pills for
-# the transparent-friendly chips defined in responsive.conf.
-set -g status-right "#{?#{==:#(_tmux-claude-agents-count),0},, #{?#{E:@resp_is_narrow},#{E:@resp_sr_claude_narrow},#{E:@catppuccin_status_claude}}}#{?#{==:#(_tmux-bell-count),0},, #{?#{E:@resp_is_narrow},#{E:@resp_sr_narrow},#{E:@catppuccin_status_bell}}}"
+# the transparent-friendly chips defined in responsive.conf. The claude gate
+# matches on a nonzero digit rather than != 0, so a transient empty value (async
+# first render, or a query failure) hides the pill instead of failing open.
+set -g status-right "#{?#{m:*[1-9]*,#(~/.config/tmux/claude/bin/_tmux-claude-agents-count)}, #{?#{E:@resp_is_narrow},#{E:@resp_sr_claude_narrow},#{E:@catppuccin_status_claude}},}#{?#{==:#(_tmux-bell-count),0},, #{?#{E:@resp_is_narrow},#{E:@resp_sr_narrow},#{E:@catppuccin_status_bell}}}"
 
 # Narrow window list: capture catppuccin's generated pill formats and wrap them
 # in the per-client narrowness predicate (narrow branches live in

--- a/tmux/claude/bin/_tmux-claude-agents-count
+++ b/tmux/claude/bin/_tmux-claude-agents-count
@@ -19,7 +19,7 @@ if [[ -f "$cache" ]]; then
   # Only serve a fresh cache whose contents are an integer. A poisoned empty
   # cache (e.g. from a failed query) must fall through and re-query rather
   # than pin the pill to a bad value for the whole TTL.
-  cached=$(cat "$cache")
+  cached=$(<"$cache")
   if (( now - mtime < ttl )) && [[ "$cached" =~ ^[0-9]+$ ]]; then
     printf '%s\n' "$cached"
     exit 0

--- a/tmux/claude/bin/_tmux-claude-agents-count
+++ b/tmux/claude/bin/_tmux-claude-agents-count
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Count background agents that finished or are waiting on input
-# (state done/blocked), for the status-right pill. Mirrors _tmux-bell-count:
-# prints a single integer.
+# Count background agents that are waiting on your input (state blocked),
+# for the status-right pill. Mirrors _tmux-bell-count: prints a single integer.
+# To also surface auth/failure states later, widen the jq select below to
+# .state | IN("blocked","waiting_for_login","error","crashed","failed").
 #
 # `claude agents --json` is ~0.35s and status-right redraws every
 # status-interval, so the result is cached with a short mtime TTL and only
@@ -15,14 +16,18 @@ ttl=10
 if [[ -f "$cache" ]]; then
   now=$(date +%s)
   mtime=$(stat -f %m "$cache" 2>/dev/null || echo 0)
-  if (( now - mtime < ttl )); then
-    cat "$cache"
+  # Only serve a fresh cache whose contents are an integer. A poisoned empty
+  # cache (e.g. from a failed query) must fall through and re-query rather
+  # than pin the pill to a bad value for the whole TTL.
+  cached=$(cat "$cache")
+  if (( now - mtime < ttl )) && [[ "$cached" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$cached"
     exit 0
   fi
 fi
 
 count=$(claude agents --json 2>/dev/null \
-  | jq '[.[] | select(.state == "done" or .state == "blocked")] | length' 2>/dev/null)
+  | jq '[.[] | select(.state == "blocked")] | length' 2>/dev/null)
 [[ "$count" =~ ^[0-9]+$ ]] || count=0
 
 # Write via temp + rename so a concurrent redraw never reads a torn count.

--- a/tmux/claude/claude.conf
+++ b/tmux/claude/claude.conf
@@ -6,13 +6,14 @@
 # --add-dir flags so sessions dispatched from the view inherit the curated
 # tool-access dirs.
 bind -N "Claude agents" a if -F "#{E:@resp_is_narrow}" \
-  "display-popup -E -w 100% -h 100% _tmux-claude-agents" \
-  "display-popup -E -w 85% -h 85% _tmux-claude-agents"
+  "display-popup -E -w 100% -h 100% ~/.config/tmux/claude/bin/_tmux-claude-agents" \
+  "display-popup -E -w 85% -h 85% ~/.config/tmux/claude/bin/_tmux-claude-agents"
 
 # Inputs for the agent-attention pill, built into @catppuccin_status_claude by
 # appearance/status.conf (post-TPM) with the same module builder as the bell
-# pill and gated there on a nonzero count. 󰚩 marks agents that finished or are
-# blocked on input.
+# pill and gated there on a nonzero count. 󰚩 marks a background agent waiting
+# on your input. Absolute path: the running server's PATH froze before this
+# topic existed, so a bare script name resolves to command-not-found.
 set -g @catppuccin_claude_icon "󰚩 "
 set -g @catppuccin_claude_color "#{@thm_mauve}"
-set -g @catppuccin_claude_text " #(_tmux-claude-agents-count)"
+set -g @catppuccin_claude_text " #(~/.config/tmux/claude/bin/_tmux-claude-agents-count)"

--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -58,10 +58,11 @@ set -g @resp_ws_narrow '#[fg=#{E:@resp_chip_bg}]#[fg=#{E:@resp_chip_fg},bg=#{
 # @resp_ws_narrow. status.conf gates it behind a nonzero bell count.
 set -g @resp_sr_narrow '#[fg=#{@thm_yellow}]#[fg=#{@thm_crust},bg=#{@thm_yellow}] #(_tmux-bell-count)#[fg=#{@thm_yellow},bg=default]#[default]'
 
-# Agent-attention indicator for the narrow status-right (finished/blocked
-# background agents). Same chip technique as the bell chip above; status.conf
-# gates it behind a nonzero count.
-set -g @resp_sr_claude_narrow '#[fg=#{@thm_mauve}]#[fg=#{@thm_crust},bg=#{@thm_mauve}] 󰚩 #(_tmux-claude-agents-count)#[fg=#{@thm_mauve},bg=default]#[default]'
+# Agent-attention indicator for the narrow status-right (a background agent
+# waiting on your input). Same chip technique as the bell chip above; status.conf
+# gates it behind a nonzero count. Absolute path because the running server's
+# frozen PATH can predate this topic, leaving a bare script name unresolvable.
+set -g @resp_sr_claude_narrow '#[fg=#{@thm_mauve}]#[fg=#{@thm_crust},bg=#{@thm_mauve}] 󰚩 #(~/.config/tmux/claude/bin/_tmux-claude-agents-count)#[fg=#{@thm_mauve},bg=default]#[default]'
 
 # Current window: rounded pill with index block + name + zoom flag. The name is
 # window_name, the working directory under automatic-rename and the manual name


### PR DESCRIPTION
## Problem

The `prefix a` agents popup crashed on launch and the 󰚩 status pill showed permanently while displaying nothing. Both came from one cause: `tmux/claude/bin` is not on the running tmux server's PATH.

The server froze its PATH at startup, before the `claude` topic existed. `tmux/path.zsh` only adds `tmux/*/bin` to newly-spawned shells via `zshenv`. The long-lived server never picked up the new directory. Its older siblings (`alerts/bin`, `navigation/bin`, `session/bin`) predate the server and are present.

- Popup: `display-popup -E _tmux-claude-agents` resolved to command-not-found. The popup opened and closed instantly.
- Pill: `#(_tmux-claude-agents-count)` returned an empty string. The gate `#{?#{==:#(...),0},,pill}` compared `"" == "0"`, got false, and rendered the pill permanently with no count.

Running either script by absolute path returned the correct result. The scripts were healthy. Only resolution was broken.

The filter was also wrong on its own terms. It counted `state == "done" or "blocked"`. `done` is sticky and passive: a completed agent stayed `done` in the feed for days, keeping the pill lit.

## Changes

- Resolve every call site by the config-relative absolute path `~/.config/tmux/claude/bin/...` (the symlinked install location). This drops the server-PATH dependency and survives future server restarts. Call sites: the popup binding and pill text in `claude.conf`, the gate in `status.conf`, and the narrow chip in `responsive.conf`.
- Narrow the pill filter to `blocked` (awaiting input) only. That is the self-clearing, act-now signal you would otherwise miss. `done` and `working` remain visible inside the `prefix a` view, which is where you go to see them. To surface auth and failure states later, widen the one-line `jq` select noted in the script comment.
- Harden against empty values. The count cache is served only when it holds an integer. A poisoned empty cache no longer pins the pill for the TTL. The status gate matches on a nonzero digit rather than `!= 0`. A transient empty value now hides the pill instead of failing open.

## Verification

- `~/.config/tmux/claude/bin/_tmux-claude-agents-count` returns an integer. Under the bare server PATH it exits 127.
- Dispatched a background agent that waits on input, confirmed its `state` is `blocked` in `claude agents --json`, and confirmed the new filter counts it (`1`) while a `done`-only feed counts `0` under the new filter and `1` under the old.
- The gate format hides the pill on both `0` and empty, and shows it on any nonzero count.
- Sourced `tmux/claude/claude.conf` into the running server and confirmed the `prefix a` binding now carries the absolute path. The popup resolves.

The `status.conf` and `responsive.conf` changes land on the next `dotfiles sync`. I did not source `status.conf` into the live server because its own comments document a self-capture hazard under a concurrent retheme.
