### PR TITLE
activitywatch: ingest iOS/iPadOS screen time from Biome

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,9 @@ repos:
     rev: v0.8.4
     hooks:
       - id: ruff
+        exclude: (^|/)vendor/
       - id: ruff-format
+        exclude: (^|/)vendor/
 
   - repo: local
     hooks:

--- a/activitywatch/install.sh
+++ b/activitywatch/install.sh
@@ -34,3 +34,11 @@ if [[ -z "${NONINTERACTIVE-}" ]]; then
   gum log --level info "  1. Grant Accessibility to ActivityWatch: System Settings > Privacy & Security > Accessibility (window titles need it)"
   gum log --level info "  2. Launch it once from this terminal so the prompt fires: open -a ActivityWatch"
 fi
+
+# The com.user.screentime-ingest LaunchAgent reads ~/Library/Biome, which is
+# TCC-protected. Grant Full Disk Access to /bin/zsh (the agent's interpreter) so
+# the ingest can decode the synced iOS/iPadOS App.InFocus streams.
+if [[ -z "${NONINTERACTIVE-}" ]]; then
+  gum log --level info "Screen Time ingest one-time setup:"
+  gum log --level info "  Grant Full Disk Access to /bin/zsh: System Settings > Privacy & Security > Full Disk Access (reads ~/Library/Biome)"
+fi

--- a/activitywatch/screentime/README.md
+++ b/activitywatch/screentime/README.md
@@ -1,0 +1,48 @@
+# Screen Time Ingest
+
+`ingest.py` decodes iOS/iPadOS app-focus history from the local Biome store
+(synced by Screen Time's "Share Across Devices") into a SQLite database, so the
+`activitywatch:activity` skill can report phone/tablet usage alongside the Mac's
+own ActivityWatch capture.
+
+## How It Works
+
+Screen Time syncs each remote device's `App.InFocus` stream to
+`~/Library/Biome/streams/restricted/App.InFocus/remote/<device>/`. Every record
+is one focus-change edge (an app gained or lost the foreground). The ingest:
+
+1. Discovers each remote device dir that holds data.
+2. Decodes the SEGB segment files (vendored `ccl_segb`, MIT) and reads three
+   protobuf fields per record: foreground flag, `CFAbsoluteTime`, bundle id.
+3. Pairs consecutive edges into `[start, end]` intervals.
+4. Appends intervals to the store, tracking a per-device timestamp watermark and
+   the still-open interval so re-runs are incremental and idempotent.
+
+`com.user.screentime-ingest` (see `macos/`) runs it hourly. It needs Full Disk
+Access to read `~/Library/Biome`.
+
+## Store
+
+`~/Library/Application Support/activitywatch/screentime/screentime.db`
+
+- `app_in_focus(device, bundle_id, start_unix, end_unix, duration_s, start_utc)`
+- `device(device, model, platform)`
+- `ingest_state(device, last_cf, open_bundle, open_start_cf)` holds the per-device ingest watermark
+
+Read it with the same DuckDB `ATTACH ... (READ_ONLY)` pattern the skill uses for
+the ActivityWatch db:
+
+```sql
+INSTALL sqlite; LOAD sqlite;
+ATTACH 'screentime.db' AS st (TYPE sqlite, READ_ONLY);
+SELECT bundle_id, sum(duration_s) / 3600 AS hours
+FROM st.app_in_focus GROUP BY bundle_id ORDER BY hours DESC;
+```
+
+## Limitations
+
+- Durations are best-effort: macOS occasionally logs incomplete foreground
+  spans, so totals run slightly under Screen Time.app.
+- Apple prunes the raw segment files, so ingest cadence bounds history retention.
+- `bundle_id` is the raw identifier (`com.google.ios.youtube`); friendly names
+  would need an App Store lookup, left to the reader.

--- a/activitywatch/screentime/ingest.py
+++ b/activitywatch/screentime/ingest.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Ingest iOS/iPadOS app-focus history from the local Biome store into SQLite.
+
+Screen Time's "Share Across Devices" syncs each remote device's App.InFocus
+stream to this Mac under ~/Library/Biome. Every record is a single focus-change
+edge (an app gained or lost foreground); pairing consecutive edges yields the
+per-app intervals this writes to a local SQLite db, which the activitywatch
+skill attaches read-only alongside the Mac's own ActivityWatch capture.
+
+SEGB decoding is delegated to the vendored ccl_segb reader. The App.InFocus
+protobuf is decoded inline: only three fields are needed, so the full protobuf
+runtime and Apple's schema are avoided.
+
+Reading ~/Library/Biome requires Full Disk Access for whatever runs this.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sqlite3
+import struct
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "vendor"))
+
+from ccl_segb import read_segb_file  # noqa: E402
+from ccl_segb.ccl_segb_common import EntryState  # noqa: E402
+
+# CFAbsoluteTime counts seconds from 2001-01-01; add this to reach the Unix epoch.
+APPLE_EPOCH_OFFSET = 978_307_200
+
+BIOME_BASE = Path.home() / "Library" / "Biome"
+APP_IN_FOCUS = BIOME_BASE / "streams" / "restricted" / "App.InFocus" / "remote"
+SYNC_DB = BIOME_BASE / "sync" / "sync.db"
+
+DEFAULT_STORE = (
+    Path.home()
+    / "Library"
+    / "Application Support"
+    / "activitywatch"
+    / "screentime"
+    / "screentime.db"
+)
+
+# DevicePeer.platform values worth ingesting. The Mac itself (3) is already
+# covered by ActivityWatch, so only the phone and tablet are pulled here.
+PLATFORM_LABELS = {1: "iOS", 2: "iOS", 3: "macOS", 7: "iPadOS"}
+
+
+def read_device_meta(sync_db: Path) -> dict[str, dict]:
+    """Map device UUID -> {model, platform} from the Biome sync database."""
+    if not sync_db.exists():
+        return {}
+    uri = f"file:{sync_db}?immutable=1"
+    with sqlite3.connect(uri, uri=True) as con:
+        rows = con.execute(
+            "SELECT device_identifier, model, platform FROM DevicePeer WHERE me = 0"
+        ).fetchall()
+    return {r[0]: {"model": r[1], "platform": r[2]} for r in rows if r[0]}
+
+
+def discover_devices(sync_db: Path) -> list[dict]:
+    """Return every remote device with App.InFocus data, enriched from DevicePeer.
+
+    The Mac's own stream lives under local/, so every remote/ device is a peer
+    sharing Screen Time. DevicePeer is consulted only for a model/platform label,
+    since data-bearing streams are not always registered there.
+    """
+    if not APP_IN_FOCUS.is_dir():
+        return []
+    meta = read_device_meta(sync_db)
+    devices = []
+    for device_dir in sorted(APP_IN_FOCUS.iterdir()):
+        if not device_dir.is_dir():
+            continue
+        has_data = any(
+            p.is_file() for p in device_dir.iterdir() if p.name != "tombstone"
+        )
+        if not has_data:
+            continue
+        m = meta.get(device_dir.name, {})
+        devices.append(
+            {
+                "device": device_dir.name,
+                "model": m.get("model"),
+                "platform": PLATFORM_LABELS.get(m.get("platform"), "unknown"),
+            }
+        )
+    return devices
+
+
+def _read_varint(buf: bytes, i: int) -> tuple[int, int]:
+    result = shift = 0
+    while True:
+        b = buf[i]
+        i += 1
+        result |= (b & 0x7F) << shift
+        if not b & 0x80:
+            return result, i
+        shift += 7
+
+
+def parse_app_in_focus(data: bytes) -> tuple[float, int, str] | None:
+    """Decode an App.InFocus protobuf record into (cf_time, in_foreground, bundle).
+
+    Fields consumed: 3 (in_foreground uint32), 4 (cf_absolute_time double),
+    6 (bundle_id string). Everything else is skipped by wire type. Returns None
+    if the record lacks a timestamp or bundle id.
+    """
+    i, n = 0, len(data)
+    in_fg: int | None = None
+    cf: float | None = None
+    bundle: str | None = None
+    while i < n:
+        tag, i = _read_varint(data, i)
+        field, wire = tag >> 3, tag & 0x7
+        if wire == 0:
+            val, i = _read_varint(data, i)
+            if field == 3:
+                in_fg = val
+        elif wire == 1:
+            if field == 4:
+                cf = struct.unpack_from("<d", data, i)[0]
+            i += 8
+        elif wire == 2:
+            length, i = _read_varint(data, i)
+            if field == 6:
+                bundle = data[i : i + length].decode("utf-8", "replace")
+            i += length
+        elif wire == 5:
+            i += 4
+        else:
+            raise ValueError(f"unsupported wire type {wire}")
+    if cf is None or bundle is None or in_fg is None:
+        return None
+    return cf, in_fg, bundle
+
+
+def iter_focus_edges(device_dir: Path):
+    """Yield (cf_time, in_foreground, bundle_id) for every App.InFocus edge.
+
+    Recent edges can appear in older segment files, so every file is scanned;
+    the caller clips by timestamp watermark rather than by file.
+    """
+    for seg in sorted(p for p in device_dir.iterdir() if p.is_file()):
+        try:
+            records = read_segb_file(str(seg))
+        except ValueError:
+            continue  # not a SEGB file (lock, stray)
+        for record in records:
+            if record.state != EntryState.Written or not any(record.data):
+                continue
+            try:
+                parsed = parse_app_in_focus(record.data)
+            except (IndexError, ValueError, struct.error):
+                continue
+            if parsed is not None:
+                yield parsed
+
+
+def stitch(edges, open_state):
+    """Pair focus-change edges into closed [start, end] intervals.
+
+    An interval opens when an app gains foreground and closes when it loses
+    foreground or a different app takes over. The last interval stays open and
+    is carried across runs via `open_state`.
+    """
+    intervals = []
+    cur = open_state
+    for cf, in_fg, bundle in edges:
+        if in_fg == 1:
+            if cur is not None and cur["bundle"] != bundle:
+                intervals.append((cur["bundle"], cur["start_cf"], cf))
+                cur = {"bundle": bundle, "start_cf": cf}
+            elif cur is None:
+                cur = {"bundle": bundle, "start_cf": cf}
+        elif cur is not None and cur["bundle"] == bundle:
+            intervals.append((cur["bundle"], cur["start_cf"], cf))
+            cur = None
+    return intervals, cur
+
+
+def init_store(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(db_path)
+    con.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS device (
+            device   TEXT PRIMARY KEY,
+            model    TEXT,
+            platform TEXT
+        );
+        CREATE TABLE IF NOT EXISTS app_in_focus (
+            device      TEXT NOT NULL,
+            bundle_id   TEXT NOT NULL,
+            start_unix  REAL NOT NULL,
+            end_unix    REAL NOT NULL,
+            duration_s  REAL NOT NULL,
+            start_utc   TEXT NOT NULL,
+            PRIMARY KEY (device, bundle_id, start_unix)
+        );
+        CREATE TABLE IF NOT EXISTS ingest_state (
+            device        TEXT PRIMARY KEY,
+            last_cf       REAL NOT NULL,
+            open_bundle   TEXT,
+            open_start_cf REAL
+        );
+        """
+    )
+    return con
+
+
+def ingest_device(con: sqlite3.Connection, dev: dict) -> int:
+    device_dir = APP_IN_FOCUS / dev["device"]
+    if not device_dir.is_dir():
+        return 0
+
+    row = con.execute(
+        "SELECT last_cf, open_bundle, open_start_cf FROM ingest_state WHERE device = ?",
+        (dev["device"],),
+    ).fetchone()
+    last_cf = row[0] if row else 0.0
+    open_state = (
+        {"bundle": row[1], "start_cf": row[2]} if row and row[1] is not None else None
+    )
+
+    edges = [e for e in iter_focus_edges(device_dir) if e[0] > last_cf]
+    edges.sort(key=lambda e: e[0])
+    if not edges and open_state is None:
+        return 0
+
+    intervals, open_state = stitch(edges, open_state)
+    for bundle, start_cf, end_cf in intervals:
+        start_unix = start_cf + APPLE_EPOCH_OFFSET
+        end_unix = end_cf + APPLE_EPOCH_OFFSET
+        con.execute(
+            "INSERT OR IGNORE INTO app_in_focus "
+            "(device, bundle_id, start_unix, end_unix, duration_s, start_utc) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                dev["device"],
+                bundle,
+                start_unix,
+                end_unix,
+                end_unix - start_unix,
+                dt.datetime.fromtimestamp(start_unix, dt.timezone.utc).isoformat(),
+            ),
+        )
+
+    new_last_cf = max((e[0] for e in edges), default=last_cf)
+    con.execute(
+        "INSERT INTO ingest_state (device, last_cf, open_bundle, open_start_cf) "
+        "VALUES (?, ?, ?, ?) ON CONFLICT(device) DO UPDATE SET "
+        "last_cf = excluded.last_cf, open_bundle = excluded.open_bundle, "
+        "open_start_cf = excluded.open_start_cf",
+        (
+            dev["device"],
+            new_last_cf,
+            open_state["bundle"] if open_state else None,
+            open_state["start_cf"] if open_state else None,
+        ),
+    )
+    con.execute(
+        "INSERT INTO device (device, model, platform) VALUES (?, ?, ?) "
+        "ON CONFLICT(device) DO UPDATE SET model = excluded.model, "
+        "platform = excluded.platform",
+        (dev["device"], dev["model"], dev["platform"]),
+    )
+    return len(intervals)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db", type=Path, default=DEFAULT_STORE, help="SQLite store path"
+    )
+    parser.add_argument(
+        "--sync-db", type=Path, default=SYNC_DB, help="Biome sync.db path"
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="suppress the per-run summary"
+    )
+    args = parser.parse_args()
+
+    devices = discover_devices(args.sync_db)
+    if not devices:
+        if not args.quiet:
+            print("no iOS/iPadOS App.InFocus data found", file=sys.stderr)
+        return 0
+
+    con = init_store(args.db)
+    total = 0
+    try:
+        for dev in devices:
+            written = ingest_device(con, dev)
+            total += written
+            if not args.quiet:
+                print(f"{dev['platform']} {dev['device'][:8]}: +{written} intervals")
+        con.commit()
+    finally:
+        con.close()
+
+    if not args.quiet:
+        print(f"ingested {total} intervals from {len(devices)} device(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/activitywatch/screentime/vendor/ccl_segb/LICENSE
+++ b/activitywatch/screentime/vendor/ccl_segb/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/activitywatch/screentime/vendor/ccl_segb/__init__.py
+++ b/activitywatch/screentime/vendor/ccl_segb/__init__.py
@@ -1,0 +1,1 @@
+from .ccl_segb import read_segb_file

--- a/activitywatch/screentime/vendor/ccl_segb/ccl_segb.py
+++ b/activitywatch/screentime/vendor/ccl_segb/ccl_segb.py
@@ -1,0 +1,34 @@
+"""
+Copyright 2023-2025, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+import os
+import pathlib
+from . import ccl_segb1
+from . import ccl_segb2
+
+
+def read_segb_file(file_path: pathlib.Path | os.PathLike | str):
+    if ccl_segb1.file_matches_segbv1_signature(file_path):
+        return ccl_segb1.read_segb1_file(file_path)
+    elif ccl_segb2.file_matches_segbv2_signature(file_path):
+        return ccl_segb2.read_segb2_file(file_path)
+    else:
+        raise ValueError("File is not a SEGB File", file_path)

--- a/activitywatch/screentime/vendor/ccl_segb/ccl_segb1.py
+++ b/activitywatch/screentime/vendor/ccl_segb/ccl_segb1.py
@@ -1,0 +1,156 @@
+import datetime
+import struct
+import typing
+import dataclasses
+import pathlib
+import os
+import zlib
+from .ccl_segb_common import bytes_to_hexview, decode_cocoa_time, EntryState
+
+"""
+Copyright 2023, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+__version__ = "0.3"
+__description__ = "A python module to read SEGB v1 files found on iOS, macOS etc."
+__contact__ = "Alex Caithness"
+
+MAGIC = b"SEGB"
+HEADER_LENGTH = 56
+RECORD_HEADER_LENGTH = 32
+ALIGNMENT_BYTES_LENGTH = 8
+
+
+@dataclasses.dataclass(frozen=True)
+class Segb1Entry:
+    timestamp1: datetime.datetime
+    timestamp2: datetime.datetime
+    data_start_offset: int
+    metadata_crc: int
+    actual_crc: int
+    data: bytes
+    state: EntryState
+    _unknown_value: int = dataclasses.field(kw_only=True, compare=False)
+
+    @property
+    def crc_passed(self):
+        return self.metadata_crc == self.actual_crc
+
+
+def stream_matches_segbv1_signature(stream: typing.BinaryIO) -> bool:
+    """
+    Returns True if the stream contains data matching the SEGB v1 file signature. Resets the stream to the same position
+    before returning.
+
+    :param stream: The stream potentially containing SEGB v1 data
+    :return: True if the stream contains data matching the SEGB v1 file signature.
+    """
+    reset_offset = stream.tell()
+    file_header = stream.read(HEADER_LENGTH)
+    stream.seek(reset_offset, os.SEEK_SET)
+
+    if len(file_header) != HEADER_LENGTH or file_header[-4:] != MAGIC:
+        return False
+
+    # TODO: consider whether we should check the end of data offset is less than the stream's size?
+    return True
+
+
+def file_matches_segbv1_signature(path: pathlib.Path | os.PathLike | str) -> bool:
+    """
+    Returns True if the file at the given path contains data matching the SEGB v1 file signature. Resets the stream to
+    the same position before returning.
+
+    :param path: The path of the file potentially containing SEGB v1 data
+    :return: True if the stream contains data matching the SEGB v1 file signature.
+    """
+    path = pathlib.Path(path)
+    with path.open("rb") as f:
+        return stream_matches_segbv1_signature(f)
+
+
+def read_segb1_stream(stream: typing.BinaryIO) -> typing.Iterable[Segb1Entry]:
+    """
+    Reads SEGB v1 data from a stream and yields an iterable of Segb1Entry objects
+    :param stream: a binary stream containing the SEGB data. The data is assumed to begin at the start of the stream
+    :return: an iterable of Segb1Entry objects
+    """
+    file_header = stream.read(HEADER_LENGTH)
+    if len(file_header) != HEADER_LENGTH or file_header[-4:] != MAGIC:
+        raise ValueError(f"Unexpected file magic. Expected: {MAGIC.hex()}; got: {file_header[-4:].hex()}")
+
+    end_of_data_offset, = struct.unpack("<I", file_header[0:4])
+
+    while stream.tell() < end_of_data_offset:
+        record_header_raw = stream.read(RECORD_HEADER_LENGTH)
+        record_length, entry_state_raw, timestamp1_raw, timestamp2_raw, crc32_stored, unknown_raw = struct.unpack(
+            "<iiddIi", record_header_raw[:32])
+        timestamp1 = decode_cocoa_time(timestamp1_raw)
+        timestamp2 = decode_cocoa_time(timestamp2_raw)
+
+        record_offset = stream.tell()
+
+        data = stream.read(record_length)
+        calculated_crc32 = zlib.crc32(data)
+        yield Segb1Entry(timestamp1, timestamp2, record_offset, crc32_stored, calculated_crc32, data,
+                                 EntryState(entry_state_raw), _unknown_value=unknown_raw)
+
+
+        # align to 8 bytes
+        if (remainder := stream.tell() % ALIGNMENT_BYTES_LENGTH) != 0:
+            stream.seek(ALIGNMENT_BYTES_LENGTH - remainder, os.SEEK_CUR)
+
+
+def read_segb1_file(path: pathlib.Path | os.PathLike | str) -> typing.Iterable[Segb1Entry]:
+    """
+    Reads SEGB v1 data from a file and yields an iterable of Segb1Entry objects
+    :param path: the path of the file to be opened
+    :return: an iterable of Segb1Entry objects
+    """
+    path = pathlib.Path(path)
+    with path.open("rb") as f:
+        yield from read_segb1_stream(f)
+
+
+def run_command(file_path: pathlib.Path | os.PathLike | str):
+    for record in read_segb1_file(file_path):
+        print("=" * 72)
+        print(f"Offset: {record.data_start_offset}")
+        print(f"Timestamp1: {record.timestamp1}")
+        print(f"Timestamp2: {record.timestamp2}")
+        if record.state == 1:
+            print(f"CRC Passed: {'True' if record.crc_passed else 'False'}")
+        print()
+        print(bytes_to_hexview(record.data))
+        print()
+    print("End of records")
+
+
+if __name__ == '__main__':
+    import sys
+
+    if len(sys.argv) < 2:
+        print(f"USAGE: {pathlib.Path(sys.argv[0]).name} <SEGB1 file>")
+        print()
+        exit(1)
+
+    run_command(sys.argv[1])
+    print()

--- a/activitywatch/screentime/vendor/ccl_segb/ccl_segb2.py
+++ b/activitywatch/screentime/vendor/ccl_segb/ccl_segb2.py
@@ -1,0 +1,220 @@
+"""
+Copyright 2023, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# This module is based upon information provided by Cellebrite,
+# found at: https://cellebrite.com/en/understanding-and-decoding-the-newest-ios-segb-format/
+# Thank you for posting the research!
+
+
+import os
+import pathlib
+import struct
+import dataclasses
+import typing
+import datetime
+import zlib
+from .ccl_segb_common import bytes_to_hexview, decode_cocoa_time, EntryState
+
+__version__ = "0.4"
+__description__ = "A python module to read SEGB v2 files found on iOS, macOS etc."
+__contact__ = "Alex Caithness"
+
+HEADER_LENGTH = 32
+ENTRY_HEADER_LENGTH = 8
+TRAILER_ENTRY_LENGTH = 16
+MAGIC = b"SEGB"
+
+
+@dataclasses.dataclass(frozen=True)
+class EntryMetadata:
+    """
+    This class relates to the trailer structures
+    """
+    metadata_offset: int
+    end_offset: int
+    state: EntryState
+    creation: datetime.datetime
+
+
+@dataclasses.dataclass(frozen=True)
+class Segb2Entry:
+    metadata: EntryMetadata
+    data_start_offset: int
+    metadata_crc: int
+    actual_crc: int
+    data: bytes
+    _unknown_value: int = dataclasses.field(kw_only=True, compare=False)
+
+    @property
+    def timestamp1(self) -> datetime:
+        return self.metadata.creation
+
+    @property
+    def crc_passed(self):
+        return self.metadata_crc == self.actual_crc
+
+    @property
+    def state(self):
+        return self.metadata.state
+
+
+def stream_matches_segbv2_signature(stream: typing.BinaryIO) -> bool:
+    """
+    Returns True if the stream contains data matching the SEGB v2 file signature. Resets the stream to the same position
+    before returning.
+
+    :param stream: The stream potentially containing SEGB v2 data
+    :return: True if the stream contains data matching the SEGB v2 file signature.
+    """
+    reset_offset = stream.tell()
+    file_header = stream.read(HEADER_LENGTH)
+    stream.seek(reset_offset, os.SEEK_SET)
+
+    if len(file_header) != HEADER_LENGTH or file_header[0:4] != MAGIC:
+        return False
+
+    return True
+
+
+def file_matches_segbv2_signature(path: pathlib.Path | os.PathLike | str) -> bool:
+    """
+    Returns True if the file at the given path contains data matching the SEGB v2 file signature. Resets the stream to
+    the same position before returning.
+
+    :param path: The path of the file potentially containing SEGB v2 data
+    :return: True if the stream contains data matching the SEGB v2 file signature.
+    """
+    path = pathlib.Path(path)
+    with path.open("rb") as f:
+        return stream_matches_segbv2_signature(f)
+
+
+def read_segb2_stream(stream: typing.BinaryIO) -> typing.Iterable[Segb2Entry]:
+    """
+    Reads SEGB v2 data from a stream and yields an iterable of Segb2Entry objects
+    :param stream: a binary stream containing the SEGB data. The data is assumed to begin at the start of the stream
+    :return: an iterable of Segb1Entry objects
+    """
+    trailer_list: list[EntryMetadata] = []
+
+    header_raw = stream.read(HEADER_LENGTH)
+    magic_number, entries_count, creation_timestamp_raw, unknown_padding = struct.unpack("<4sid16s", header_raw)
+    if magic_number != MAGIC:
+        raise ValueError(f"Unexpected file magic. Expected: {MAGIC.hex()}; got: {magic_number.hex()}")
+
+    creation_date = decode_cocoa_time(creation_timestamp_raw)  # nothing done with this at the moment...
+
+    # To read the trailer we can just calculate its size and seek from end:
+    trailer_reverse_offset = TRAILER_ENTRY_LENGTH * entries_count
+    stream.seek(-trailer_reverse_offset, os.SEEK_END)
+
+    for _ in range(entries_count):
+        meta_offset = stream.tell()
+        trailer_entry_raw = stream.read(TRAILER_ENTRY_LENGTH)
+        entry_end_offset, entry_state_raw, entry_timestamp_raw = struct.unpack("<2id", trailer_entry_raw)
+        try:
+            entry_state = EntryState(entry_state_raw)
+        except ValueError:
+            # Some SEGB v2 files contain zeroed/unused trailer slots (state 0,
+            # end offset 0); they reference no record data, so skip them.
+            continue
+        trailer_list.append(
+            EntryMetadata(
+                meta_offset, entry_end_offset, entry_state, decode_cocoa_time(entry_timestamp_raw)))
+
+    # To read the records, in order, get to the end of the header:
+    stream.seek(HEADER_LENGTH, os.SEEK_SET)
+
+    # go through the trailer list in order of offset:
+    trailer_list.sort(key=lambda x: x.end_offset)
+    previous_entry: typing.Optional[Segb2Entry] = None
+    for trailer_entry in trailer_list:
+        entry_offset = stream.tell()
+
+        # State 4 is an empty record
+        if trailer_entry.state == 4:
+            continue
+
+        # Two trailer entries can share an end offset (e.g. a record that was
+        # written and later marked deleted); both reference the same data
+        # region, which has already been read from the stream.
+        if previous_entry is not None and trailer_entry.end_offset == previous_entry.metadata.end_offset:
+            yield dataclasses.replace(previous_entry, metadata=trailer_entry)
+            continue
+
+        # NB end offset is relative to the start of entry area
+        entry_length = trailer_entry.end_offset - stream.tell() + HEADER_LENGTH
+
+        # Stale trailer entries (e.g. left behind after the data area was
+        # reused) can point inside a region already consumed by a newer
+        # record; their original data is gone, so they cannot be read.
+        if entry_length < ENTRY_HEADER_LENGTH:
+            continue
+
+        entry_raw = stream.read(entry_length)
+        data = entry_raw[ENTRY_HEADER_LENGTH:]
+        crc32_stored, unknown_raw = struct.unpack("Ii", entry_raw[:ENTRY_HEADER_LENGTH])
+        crc32_calculated = calculated_crc = zlib.crc32(data)
+
+        # align to 4 bytes
+        if (remainder := trailer_entry.end_offset % 4) != 0:
+            stream.seek(4 - remainder, os.SEEK_CUR)
+
+        previous_entry = Segb2Entry(trailer_entry, entry_offset, crc32_stored, calculated_crc, data, _unknown_value=unknown_raw)
+        yield previous_entry
+
+
+def read_segb2_file(path: pathlib.Path | os.PathLike | str) -> typing.Iterable[Segb2Entry]:
+    """
+    Reads SEGB v2 data from a file and yields an iterable of Segb2Entry objects
+    :param path: the path of the file to be opened
+    :return: an iterable of Segb1Entry objects
+    """
+    path = pathlib.Path(path)
+    with path.open("rb") as f:
+        yield from read_segb2_stream(f)
+
+
+def run_command(file_path: pathlib.Path | os.PathLike | str):
+    for record in read_segb2_file(file_path):
+        print("=" * 72)
+        print(f"Offset: {record.data_start_offset}")
+        print(f"Creation Timestamp: {record.metadata.creation}")
+        print(f"State: {record.metadata.state.name}")
+        if record.metadata.state == 1:
+            print(f"CRC Passed: {'True' if record.crc_passed else 'False'}")
+        print()
+        print(bytes_to_hexview(record.data))
+        print()
+    print("End of records")
+
+
+if __name__ == '__main__':
+    import sys
+
+    if len(sys.argv) < 2:
+        print(f"USAGE: {pathlib.Path(sys.argv[0]).name} <SEGB2 file>")
+        print()
+        exit(1)
+
+    run_command(sys.argv[1])
+    print()

--- a/activitywatch/screentime/vendor/ccl_segb/ccl_segb_common.py
+++ b/activitywatch/screentime/vendor/ccl_segb/ccl_segb_common.py
@@ -1,0 +1,60 @@
+import enum
+import datetime
+
+
+COCOA_EPOCH = datetime.datetime(2001, 1, 1, 0, 0, 0)
+
+
+class EntryState(enum.IntEnum):
+    Written = 1
+    Deleted = 3
+    Unknown = 4
+
+
+def decode_cocoa_time(seconds) -> datetime.datetime:
+    """
+    Decodes a Cocoa/Mac Absolute timestamp
+
+    :param seconds: the timestamp value in seconds
+    :return: the decoded timestamp as a datetime.datetime
+    """
+    return COCOA_EPOCH + datetime.timedelta(seconds=seconds)
+
+
+def bytes_to_hexview(b, width=16, show_offset=True, show_ascii=True,
+                     line_sep="\n", start_offset=0, max_bytes=-1) -> str:
+    """
+    Generates a hexview style string for the bytes object b
+
+    :param b: The data (as a bytes object) to be presented as a hexview
+    :param width: the width of each line of the hexview in bytes (16 by default)
+    :param show_offset: whether to show the offset on the left of the hexview (True by default)
+    :param show_ascii: whether to show the ASCII representation of the data on the right of the hexview (True by
+    default)
+    :param line_sep: string to separate each line of the hexview ('\n' by default)
+    :param start_offset: offset to start reading the data from (0 by default)
+    :param max_bytes: the maximum number of bytes to render as a hexview or -1 for all of the data (-1 by default)
+    :return: a hexview style string for the bytes object b
+    """
+    line_fmt = ""
+    if show_offset:
+        line_fmt += "{offset:08x}: "
+    line_fmt += "{hex}"
+    if show_ascii:
+        line_fmt += " {ascii}"
+
+    b = b[start_offset:]
+    if max_bytes > -1:
+        b = b[:max_bytes]
+
+    offset = 0
+    lines = []
+    while offset < len(b):
+        chunk = b[offset:offset + width]
+        ascii = "".join(chr(x) if x >= 0x20 and x < 0x7f else "." for x in chunk)
+        hex = " ".join(format(x, "02x") for x in chunk).ljust(width * 3)
+        line = line_fmt.format(offset=offset, hex=hex, ascii=ascii)
+        lines.append(line)
+        offset += width
+
+    return line_sep.join(lines)

--- a/macos/com.user.screentime-ingest.plist
+++ b/macos/com.user.screentime-ingest.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.screentime-ingest</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
+        <string>exec "$(mise which python3)" "$HOME/.dotfiles/activitywatch/screentime/ingest.py"</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/screentime-ingest.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/screentime-ingest.log</string>
+</dict>
+</plist>

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -77,6 +77,10 @@ install_launch_agent com.user.theme-sync.plist "theme-sync watcher"
 # autostart, so leave AW's built-in login item disabled to avoid a double launch.
 install_launch_agent com.user.activitywatch.plist "ActivityWatch capture"
 
+# Hourly ingest of iOS/iPadOS app-focus history from the local Biome store into
+# the ActivityWatch app-support dir. Needs Full Disk Access (see activitywatch/install.sh).
+install_launch_agent com.user.screentime-ingest.plist "Screen Time ingest"
+
 # Only setup upgrade if we're in separate-directory mode (not a symlink)
 if [[ ! -L "$HOME/.dotfiles" ]]; then
   setup_dotfiles_upgrade


### PR DESCRIPTION
Adds an iOS/iPadOS layer to the ActivityWatch observability topic. Screen Time's "Share Across Devices" already syncs each device's `App.InFocus` stream to `~/Library/Biome` on the Mac; this decodes those streams into a local SQLite store so the `activitywatch:activity` skill can report phone and tablet usage next to the Mac's own capture.

`ingest.py` reads three protobuf fields per record (foreground flag, `CFAbsoluteTime`, bundle id), pairs consecutive focus-change edges into per-app intervals, and appends them with a per-device timestamp watermark and an open-interval carry so runs are incremental and idempotent. `com.user.screentime-ingest` runs it hourly.

## Decisions

- **SEGB decoding is vendored.** The on-disk format has two undocumented layouts (v1/v2), so `ccl_segb` (MIT, pure stdlib, from CCL Forensics) is vendored under `vendor/`. Only the App.InFocus protobuf is decoded inline, and since just three fields are needed, that avoids pulling in the full `protobuf` runtime and Apple's schema.
- **Devices are discovered from the filesystem.** Keying discovery on the Biome `sync.db` peer table (as upstream `aw-import-screentime` does) silently dropped real data here: one iPhone identity carried `platform=1` and three data-bearing streams were absent from `DevicePeer` entirely. Every `remote/` stream is a synced peer (the Mac's own lives under `local/`), so the ingest walks those directories and consults `DevicePeer` only for a model/platform label.
- **Vendored code is excluded from ruff.** Third-party files shouldn't be linted or reformatted, so both ruff hooks now skip `vendor/`.

## Testing

Ran against the live Biome store: 6711 intervals across three devices, realistic top apps (Reddit, Disney+, YouTube, Safari) and durations, zero negative spans. A second run added zero rows and advanced the watermark, confirming idempotency and the open-interval carry. Verified the DuckDB `ATTACH ... (READ_ONLY)` path the skill will use returns per-app totals. `plutil -lint`, `shellcheck`, and the pre-commit suite pass.

Reading `~/Library/Biome` is TCC-protected, so the topic installer now prints a one-time Full Disk Access step for `/bin/zsh` (the agent's interpreter).
