### PR TITLE
vscode: rm VS Code Insiders

### DIFF
--- a/vscode/Brewfile
+++ b/vscode/Brewfile
@@ -1,2 +1,1 @@
 cask 'visual-studio-code', args: corporate_cask_args
-cask 'visual-studio-code@insiders'


### PR DESCRIPTION
Drops the `visual-studio-code@insiders` cask from `vscode/Brewfile`. No longer used; keep the stable build only.
