### PR TITLE
tmux: add rounded caps to narrow claude agents pill

### DIFF
--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -62,7 +62,7 @@ set -g @resp_sr_narrow '#[fg=#{@thm_yellow}]#[fg=#{@thm_crust},bg=#{@thm_yell
 # waiting on your input). Same chip technique as the bell chip above; status.conf
 # gates it behind a nonzero count. Absolute path because the running server's
 # frozen PATH can predate this topic, leaving a bare script name unresolvable.
-set -g @resp_sr_claude_narrow '#[fg=#{@thm_mauve}]#[fg=#{@thm_crust},bg=#{@thm_mauve}] 󰚩 #(~/.config/tmux/claude/bin/_tmux-claude-agents-count)#[fg=#{@thm_mauve},bg=default]#[default]'
+set -g @resp_sr_claude_narrow '#[fg=#{@thm_mauve}]#[fg=#{@thm_crust},bg=#{@thm_mauve}]󰚩 #(~/.config/tmux/claude/bin/_tmux-claude-agents-count)#[fg=#{@thm_mauve},bg=default]#[default]'
 
 # Current window: rounded pill with index block + name + zoom flag. The name is
 # window_name, the working directory under automatic-rename and the manual name


### PR DESCRIPTION
On a narrow client (phone or small SSH window, width < 80), the status-right swaps the wide Catppuccin pills for transparent-friendly chips. Every chip fakes rounded ends by wrapping its content in two powerline half-circle glyphs (`` U+E0B6, `` U+E0B4) drawn in the chip's background color as a foreground over the bare bar. The agent-attention chip `@resp_sr_claude_narrow` had neither, so it rendered as a hard-edged solid mauve block with the count inside instead of a floating rounded pill like its neighbors.

The fix mirrors the bell chip on the line directly above (`@resp_sr_narrow`), its exact structural twin: add the left cap after the opening `#[fg=mauve]`, the right cap before the closing `#[default]`, and drop the now-redundant leading space so the cap sits flush against the `󰚩` icon.

Verified by reloading the module into the live server and confirming `@resp_sr_claude_narrow` now brackets the mauve segment with both caps in the same positions the four working sibling chips use.
