### PR TITLE
ci: speed up bootstrap jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,12 +53,27 @@ jobs:
     - name: Cache Homebrew packages
       uses: actions/cache@v6
       with:
-        key: homebrew-v2-${{ runner.os }}-${{ hashFiles('**/Brewfile') }}
+        key: homebrew-v3-${{ runner.os }}-${{ hashFiles('**/Brewfile') }}
         restore-keys: |
+          homebrew-v3-${{ runner.os }}-
           homebrew-v2-${{ runner.os }}-
         path: |
           ~/Library/Caches/Homebrew
+          /opt/homebrew/Library/Taps
           /home/linuxbrew/.linuxbrew
+    - name: Cache cargo-installed binaries
+      uses: actions/cache@v6
+      with:
+        # No repo file hashes to the crate version, so key on run_id: the
+        # exact key never pre-exists, the cache (a few MB) re-saves every
+        # run, and restore-keys pull the most recent prior save.
+        key: cargo-install-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: |
+          cargo-install-${{ runner.os }}-
+        path: |
+          ~/.cargo/bin
+          ~/.cargo/.crates.toml
+          ~/.cargo/.crates2.json
     - name: Bootstrap
       run: ./scripts/bootstrap
       env:

--- a/bin/dotf
+++ b/bin/dotf
@@ -4,7 +4,11 @@
 export ZSH="$HOME/.dotfiles"
 
 "$ZSH/scripts/homebrew.sh"
-gum spin --show-output --show-error --title "brew update" -- brew update
+if [ -n "$CI" ]; then
+  echo "› skipping brew update (CI)"
+else
+  gum spin --show-output --show-error --title "brew update" -- brew update
+fi
 
 echo "› building default packages"
 "$ZSH/bin/build-default-packages"


### PR DESCRIPTION
`bootstrap (macos)` is the CI bottleneck at ~8m while everything else finishes under 90s. Measured breakdown of a fully cache-warm run put the time in three places: an unconditional `brew update` (~28s), 12 taps cloned fresh every run (~54s), and `cargo install worktrunk-sync` compiling from source every run (~2m). This fixes all three:

- `bin/dotf` skips `brew update` when `$CI` is set. `HOMEBREW_NO_AUTO_UPDATE` suppresses only implicit updates, so the explicit call in `bin/dotf` still ran every time. Skipping also stabilizes the bottle cache, since bottles now track the runner-image snapshot instead of daily Homebrew HEAD. The local nightly path is unchanged.
- The Homebrew cache now includes `/opt/homebrew/Library/Taps`, so `brew tap` no-ops on warm runs and `scripts/install-trust` needs no changes. The key bump to v3 is required: an exact hit on the old key skips the save, so taps would never enter the cache. The transitional `homebrew-v2-` restore-key keeps the first v3 run warm on bottles and can be dropped later.
- A new cache holds `~/.cargo/bin` plus cargo's install manifests, making `cargo install worktrunk-sync` a fast no-op when the installed version matches crates.io. Keyed on `run_id` since no repo file hashes to the crate version: the exact key never pre-exists, the few-MB cache re-saves every run, and restore-keys pull the latest prior save. Cargo's up-to-date check doesn't consider the rustc that built the binary, so a mise rust bump won't trigger a rebuild. A new worktrunk-sync release compiles once and re-caches.

Rejected caching `/opt/homebrew` wholesale to skip the ~2m45s bottle pour: multi-GB with image preinstalls, and cached keg state is already fragile at small scale (see the openssl relink workaround in the workflow). Also rejected pinning worktrunk-sync with a Renovate manager, since the shared `install.sh` would hold back local machines too.

Expected: macOS Bootstrap step 7m15s → ~4m (job ~8m → ~4.5m), Linux ~5m → ~3m. Run 1 on this PR is cold for both new caches. A follow-up push gets the warm path.
