### PR TITLE
worktrunk: harden wt-prune against silent detection drift

### DIFF
--- a/bin/worktree-prune
+++ b/bin/worktree-prune
@@ -11,13 +11,15 @@ DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 source "${0:A:h}/../scripts/lib/report-failure.sh"
 
 PRUNE_LOG=$(mktemp)
-trap 'rm -f "$PRUNE_LOG"' EXIT
+AUDIT_LOG=$(mktemp)
+trap 'rm -f "$PRUNE_LOG" "$AUDIT_LOG"' EXIT
+
+revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 gum log --level info "Running worktree prune"
 if ! "$DOTFILES_HOME/bin/wt-all" prune --before 2>&1 | tee "$PRUNE_LOG"; then
   gum log --level error "worktree prune failed"
 
-  revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
   output=$(tail -n 100 "$PRUNE_LOG" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')
   report_failure "worktree-prune" "Nightly worktree prune failed" "wt all prune --before" "$output" "$revision"
   exit 1
@@ -25,3 +27,21 @@ fi
 
 report_success "worktree-prune"
 gum log --level info "Worktree prune completed successfully"
+
+# Drift tripwire: an independent oracle re-derives the survivor set and flags
+# any worktree a healthy prune should already have removed. It stays silent
+# when clean, so any output means the pruner missed something. Latched under
+# its own job name, so drift files a separate to-do from a prune failure and
+# a green prune with silent drift still surfaces.
+gum log --level info "Auditing for prune drift"
+"$DOTFILES_HOME/bin/wt-all" prune-audit 2>/dev/null \
+  | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' \
+  | grep -v '^[[:space:]]*$' >"$AUDIT_LOG" || true
+
+if [[ -s "$AUDIT_LOG" ]]; then
+  gum log --level warn "prune drift detected"
+  report_failure "wt-prune-drift" "Worktree prune drift detected" "wt all prune-audit" "$(cat "$AUDIT_LOG")" "$revision"
+else
+  report_success "wt-prune-drift"
+  gum log --level info "No prune drift"
+fi

--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -57,10 +57,17 @@ pr_state () {
 
 # Decide a survivor's fate from its resolved state. Pure: it reads only its
 # arguments, touches no globals, and has no side effects, so the removal
-# invariants can be exercised in isolation. Prints "<action>\t<reason>" where
-# action is remove, defer, or keep. This is the source of truth; main maps the
-# action to a `wt remove` variant or the interactive checklist, it does not
-# re-decide.
+# rules can be exercised in isolation. This is the source of truth; main acts
+# on the answer but does not re-derive it.
+#
+# Prints "<action>\t<reason>" for defer/keep, and "<action>\t<reason>\t<mode>"
+# for remove, where:
+#   action  remove / defer / keep
+#   reason  a short human string, for the dry-run table (display only, never
+#           matched on: renaming a reason must not change behavior)
+#   mode    delete-branch when the work has landed, keep-branch when the branch
+#           still holds the only copy of committed work. main maps this token
+#           to the `wt remove` flags, so the branch-deletion call lives here.
 #
 #   pr_state       MERGED / CLOSED / OPEN / "" (no PR on the forge)
 #   onremote       "onremote" when the tip is pushed, anything else otherwise
@@ -76,18 +83,18 @@ classify_survivor () {
 
   # Merged upstream: the work landed, so the leftovers are cruft even when dirty
   # or ahead. A squash merge leaves local commits, so the forge state is the
-  # only proof it landed, and it outranks a dirty tree.
-  [[ "$pr_state" == MERGED ]] && { print -r -- "remove"$'\t'"merged"; return }
+  # only proof it landed, and it outranks a dirty tree. Landed, so drop branch.
+  [[ "$pr_state" == MERGED ]] && { print -r -- "remove"$'\t'"merged"$'\t'"delete-branch"; return }
 
   # Closed without merging is weaker than merged, so guard it: remove only when
   # the tip is backed up on a remote (recoverable) and the tree is clean.
   [[ "$pr_state" == CLOSED && "$onremote" == onremote && "$clean" == clean ]] \
-    && { print -r -- "remove"$'\t'"closed, recoverable"; return }
+    && { print -r -- "remove"$'\t'"closed, recoverable"$'\t'"delete-branch"; return }
 
-  # Old and clean with no decisive forge state: drop the stale checkout. Keeps
-  # the branch (so committed work survives) and applies whatever the PR state.
+  # Old and clean with no decisive forge state: drop the stale checkout but keep
+  # the branch, so committed work survives. Applies whatever the PR state.
   (( before_enabled )) && [[ "$clean" == clean ]] && (( age_exceeded )) \
-    && { print -r -- "remove"$'\t'"aged out"; return }
+    && { print -r -- "remove"$'\t'"aged out"$'\t'"keep-branch"; return }
 
   # Preserved this run. Label why, for the dry-run reasons table.
   [[ "$pr_state" == OPEN ]] && { print -r -- "keep"$'\t'"open PR"; return }
@@ -217,9 +224,9 @@ main () {
       integer classify_before=before_enabled
       (( interactive )) && classify_before=0
 
-      local decision action reason
+      local decision action reason mode
       decision=$(classify_survivor "$pr_st" "$onremote" "$clean" "$is_current" "$classify_before" "$age_exceeded")
-      IFS=$'\t' read -r action reason <<<"$decision"
+      IFS=$'\t' read -r action reason mode <<<"$decision"
 
       local pr_disp="-"
       [[ -n "$pr_st" ]] && pr_disp="${pr_st}#${pr_num}"
@@ -235,10 +242,12 @@ main () {
       # count only confirmed removals so the summary matches what was removed (a
       # dry-run counts everything it lists, since it removes nothing).
       if [[ "$action" == remove ]]; then
-        # Aged-out drops only the directory and keeps the branch, so committed
-        # work survives. Merged and closed landed, so force-delete the branch.
+        # classify_survivor owns the branch-deletion call via its mode token:
+        # keep-branch drops only the directory (committed work survives), any
+        # other mode force-deletes the landed branch too. main does not infer
+        # this from the display reason, so rewording a reason is behavior-safe.
         local -a rmflags=(--foreground)
-        [[ "$reason" == "aged out" ]] || rmflags+=(--force --force-delete)
+        [[ "$mode" == keep-branch ]] || rmflags+=(--force --force-delete)
         if (( dry_run )) || wt remove "${rmflags[@]}" "$branch" </dev/null >/dev/null 2>&1; then
           (( worktrees++ )); seen[$branch]=1
         fi

--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -55,6 +55,49 @@ pr_state () {
   fi
 }
 
+# Decide a survivor's fate from its resolved state. Pure: it reads only its
+# arguments, touches no globals, and has no side effects, so the removal
+# invariants can be exercised in isolation. Prints "<action>\t<reason>" where
+# action is remove, defer, or keep. This is the source of truth; main maps the
+# action to a `wt remove` variant or the interactive checklist, it does not
+# re-decide.
+#
+#   pr_state       MERGED / CLOSED / OPEN / "" (no PR on the forge)
+#   onremote       "onremote" when the tip is pushed, anything else otherwise
+#   clean          "clean" when the tree has no changes, anything else otherwise
+#   is_current     "true" for the checked-out worktree
+#   before_enabled 1 when the age pass is active
+#   age_exceeded   1 when the worktree is older than the age threshold
+classify_survivor () {
+  local pr_state=$1 onremote=$2 clean=$3 is_current=$4 before_enabled=$5 age_exceeded=$6
+
+  # Never the current worktree: you cannot remove the checkout you stand in.
+  [[ "$is_current" == true ]] && { print -r -- "keep"$'\t'"current worktree"; return }
+
+  # Merged upstream: the work landed, so the leftovers are cruft even when dirty
+  # or ahead. A squash merge leaves local commits, so the forge state is the
+  # only proof it landed, and it outranks a dirty tree.
+  [[ "$pr_state" == MERGED ]] && { print -r -- "remove"$'\t'"merged"; return }
+
+  # Closed without merging is weaker than merged, so guard it: remove only when
+  # the tip is backed up on a remote (recoverable) and the tree is clean.
+  [[ "$pr_state" == CLOSED && "$onremote" == onremote && "$clean" == clean ]] \
+    && { print -r -- "remove"$'\t'"closed, recoverable"; return }
+
+  # Old and clean with no decisive forge state: drop the stale checkout. Keeps
+  # the branch (so committed work survives) and applies whatever the PR state.
+  (( before_enabled )) && [[ "$clean" == clean ]] && (( age_exceeded )) \
+    && { print -r -- "remove"$'\t'"aged out"; return }
+
+  # Preserved this run. Label why, for the dry-run reasons table.
+  [[ "$pr_state" == OPEN ]] && { print -r -- "keep"$'\t'"open PR"; return }
+  if [[ "$pr_state" == CLOSED ]]; then
+    [[ "$clean" == clean ]] && { print -r -- "keep"$'\t'"local-only"; return }
+    print -r -- "keep"$'\t'"dirty & closed"; return
+  fi
+  print -r -- "defer"$'\t'"local-only"
+}
+
 main () {
   # wt subcommands occasionally flush stray bookkeeping to stdout mid-run, which
   # would corrupt our single summary line (and the `wt all` table). Detach the
@@ -146,6 +189,9 @@ main () {
   # handle passed to `wt remove` and the raw tab-separated display row.
   local -a rec_handles rec_rows loc_handles loc_rows
 
+  # Standalone dry-run: a row per survivor for the reasons table below.
+  local -a reason_rows
+
   if [[ "$has_linked" == true ]]; then
     local remote_host
     remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
@@ -158,43 +204,52 @@ main () {
       [[ -n "${seen[$branch]:-}" ]] && continue
 
       # Resolve the exact PR/MR state for this survivor. The integration pass
-      # already cleared branches merged into the local default; a squash-merged
+      # already cleared branches merged into the local default. A squash-merged
       # PR still shows local commits ahead of main, so only the forge state
       # proves it landed. This runs once per survivor, not once per PR ever.
       pr_out=$(pr_state "$branch" "$remote_host")
       IFS=$'\t' read -r pr_st pr_num <<<"$pr_out"
 
+      # The age pass is consulted only under --before. Interactive ignores it
+      # and defers aged candidates to the checklist, so mask before there.
+      integer age_exceeded=0
+      (( before_enabled && now - ts >= before_secs )) && age_exceeded=1
+      integer classify_before=before_enabled
+      (( interactive )) && classify_before=0
+
+      local decision action reason
+      decision=$(classify_survivor "$pr_st" "$onremote" "$clean" "$is_current" "$classify_before" "$age_exceeded")
+      IFS=$'\t' read -r action reason <<<"$decision"
+
+      local pr_disp="-"
+      [[ -n "$pr_st" ]] && pr_disp="${pr_st}#${pr_num}"
+
+      # Standalone dry-run: record what would happen and why. WT_ALL runs keep
+      # the terse count contract, so they skip the table.
+      if (( dry_run )) && [[ -z "${WT_ALL:-}" ]]; then
+        reason_rows+=("${wtpath:t}"$'\t'"$branch"$'\t'"$pr_disp"$'\t'"$action"$'\t'"$reason")
+      fi
+
       # Removals read stdin from /dev/null: the loop's stdin is the jq pipe, and
       # a `wt remove` that pauses on a prompt would otherwise consume it. We
       # count only confirmed removals so the summary matches what was removed (a
       # dry-run counts everything it lists, since it removes nothing).
-
-      # Merged upstream: the work landed, so drop worktree and branch even when
-      # dirty. The leftovers are cruft. Never the current worktree: you cannot
-      # remove the checkout you are standing in.
-      if [[ "$pr_st" == MERGED && "$is_current" != true ]]; then
-        if (( dry_run )) || wt remove --foreground --force --force-delete "$branch" </dev/null >/dev/null 2>&1; then
+      if [[ "$action" == remove ]]; then
+        # Aged-out drops only the directory and keeps the branch, so committed
+        # work survives. Merged and closed landed, so force-delete the branch.
+        local -a rmflags=(--foreground)
+        [[ "$reason" == "aged out" ]] || rmflags+=(--force --force-delete)
+        if (( dry_run )) || wt remove "${rmflags[@]}" "$branch" </dev/null >/dev/null 2>&1; then
           (( worktrees++ )); seen[$branch]=1
         fi
         continue
       fi
 
-      # Closed without merging is weaker than merged, so guard it: remove only
-      # when the tip is on a remote (recoverable), the tree is clean (no
-      # only-local work), and this is not the current worktree.
-      if [[ "$pr_st" == CLOSED && "$onremote" == onremote && "$clean" == clean && "$is_current" != true ]]; then
-        if (( dry_run )) || wt remove --foreground --force --force-delete "$branch" </dev/null >/dev/null 2>&1; then
-          (( worktrees++ )); seen[$branch]=1
-        fi
-        continue
-      fi
-
-      # Interactive: defer the ambiguous remainder to the checklist instead of
-      # the age pass. Never offer the current worktree.
+      # Interactive: defer everything classify did not auto-remove to the
+      # checklist, split by recoverability. Never offer the current worktree.
       if (( interactive )); then
         [[ "$is_current" == true ]] && continue
-        local dir=${wtpath:t} pr_disp="-" remote_disp="LOCAL-ONLY"
-        [[ -n "$pr_st" ]] && pr_disp="${pr_st}#${pr_num}"
+        local dir=${wtpath:t} remote_disp="LOCAL-ONLY"
         [[ "$onremote" == onremote ]] && remote_disp="onremote"
         local row="$dir"$'\t'"$branch"$'\t'"$pr_disp"$'\t'"$remote_disp"$'\t'"$clean"
         if [[ "$onremote" == onremote ]]; then
@@ -203,15 +258,6 @@ main () {
           loc_handles+=("$branch"); loc_rows+=("$row")
         fi
         continue
-      fi
-
-      # Age pass: old and clean. Drop the worktree directory but keep the branch
-      # (plain `wt remove` deletes a branch only when merged), so committed work
-      # survives and a dirty worktree makes `wt remove` fail and get skipped.
-      if (( before_enabled )) && [[ "$clean" == clean ]] && (( now - ts >= before_secs )); then
-        if (( dry_run )) || wt remove --foreground "$branch" </dev/null >/dev/null 2>&1; then
-          (( worktrees++ )); seen[$branch]=1
-        fi
       fi
     done < <(jq -r '
       .[]
@@ -294,6 +340,17 @@ main () {
     fi
   fi
 
+  # Standalone dry-run: print the per-survivor decisions so the forge and age
+  # passes explain themselves (the integration pass is covered by `wt step
+  # prune --dry-run`). This prints even when nothing would be removed, so a
+  # survivor that is kept still shows the reason it was kept.
+  if (( dry_run )) && [[ -z "${WT_ALL:-}" ]] && (( ${#reason_rows} > 0 )); then
+    {
+      print -r -- "DIR"$'\t'"BRANCH"$'\t'"STATE"$'\t'"DECISION"$'\t'"REASON"
+      print -rl -- "${reason_rows[@]}"
+    } | column -t -s $'\t' >&$stdout_fd
+  fi
+
   (( worktrees == 0 && branches == 0 )) && return
 
   # Under `wt all`, emit tab-separated counts so the caller can build a table.
@@ -316,4 +373,7 @@ plural () {
   print -r -- "$n $noun"
 }
 
-main "$@"
+# Run only when executed directly. When sourced (tests, wt-prune-audit),
+# ZSH_EVAL_CONTEXT gains a ":file" suffix, so the functions are defined without
+# running the prune.
+[[ "$ZSH_EVAL_CONTEXT" == toplevel ]] && main "$@"

--- a/bin/wt-prune-audit
+++ b/bin/wt-prune-audit
@@ -1,0 +1,64 @@
+#!/usr/bin/env zsh
+# wt prune-audit: an independent oracle that catches a prune that silently
+# stopped removing what it should. It re-derives the survivor set from a fresh
+# `wt list` and applies the minimal landed-work invariant, so it fires whatever
+# the cause of the miss (a truncated forge query, a detection regression, a
+# skipped pass). It is deliberately simpler than the pruner and does not share
+# its decision code: it reuses only pr_state, sourced from bin/wt-prune.
+#
+# Prints "<branch>\t<reason>" for each linked, non-current worktree that a
+# healthy prune should already have removed:
+#   - main_state is empty/integrated: `wt list` already knows the work landed
+#     into the default branch, so no forge call is needed.
+#   - otherwise the branch has a MERGED PR that outlived the prune.
+# Prints nothing when there is no drift. Dispatched fleet-wide via
+# `wt all prune-audit`, so a clean repo emits nothing and is skipped.
+
+set -uo pipefail
+
+# Sourcing defines pr_state without running the prune (guarded on
+# ZSH_EVAL_CONTEXT). $0 is this script's path even when invoked by `wt`.
+source "${0:A:h}/wt-prune"
+
+main () {
+  local list_json
+  list_json=$(wt list --format=json 2>/dev/null)
+  [[ -n "$list_json" && "$list_json" != "[]" ]] || return 0
+
+  # Only linked, non-main, non-current worktrees with a branch are candidates.
+  # Skip the forge entirely when none survive, matching the pruner's gating so
+  # most repos in a fan-out cost nothing.
+  local has_candidate
+  has_candidate=$(jq -r 'any(.[];
+    .kind == "worktree" and (.is_main | not) and (.is_current | not) and ((.branch // "") != ""))' <<<"$list_json")
+  [[ "$has_candidate" == true ]] || return 0
+
+  local remote_host
+  remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
+
+  local branch main_state pr_out pr_st
+  while IFS=$'\t' read -r branch main_state; do
+    # Free signal: `wt list` already resolved this as integrated into the
+    # default branch, so a healthy prune would have removed it.
+    if [[ "$main_state" == empty || "$main_state" == integrated ]]; then
+      print -r -- "$branch"$'\t'"integrated ($main_state)"
+      continue
+    fi
+
+    # Otherwise pay for one forge lookup: a MERGED PR that still has a worktree
+    # is exactly the historical backlog this tripwire guards against.
+    pr_out=$(pr_state "$branch" "$remote_host")
+    IFS=$'\t' read -r pr_st _ <<<"$pr_out"
+    [[ "$pr_st" == MERGED ]] && print -r -- "$branch"$'\t'"merged PR survived"
+  done < <(jq -r '
+    .[]
+    | select(.kind == "worktree" and (.is_main | not) and (.is_current | not) and ((.branch // "") != ""))
+    | [ .branch, (.main_state // "") ] | @tsv' <<<"$list_json")
+
+  # Drift is signalled by the printed violator lines, not by exit status: under
+  # `wt all`, a nonzero return would flag the repo as failed rather than as
+  # merely having output.
+  return 0
+}
+
+[[ "$ZSH_EVAL_CONTEXT" == toplevel ]] && main "$@"

--- a/worktrunk/.shellspec
+++ b/worktrunk/.shellspec
@@ -1,0 +1,1 @@
+--shell bash

--- a/worktrunk/spec/wt_prune_spec.sh
+++ b/worktrunk/spec/wt_prune_spec.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+#
+# Locks the wt-prune removal invariants against a silent detection regression:
+# the classify_survivor decision matrix (the source of truth for what gets
+# removed), parse_duration, the standalone --dry-run reasons table, and the
+# wt-prune-audit drift oracle. classify_survivor and parse_duration are
+# exercised by sourcing bin/wt-prune under the ZSH_EVAL_CONTEXT guard, which
+# defines the functions without running the prune. The dry-run and audit cases
+# are black-box: PATH-shim stubs for wt/gh/gum feed canned wt list and gh pr
+# view state to the real script, following scripts/spec/dotfiles_sync_spec.sh.
+
+wtprune="$SHELLSPEC_PROJECT_ROOT/../bin/wt-prune"
+wtaudit="$SHELLSPEC_PROJECT_ROOT/../bin/wt-prune-audit"
+
+# Preserve empty positional args (a survivor with no PR passes "" for pr_state),
+# which `classify_survivor $*` would drop. The leading _ is $0 for `zsh -c`.
+run_classify() { zsh -fc 'source "$1"; shift; classify_survivor "$@"' _ "$wtprune" "$@"; }
+run_parse()    { zsh -fc 'source "$1"; shift; parse_duration "$@"'    _ "$wtprune" "$@"; }
+
+Describe "classify_survivor decision matrix"
+  # pr_state onremote clean is_current before age  -> action  reason
+  Parameters
+    # Case 1 & 2: merged wins over a dirty tree and local commits ahead. A
+    # squash merge leaves both, so only the MERGED forge state proves it landed.
+    "MERGED"  "local"    "dirty"  "false"  1  1  "remove"  "merged"
+    "MERGED"  "onremote" "clean"  "false"  0  0  "remove"  "merged"
+    # Case 3: closed, backed up on a remote, clean -> recoverable, remove.
+    "CLOSED"  "onremote" "clean"  "false"  0  0  "remove"  "closed, recoverable"
+    # Case 4: closed but local-only or dirty -> keep, the work is only here.
+    "CLOSED"  "local"    "clean"  "false"  0  0  "keep"    "local-only"
+    "CLOSED"  "onremote" "dirty"  "false"  0  0  "keep"    "dirty & closed"
+    # Case 5: an open PR is preserved.
+    "OPEN"    "onremote" "clean"  "false"  0  0  "keep"    "open PR"
+    # Case 6: the current worktree is never force-removed, even when merged.
+    "MERGED"  "local"    "dirty"  "true"   0  0  "keep"    "current worktree"
+    # Case 7: pushed with no PR and not yet aged -> defer, do not auto-remove.
+    # NOPR is the sentinel for an empty pr_state (a survivor with no PR).
+    "NOPR"    "onremote" "clean"  "false"  1  0  "defer"   "local-only"
+    # Age pass: old and clean with no decisive PR state -> remove, keep branch.
+    "NOPR"    "local"    "clean"  "false"  1  1  "remove"  "aged out"
+    # Age applies whatever the PR state: an old, clean open-PR checkout ages out.
+    "OPEN"    "onremote" "clean"  "false"  1  1  "remove"  "aged out"
+  End
+
+  Example "$1/$2/$3 current=$4 before=$5 age=$6 -> $7 ($8)"
+    pr="$1"; [ "$pr" = NOPR ] && pr=""
+    When call run_classify "$pr" "$2" "$3" "$4" "$5" "$6"
+    The output should equal "$(printf '%s\t%s' "$7" "$8")"
+    The status should be success
+  End
+End
+
+Describe "parse_duration"
+  It "converts 2w to seconds"
+    When call run_parse 2w
+    The output should equal 1209600
+    The status should be success
+  End
+
+  It "fails on an unknown spec so callers fall back to a default"
+    When call run_parse bogus
+    The status should be failure
+    The output should equal ""
+  End
+End
+
+Describe "wt-prune --dry-run and wt-prune-audit (black-box)"
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/wt-prune"
+    repo="$sandbox/repo"
+    stubdir="$sandbox/stub"
+    export WT_LIST_JSON="$sandbox/list.json"
+    export WT_REMOVE_LOG="$sandbox/removed.log"
+    export PR_STATE_FILE="$sandbox/pr_state"
+    rm -rf "$sandbox"
+    mkdir -p "$stubdir"
+    : >"$WT_REMOVE_LOG"
+
+    # wt stub: `step prune` probe reports nothing integrated (so the survivor
+    # reaches the forge pass); `list` emits the canned fixture; `remove` only
+    # logs, so a dry-run that wrongly removed would leave a trace here.
+    cat >"$stubdir/wt" <<'WT'
+#!/usr/bin/env bash
+case "$1" in
+  step)   echo "[]" ;;
+  list)   cat "$WT_LIST_JSON" ;;
+  remove) printf 'remove %s\n' "$*" >>"$WT_REMOVE_LOG" ;;
+esac
+exit 0
+WT
+    chmod +x "$stubdir/wt"
+
+    # gh stub: `gh pr view <branch> --json state,number --jq …` resolves to the
+    # state under test. pr_state formats it as "STATE\tNUMBER".
+    cat >"$stubdir/gh" <<'GH'
+#!/usr/bin/env bash
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '%s\t42\n' "$(cat "$PR_STATE_FILE")"
+fi
+exit 0
+GH
+    chmod +x "$stubdir/gh"
+
+    # gum stub: unused on the non-interactive path, present so an accidental
+    # call cannot escape to the real binary.
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stubdir/gum"
+    chmod +x "$stubdir/gum"
+
+    # A real repo with a github origin, so `git remote get-url origin` routes
+    # pr_state to the gh path. Worktree contents are canned in the fixture.
+    git init -q -b main "$repo"
+    git -C "$repo" -c user.email=test@example.com -c user.name=test \
+      commit -q --allow-empty -m init
+    git -C "$repo" remote add origin "https://github.com/test/repo.git"
+
+    printf 'MERGED' >"$PR_STATE_FILE"
+  }
+  BeforeEach 'setup'
+
+  # A merged survivor whose branch main_state still diverges (the squash-merge
+  # shape): the integration pass misses it, the forge state carries the removal.
+  fixture_merged_survivor() {
+    cat >"$WT_LIST_JSON" <<'JSON'
+[
+  {"kind":"worktree","branch":"main","is_main":true,"is_current":true,
+   "path":"/repo","main_state":"is_main","commit":{"timestamp":0},
+   "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
+   "remote":{"ahead":0,"behind":0}},
+  {"kind":"worktree","branch":"feature-x","is_main":false,"is_current":false,
+   "path":"/repo/.worktrees/feature-x","main_state":"diverged","commit":{"timestamp":1000},
+   "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
+   "remote":{"ahead":0,"behind":0}}
+]
+JSON
+  }
+
+  run_prune() { ( cd "$repo" && PATH="$stubdir:$PATH" zsh "$wtprune" "$@" ); }
+  run_audit() { ( cd "$repo" && PATH="$stubdir:$PATH" zsh "$wtaudit" ); }
+
+  It "dry-run prints a reasons table and removes nothing"
+    fixture_merged_survivor
+    When call run_prune --dry-run
+    The status should be success
+    The output should include "DECISION"
+    The output should include "REASON"
+    The output should include "feature-x"
+    The output should include "remove"
+    The output should include "merged"
+    The contents of file "$WT_REMOVE_LOG" should equal ""
+  End
+
+  It "dry-run -i refuses without a terminal and removes nothing"
+    fixture_merged_survivor
+    When call run_prune --dry-run -i
+    The status should equal 1
+    The stderr should include "requires a terminal"
+    The contents of file "$WT_REMOVE_LOG" should equal ""
+  End
+
+  It "audit flags a merged survivor the prune left behind"
+    fixture_merged_survivor
+    printf 'MERGED' >"$PR_STATE_FILE"
+    When call run_audit
+    The status should be success
+    The line 1 of output should equal "$(printf 'feature-x\tmerged PR survived')"
+  End
+
+  It "audit flags an integrated survivor without a forge call"
+    cat >"$WT_LIST_JSON" <<'JSON'
+[
+  {"kind":"worktree","branch":"agent-x","is_main":false,"is_current":false,
+   "path":"/repo/.worktrees/agent-x","main_state":"integrated","commit":{"timestamp":0},
+   "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
+   "remote":null}
+]
+JSON
+    When call run_audit
+    The status should be success
+    The line 1 of output should equal "$(printf 'agent-x\tintegrated (integrated)')"
+  End
+
+  It "audit stays silent when the survivor's PR is still open"
+    fixture_merged_survivor
+    printf 'OPEN' >"$PR_STATE_FILE"
+    When call run_audit
+    The status should be success
+    The output should equal ""
+  End
+End

--- a/worktrunk/spec/wt_prune_spec.sh
+++ b/worktrunk/spec/wt_prune_spec.sh
@@ -144,8 +144,10 @@ GH
 JSON
   }
 
-  run_prune() { ( cd "$repo" && PATH="$stubdir:$PATH" zsh "$wtprune" "$@" ); }
-  run_audit() { ( cd "$repo" && PATH="$stubdir:$PATH" zsh "$wtaudit" ); }
+  # `zsh -f` skips ~/.zshenv, which after bootstrap re-runs `brew shellenv` and
+  # reorders PATH, pushing $stubdir below a real wt/gh and shadowing the stubs.
+  run_prune() { ( cd "$repo" && PATH="$stubdir:$PATH" zsh -f "$wtprune" "$@" ); }
+  run_audit() { ( cd "$repo" && PATH="$stubdir:$PATH" zsh -f "$wtaudit" ); }
 
   It "dry-run prints a reasons table and removes nothing"
     fixture_merged_survivor

--- a/worktrunk/spec/wt_prune_spec.sh
+++ b/worktrunk/spec/wt_prune_spec.sh
@@ -19,34 +19,41 @@ run_classify() { zsh -fc 'source "$1"; shift; classify_survivor "$@"' _ "$wtprun
 run_parse()    { zsh -fc 'source "$1"; shift; parse_duration "$@"'    _ "$wtprune" "$@"; }
 
 Describe "classify_survivor decision matrix"
-  # pr_state onremote clean is_current before age  -> action  reason
+  # A remove decision carries a mode (delete-branch / keep-branch) that main
+  # maps to the wt remove flags. keep/defer carry no mode. Branch deletion keys
+  # off the mode token. The reason string stays display-only.
+  # pr_state onremote clean is_current before age  -> action reason  mode
   Parameters
     # Case 1 & 2: merged wins over a dirty tree and local commits ahead. A
-    # squash merge leaves both, so only the MERGED forge state proves it landed.
-    "MERGED"  "local"    "dirty"  "false"  1  1  "remove"  "merged"
-    "MERGED"  "onremote" "clean"  "false"  0  0  "remove"  "merged"
+    # squash merge leaves both, so only the MERGED forge state proves it landed,
+    # and the landed branch is safe to delete.
+    "MERGED"  "local"    "dirty"  "false"  1  1  "remove"  "merged"               "delete-branch"
+    "MERGED"  "onremote" "clean"  "false"  0  0  "remove"  "merged"               "delete-branch"
     # Case 3: closed, backed up on a remote, clean -> recoverable, remove.
-    "CLOSED"  "onremote" "clean"  "false"  0  0  "remove"  "closed, recoverable"
+    "CLOSED"  "onremote" "clean"  "false"  0  0  "remove"  "closed, recoverable"  "delete-branch"
     # Case 4: closed but local-only or dirty -> keep, the work is only here.
-    "CLOSED"  "local"    "clean"  "false"  0  0  "keep"    "local-only"
-    "CLOSED"  "onremote" "dirty"  "false"  0  0  "keep"    "dirty & closed"
+    "CLOSED"  "local"    "clean"  "false"  0  0  "keep"    "local-only"           ""
+    "CLOSED"  "onremote" "dirty"  "false"  0  0  "keep"    "dirty & closed"       ""
     # Case 5: an open PR is preserved.
-    "OPEN"    "onremote" "clean"  "false"  0  0  "keep"    "open PR"
+    "OPEN"    "onremote" "clean"  "false"  0  0  "keep"    "open PR"              ""
     # Case 6: the current worktree is never force-removed, even when merged.
-    "MERGED"  "local"    "dirty"  "true"   0  0  "keep"    "current worktree"
+    "MERGED"  "local"    "dirty"  "true"   0  0  "keep"    "current worktree"     ""
     # Case 7: pushed with no PR and not yet aged -> defer, do not auto-remove.
     # NOPR is the sentinel for an empty pr_state (a survivor with no PR).
-    "NOPR"    "onremote" "clean"  "false"  1  0  "defer"   "local-only"
-    # Age pass: old and clean with no decisive PR state -> remove, keep branch.
-    "NOPR"    "local"    "clean"  "false"  1  1  "remove"  "aged out"
+    "NOPR"    "onremote" "clean"  "false"  1  0  "defer"   "local-only"           ""
+    # Age pass: old and clean with no decisive PR state -> remove but keep the
+    # branch, so committed work survives.
+    "NOPR"    "local"    "clean"  "false"  1  1  "remove"  "aged out"             "keep-branch"
     # Age applies whatever the PR state: an old, clean open-PR checkout ages out.
-    "OPEN"    "onremote" "clean"  "false"  1  1  "remove"  "aged out"
+    "OPEN"    "onremote" "clean"  "false"  1  1  "remove"  "aged out"             "keep-branch"
   End
 
-  Example "$1/$2/$3 current=$4 before=$5 age=$6 -> $7 ($8)"
+  Example "$1/$2/$3 current=$4 before=$5 age=$6 -> $7 ($8${9:+/$9})"
     pr="$1"; [ "$pr" = NOPR ] && pr=""
+    expected="$(printf '%s\t%s' "$7" "$8")"
+    [ -n "${9:-}" ] && expected="$expected$(printf '\t%s' "$9")"
     When call run_classify "$pr" "$2" "$3" "$4" "$5" "$6"
-    The output should equal "$(printf '%s\t%s' "$7" "$8")"
+    The output should equal "$expected"
     The status should be success
   End
 End
@@ -92,11 +99,13 @@ WT
     chmod +x "$stubdir/wt"
 
     # gh stub: `gh pr view <branch> --json state,number --jq …` resolves to the
-    # state under test. pr_state formats it as "STATE\tNUMBER".
+    # state under test. pr_state formats it as "STATE\tNUMBER". An empty state
+    # file mimics a branch with no PR (real gh exits nonzero, printing nothing).
     cat >"$stubdir/gh" <<'GH'
 #!/usr/bin/env bash
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
-  printf '%s\t42\n' "$(cat "$PR_STATE_FILE")"
+  state="$(cat "$PR_STATE_FILE")"
+  [ -n "$state" ] && printf '%s\t42\n' "$state"
 fi
 exit 0
 GH
@@ -156,6 +165,28 @@ JSON
     The status should equal 1
     The stderr should include "requires a terminal"
     The contents of file "$WT_REMOVE_LOG" should equal ""
+  End
+
+  # The main-side half of the mode contract: a real (non-dry) removal must pass
+  # the flags classify_survivor's mode implies, so branch deletion tracks the
+  # decision rather than the wording of the reason.
+  It "force-deletes the branch of a merged worktree"
+    fixture_merged_survivor
+    printf 'MERGED' >"$PR_STATE_FILE"
+    When call run_prune
+    The status should be success
+    The output should include "worktree"
+    The contents of file "$WT_REMOVE_LOG" should include "--force --force-delete feature-x"
+  End
+
+  It "removes an aged-out worktree without deleting its branch"
+    fixture_merged_survivor
+    : >"$PR_STATE_FILE"
+    When call run_prune --before 1mo
+    The status should be success
+    The output should include "worktree"
+    The contents of file "$WT_REMOVE_LOG" should include "--foreground feature-x"
+    The contents of file "$WT_REMOVE_LOG" should not include "force-delete"
   End
 
   It "audit flags a merged survivor the prune left behind"


### PR DESCRIPTION
`bin/wt-prune` has been rebuilt from scratch twice in three weeks. Both times the cause was the same: the logic that decides what to remove quietly stopped matching worktrees it should have removed, and nobody noticed until a backlog had piled up. A third rewrite wouldn't fix that. This makes the script able to check its own work instead.

## One place decides what to remove

The removal decision moves out of the middle of `main` and into `classify_survivor`, a small function that takes a worktree's state (its PR status, whether the tip is pushed, whether the tree is clean, whether it's the current worktree, and its age) and returns one of `remove`, `defer`, or `keep` plus a plain-English reason. `main` acts on that answer (run `wt remove`, or offer it in the interactive list) but no longer works out the decision itself. A guard on `ZSH_EVAL_CONTEXT` replaces the bare `main "$@"` at the bottom, so the file can be sourced to get at its functions without running a prune.

This doesn't change what gets removed. `wt all prune --dry-run` picks exactly the same worktrees before and after (both report `2` against the live repo). The one intended difference: the current worktree is now kept up front, instead of falling through to the age pass and failing to remove the checkout you're standing in.

## Dry-run explains itself

A standalone `--dry-run` now prints a `DIR/BRANCH/STATE/DECISION/REASON` table, so each worktree says what would happen to it and why. The counts that `wt all` depends on are unchanged, so the combined `wt all` table looks the same as before. Sample against the live repo:

```
DIR                       BRANCH                    STATE       DECISION  REASON
claude-completions-audit  claude-completions-audit  MERGED#554  remove    merged
activitywatch-ios-ingest  activitywatch-ios-ingest  OPEN#555    keep      open PR
```

## A separate check for drift

`bin/wt-prune-audit` is a second, independent check. It looks at the worktrees left over after a prune and applies one simple rule: flag any linked, non-current worktree whose work has clearly landed. That means either `wt list` already reports it as merged into the default branch, or its PR shows as merged on GitHub/GitLab. That catches a missed removal no matter what caused it. It intentionally does not reuse `classify_survivor`. A second, simpler way of arriving at the answer is what makes it a real check rather than a copy of the thing it's checking.

`bin/worktree-prune` runs the check after the nightly prune. If it finds anything, it files a Things to-do under its own name, so a prune that finished cleanly but left something behind still gets reported (and the to-do clears once things are clean again).

Running it against the live repo already found real cases: `claude-completions-audit` is squash-merged (PR #554 landed, but the branch still shows commits ahead of `main`, so only the merged PR proves it) and an already-merged agent worktree that stuck around. The next nightly prune removes both, after which the check goes quiet. That's the point.

## Tests

New `worktrunk/` topic spec, following the `scripts/spec/dotfiles_sync_spec.sh` stub-on-`PATH` precedent. CI's `*/.shellspec` loop finds it with no workflow change.

- `classify_survivor` across the known failure cases: a PR merged outside the recent window, a squash merge (merged beats a dirty tree), closed-and-recoverable vs closed-but-only-local, an open PR, the current-worktree guard, and the age pass.
- `parse_duration` conversion, and its fall back to a default on a bad value.
- `--dry-run` end to end: the table prints and nothing is removed, including `--dry-run -i` refusing to run without a terminal.
- The drift check end to end: a merged or already-landed leftover is flagged, a still-open PR is not.

From the wt-prune Hardening task.
