### PR TITLE
claude: add claude-prune-agents

### DIFF
--- a/bin/claude-prune-agents
+++ b/bin/claude-prune-agents
@@ -40,7 +40,7 @@ split_worktree_path () {
 #
 # Prints "<action>\t<reason>", where action is one of:
 #   stale  every PR is in a terminal state, so the agent is removable
-#   keep   at least one PR is still open
+#   keep   at least one PR is still open, or could not be resolved
 #   skip   no PR was discovered, so there is nothing to judge
 #
 # The reason is a short human string for the table, display only: main never
@@ -48,10 +48,11 @@ split_worktree_path () {
 classify_agent () {
   (( $# == 0 )) && { print -r -- "skip"$'\t'"no PRs"; return }
 
-  local st
-  for st in "$@"; do
-    [[ "$st" == OPEN ]] && { print -r -- "keep"$'\t'"open PR"; return }
-  done
+  [[ " $* " == *" OPEN "* ]] && { print -r -- "keep"$'\t'"open PR"; return }
+
+  # ERROR is a lookup that failed rather than a state the forge reported. The
+  # PR behind it may well be open, so it blocks removal like an open one.
+  [[ " $* " == *" ERROR "* ]] && { print -r -- "keep"$'\t'"PR lookup failed"; return }
 
   # Closed-unmerged does not block: only an open PR means work is still in
   # flight. Both terminal states are named so a mixed set explains itself.
@@ -117,12 +118,21 @@ agent_prs () {
   local num st
 
   if [[ -n "$slug" && -n "$branch" ]]; then
-    while IFS=$'\t' read -r num st; do
-      [[ -z "$num" ]] && continue
-      seen[$slug#$num]=1
-      out+=("$num"$'\t'"$st")
-    done < <(gh pr list --repo "$slug" --head "$branch" --state all \
-      --json number,state --jq '.[] | "\(.number)\t\(.state)"' 2>/dev/null)
+    # Captured rather than piped, so a failed query stays distinguishable from
+    # a branch that genuinely has no PR. Both are empty output, but only the
+    # failure exits nonzero, and treating it as "no PRs" would hide an open PR
+    # and let the agent classify as stale.
+    local listing
+    if listing=$(gh pr list --repo "$slug" --head "$branch" --state all \
+        --json number,state --jq '.[] | "\(.number)\t\(.state)"' 2>/dev/null); then
+      while IFS=$'\t' read -r num st; do
+        [[ -z "$num" ]] && continue
+        seen[$slug#$num]=1
+        out+=("$num"$'\t'"$st")
+      done <<<"$listing"
+    else
+      out+=("-"$'\t'"ERROR")
+    fi
   fi
 
   local refslug refnum
@@ -172,7 +182,11 @@ scan_agents () {
     while IFS=$'\t' read -r num st; do
       [[ -z "$num" ]] && continue
       pr_states+=("$st")
-      pr_disp+=("#$num ${st:l}")
+      if [[ "$st" == ERROR ]]; then
+        pr_disp+=("lookup failed")
+      else
+        pr_disp+=("#$num ${st:l}")
+      fi
     done < <(agent_prs "$slug" "$branch" "$summary")
 
     local action reason
@@ -259,6 +273,14 @@ main () {
   elif (( force )); then
     remove_ids=("${stale_ids[@]}")
   else
+    # Without gum there is no checklist to approve the batch, and silently
+    # removing nothing would read as "nothing was stale". Name the two flags
+    # that work without it instead.
+    if (( ! ${+commands[gum]} )); then
+      print -ru2 -- "claude-prune-agents: gum is required to select interactively; use --force or --dry-run"
+      return 1
+    fi
+
     # Preselect everything: enter accepts the batch, individual rows can be
     # deselected, esc removes nothing.
     local labels_str
@@ -284,7 +306,7 @@ main () {
   done
 
   local -a notes
-  (( kept ))    && notes+=("$kept kept: open PRs")
+  (( kept ))    && notes+=("$kept kept")
   (( skipped )) && notes+=("$skipped skipped: no PRs")
   (( failed ))  && notes+=("$failed failed")
 

--- a/bin/claude-prune-agents
+++ b/bin/claude-prune-agents
@@ -1,0 +1,305 @@
+#!/usr/bin/env zsh
+#/ Usage: claude-prune-agents [-f|--force] [-n|--dry-run]
+#/ Remove completed background agents whose pull requests have all left the
+#/ open state.
+#/
+#/   -f, --force    remove every stale agent without prompting
+#/   -n, --dry-run  print the decision table, remove nothing
+#
+# Completed agents (`claude agents`) accumulate indefinitely, and most of them
+# shipped a PR that has since merged. An agent is prunable when every PR it
+# produced has left the open state: a single open PR keeps it, and an agent with
+# no discoverable PR is reported but never auto-removed.
+#
+# PRs are discovered two ways, unioned and deduped by <owner>/<repo>#<number>:
+# the branch the agent worked on (resolved from its worktree path, which
+# survives the worktree directory being deleted) and the PR references in the
+# agent's own summary text. Removal is `claude rm`, which owns the worktree and
+# refuses when there are unpushed commits.
+
+set -uo pipefail
+setopt typeset_silent
+
+# Captured at file scope: inside a function $0 is the function name, so --help
+# could not find the usage header to print.
+typeset -g script_path=${0:A}
+
+# Split a worktree path into its parent repo root and branch. Worktrunk uses
+# .worktrees/, the built-in harness uses .claude/worktrees/. Prints
+# "<repo root>\t<branch>", or nothing when the path is not a worktree.
+split_worktree_path () {
+  local path=$1
+  [[ "$path" =~ '^(.+)/(\.worktrees|\.claude/worktrees)/([^/]+)' ]] || return 1
+  print -r -- "$match[1]"$'\t'"$match[3]"
+}
+
+# Decide an agent's fate from the resolved states of its PRs. Pure: it reads
+# only its arguments, touches no globals, and has no side effects, so the
+# removal rules can be exercised in isolation. This is the source of truth;
+# main acts on the answer but does not re-derive it.
+#
+# Prints "<action>\t<reason>", where action is one of:
+#   stale  every PR is in a terminal state, so the agent is removable
+#   keep   at least one PR is still open
+#   skip   no PR was discovered, so there is nothing to judge
+#
+# The reason is a short human string for the table, display only: main never
+# matches on it, so rewording one is behavior-safe.
+classify_agent () {
+  (( $# == 0 )) && { print -r -- "skip"$'\t'"no PRs"; return }
+
+  local st
+  for st in "$@"; do
+    [[ "$st" == OPEN ]] && { print -r -- "keep"$'\t'"open PR"; return }
+  done
+
+  # Closed-unmerged does not block: only an open PR means work is still in
+  # flight. Both terminal states are named so a mixed set explains itself.
+  local -a reasons
+  [[ " $* " == *" MERGED "* ]] && reasons+=(merged)
+  [[ " $* " == *" CLOSED "* ]] && reasons+=(closed)
+
+  # Every state was something this script does not recognize. Keep rather than
+  # remove, so an unmodeled state can never delete an agent.
+  (( ${#reasons} )) || { print -r -- "keep"$'\t'"unknown PR state"; return }
+
+  print -r -- "stale"$'\t'"${(j:, :)reasons}"
+}
+
+format_age () {
+  integer secs=$1
+  (( secs < 3600 )) && { print -r -- "$(( secs / 60 ))m"; return }
+  (( secs < 86400 )) && { print -r -- "$(( secs / 3600 ))h"; return }
+  print -r -- "$(( secs / 86400 ))d"
+}
+
+typeset -gA repo_slugs
+
+# Resolve a repo root to its <owner>/<repo> slug, memoized: the scan hits the
+# same handful of repos repeatedly, and this is a subprocess per call.
+repo_slug () {
+  local root=$1
+  [[ -z "$root" || ! -d "$root" ]] && return 1
+  if [[ -z "${repo_slugs[$root]:-}" ]]; then
+    repo_slugs[$root]=$( (cd "$root" && gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) )
+    [[ -z "${repo_slugs[$root]}" ]] && repo_slugs[$root]="-"
+  fi
+  [[ "${repo_slugs[$root]}" == "-" ]] && return 1
+  print -r -- "${repo_slugs[$root]}"
+}
+
+# Every PR reference in an agent's summary text, as "<owner>/<repo>\t<number>".
+# Full github.com URLs carry their own repo. Bare #<n> refs resolve against the
+# agent's own repo, and are dropped when it has none, since a bare number
+# against the wrong repo would resolve to an unrelated PR.
+summary_pr_refs () {
+  local summary=$1 slug=$2 ref
+  for ref in ${(f)"$(print -r -- "$summary" | grep -oE 'github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+')"}; do
+    [[ -z "$ref" ]] && continue
+    local rest=${ref#github.com/}
+    print -r -- "${rest%%/pull/*}"$'\t'"${rest##*/pull/}"
+  done
+
+  [[ -z "$slug" ]] && return
+  for ref in ${(f)"$(print -r -- "$summary" | grep -oE '#[0-9]+')"}; do
+    [[ -z "$ref" ]] && continue
+    print -r -- "$slug"$'\t'"${ref#\#}"
+  done
+}
+
+# Resolve every PR an agent produced, printing "<number>\t<STATE>" per PR in
+# discovery order. Refs that fail to resolve (issue numbers, another repo's
+# numbering) are dropped rather than treated as blocking.
+agent_prs () {
+  local slug=$1 branch=$2 summary=$3
+  local -A seen
+  local -a out
+  local num st
+
+  if [[ -n "$slug" && -n "$branch" ]]; then
+    while IFS=$'\t' read -r num st; do
+      [[ -z "$num" ]] && continue
+      seen[$slug#$num]=1
+      out+=("$num"$'\t'"$st")
+    done < <(gh pr list --repo "$slug" --head "$branch" --state all \
+      --json number,state --jq '.[] | "\(.number)\t\(.state)"' 2>/dev/null)
+  fi
+
+  local refslug refnum
+  while IFS=$'\t' read -r refslug refnum; do
+    [[ -z "$refnum" || -n "${seen[$refslug#$refnum]:-}" ]] && continue
+    seen[$refslug#$refnum]=1
+    st=$(gh pr view "$refnum" --repo "$refslug" --json state --jq .state 2>/dev/null)
+    [[ -z "$st" ]] && continue
+    out+=("$refnum"$'\t'"$st")
+  done < <(summary_pr_refs "$summary" "$slug")
+
+  (( ${#out} )) && print -rl -- "${out[@]}"
+}
+
+# Classify every candidate agent, one tab-separated row per agent appended to
+# the given file: id, name, age, PR summary, action, reason.
+scan_agents () {
+  local outfile=$1
+  : >"$outfile"
+
+  local id cwd started name
+  while IFS=$'\t' read -r id cwd started name; do
+    [[ -z "$id" ]] && continue
+
+    local statefile=$HOME/.claude/jobs/$id/state.json
+    local worktree_path="" summary=""
+    if [[ -f "$statefile" ]]; then
+      worktree_path=$(jq -r '.worktreePath // ""' "$statefile" 2>/dev/null)
+      summary=$(jq -r '[.detail // "", .output.result // ""] | join(" ")' "$statefile" 2>/dev/null)
+    fi
+
+    # The worktree path is the branch signal, not cwd: a finished agent reports
+    # cwd as the repo root even when it worked in a worktree.
+    local repo_root="" branch="" split
+    if split=$(split_worktree_path "${worktree_path:-$cwd}"); then
+      IFS=$'\t' read -r repo_root branch <<<"$split"
+    else
+      repo_root=$cwd
+    fi
+
+    local slug=""
+    slug=$(repo_slug "$repo_root") || slug=""
+
+    local -a pr_states pr_disp
+    pr_states=() pr_disp=()
+    local num st
+    while IFS=$'\t' read -r num st; do
+      [[ -z "$num" ]] && continue
+      pr_states+=("$st")
+      pr_disp+=("#$num ${st:l}")
+    done < <(agent_prs "$slug" "$branch" "$summary")
+
+    local action reason
+    IFS=$'\t' read -r action reason < <(classify_agent "${pr_states[@]}")
+
+    local disp="-"
+    (( ${#pr_disp} )) && disp="${(j:, :)pr_disp}"
+
+    print -r -- "$id"$'\t'"$name"$'\t'"$(format_age $(( EPOCHSECONDS - started / 1000 )))"$'\t'"$disp"$'\t'"$action"$'\t'"$reason" >>"$outfile"
+  done <<<"$agents_tsv"
+}
+
+main () {
+  local dry_run=0 force=0 arg
+  for arg in "$@"; do
+    case "$arg" in
+      -n|--dry-run) dry_run=1 ;;
+      -f|--force)   force=1 ;;
+      -h|--help)    grep '^#/' "$script_path" | cut -c4-; return ;;
+      *) print -ru2 -- "claude-prune-agents: unknown option: $arg"; return 1 ;;
+    esac
+  done
+
+  zmodload zsh/datetime
+
+  local agents_json
+  agents_json=$(claude agents --json --all 2>/dev/null)
+  [[ -z "$agents_json" || "$agents_json" == "[]" ]] && { print -r -- "no agents"; return }
+
+  # Only completed background agents are candidates. Every other state --
+  # working, failed, anything new -- is left alone.
+  local agents_tsv
+  agents_tsv=$(jq -r '
+    .[]
+    | select(.kind == "background" and .state == "done")
+    | [.id, .cwd, (.startedAt | tostring), .name] | @tsv' <<<"$agents_json")
+  [[ -z "$agents_tsv" ]] && { print -r -- "no completed agents"; return }
+
+  integer total=$(print -r -- "$agents_tsv" | grep -c .)
+
+  # An explicit template: macOS mktemp resolves its default from the process's
+  # confstr temp dir, not $TMPDIR, which sandboxed callers may have redirected.
+  local rows_file
+  rows_file=$(mktemp "${TMPDIR:-/tmp}/claude-prune-agents.XXXXXX") || return 1
+  trap "rm -f '$rows_file'" EXIT
+
+  # A handful of gh calls per agent, so show progress. gum spin needs a command
+  # to wrap, and the scan is an in-process function, so spin on the wait.
+  if [[ -t 2 ]] && (( ${+commands[gum]} )); then
+    scan_agents "$rows_file" &
+    local scan_pid=$!
+    gum spin --title "Resolving PRs for $total agents" -- \
+      zsh -c "while kill -0 $scan_pid 2>/dev/null; do sleep 0.2; done"
+    wait $scan_pid
+  else
+    scan_agents "$rows_file"
+  fi
+
+  local -a stale_ids stale_rows all_rows
+  integer kept=0 skipped=0
+  local id name age prs action reason
+  while IFS=$'\t' read -r id name age prs action reason; do
+    [[ -z "$id" ]] && continue
+    all_rows+=("$id"$'\t'"$name"$'\t'"$age"$'\t'"$prs"$'\t'"$action"$'\t'"$reason")
+    case "$action" in
+      stale) stale_ids+=("$id"); stale_rows+=("$id"$'\t'"$name"$'\t'"$age"$'\t'"$prs") ;;
+      keep)  (( kept++ )) ;;
+      skip)  (( skipped++ )) ;;
+    esac
+  done < "$rows_file"
+
+  if (( dry_run )); then
+    {
+      print -r -- "ID"$'\t'"NAME"$'\t'"AGE"$'\t'"PRS"$'\t'"DECISION"$'\t'"REASON"
+      (( ${#all_rows} )) && print -rl -- "${all_rows[@]}"
+    } | column -t -s $'\t'
+  fi
+
+  local -a remove_ids
+  if (( ${#stale_ids} == 0 )); then
+    remove_ids=()
+  elif (( dry_run )); then
+    remove_ids=()
+  elif (( force )); then
+    remove_ids=("${stale_ids[@]}")
+  else
+    # Preselect everything: enter accepts the batch, individual rows can be
+    # deselected, esc removes nothing.
+    local labels_str
+    labels_str=$(printf '%s\n' "${stale_rows[@]}" | column -t -s $'\t')
+    local selected_str
+    selected_str=$(printf '%s\n' "${(@f)labels_str}" \
+      | gum choose --no-limit --selected='*' --header "Select agents to remove")
+    local line
+    for line in "${(@f)selected_str}"; do
+      [[ -z "$line" ]] && continue
+      remove_ids+=("${line%% *}")
+    done
+  fi
+
+  integer removed=0 failed=0
+  for id in "${remove_ids[@]}"; do
+    if claude rm "$id" </dev/null >/dev/null 2>&1; then
+      (( removed++ ))
+    else
+      (( failed++ ))
+      gum log --level warn "claude rm $id failed, likely unpushed commits"
+    fi
+  done
+
+  local -a notes
+  (( kept ))    && notes+=("$kept kept: open PRs")
+  (( skipped )) && notes+=("$skipped skipped: no PRs")
+  (( failed ))  && notes+=("$failed failed")
+
+  local summary="$(plural $removed agent) removed"
+  (( dry_run )) && summary="$(plural ${#stale_ids} agent) removable"
+  (( ${#notes} )) && summary="$summary (${(j:, :)notes})"
+  print -r -- "$summary"
+}
+
+plural () {
+  local n=$1 noun=$2
+  (( n == 1 )) && { print -r -- "$n $noun"; return }
+  print -r -- "$n ${noun}s"
+}
+
+# Run only when executed directly. When sourced (tests), ZSH_EVAL_CONTEXT gains
+# a ":file" suffix, so the functions are defined without running the prune.
+[[ "$ZSH_EVAL_CONTEXT" == toplevel ]] && main "$@"

--- a/claude/.shellspec
+++ b/claude/.shellspec
@@ -1,0 +1,1 @@
+--shell bash

--- a/claude/README.md
+++ b/claude/README.md
@@ -43,6 +43,17 @@ The agent is dispatched detached and its id is logged. Monitoring and attach hap
 
 `prefix a` opens the agent view in a popup, near-fullscreen on a narrow client. A 󰚩 pill appears in the status bar while a background agent is waiting on your input, and disappears when none remain.
 
+### Pruning
+
+`claude-prune-agents` clears completed agents whose work has landed. An agent is
+removable when every PR it produced has left the open state. A single open PR
+keeps it, and an agent with no discoverable PR is reported but never removed.
+
+PRs come from the branch the agent worked on and from the PR references in its
+own summary. The stale set is offered as a preselected checklist, so enter
+accepts the batch and esc removes nothing. `--dry-run` prints the decisions
+without removing, `--force` skips the prompt.
+
 ### Curation
 
 `CLAUDE_AGENTS_ADD_DIR` (colon-separated) passes tool-access directories as repeated `--add-dir` to both the launcher's dispatch and the popup.

--- a/claude/completion.zsh
+++ b/claude/completion.zsh
@@ -692,4 +692,12 @@ _claude_install() {
     '1:target:(stable latest)'
 }
 
+_claude_prune_agents() {
+  _arguments \
+    '(-f --force)'{-f,--force}'[Remove every stale agent without prompting]' \
+    '(-n --dry-run)'{-n,--dry-run}'[Print the decision table without removing]' \
+    '(-h --help)'{-h,--help}'[Display help]'
+}
+
 compdef _claude claude
+compdef _claude_prune_agents claude-prune-agents

--- a/claude/spec/claude_prune_agents_spec.sh
+++ b/claude/spec/claude_prune_agents_spec.sh
@@ -26,6 +26,11 @@ Describe "classify_agent decision matrix"
     # Closed-unmerged does not block, so a terminal mix is still removable.
     "MERGED CLOSED"    "stale"  "merged, closed"
     "CLOSED"           "stale"  "closed"
+    # A failed lookup blocks removal: the PR behind it may well be open, so it
+    # must not be classified away by whatever else did resolve.
+    "ERROR"            "keep"   "PR lookup failed"
+    "MERGED ERROR"     "keep"   "PR lookup failed"
+    "OPEN ERROR"       "keep"   "open PR"
     # An unmodeled state can never delete an agent.
     "DRAFTED"          "keep"   "unknown PR state"
   End
@@ -84,6 +89,9 @@ Describe "claude-prune-agents --dry-run (black-box)"
     write_state open0001 "$repo/.worktrees/open-branch"   "shipped it"
     write_state bare0001 ""                               "shipped as PR #77"
     write_state lost0001 ""                               "nothing to see"
+    # flaky-agent's branch query fails while its summary ref still resolves to a
+    # merged PR: classifying from that partial result would remove it.
+    write_state flaky001 "$repo/.worktrees/flaky-branch"  "shipped as PR #77"
 
     cat >"$sandbox/agents.json" <<JSON
 [
@@ -91,6 +99,7 @@ Describe "claude-prune-agents --dry-run (black-box)"
   {"id":"open0001","cwd":"$repo","kind":"background","startedAt":1,"name":"open agent","state":"done"},
   {"id":"bare0001","cwd":"$repo","kind":"background","startedAt":1,"name":"bare ref agent","state":"done"},
   {"id":"lost0001","cwd":"$sandbox/gone","kind":"background","startedAt":1,"name":"lost agent","state":"done"},
+  {"id":"flaky001","cwd":"$repo","kind":"background","startedAt":1,"name":"flaky agent","state":"done"},
   {"id":"working1","cwd":"$repo","kind":"background","startedAt":1,"name":"busy agent","state":"working"},
   {"pid":123,"cwd":"$repo","kind":"interactive","startedAt":1,"name":"live session","status":"idle"}
 ]
@@ -125,6 +134,9 @@ case "$2" in
     case "$*" in
       *merged-branch*) printf '1\tMERGED\n' ;;
       *open-branch*)   printf '2\tOPEN\n' ;;
+      # A transient failure: empty output, but nonzero, as real gh exits on an
+      # auth, rate-limit, or network error.
+      *flaky-branch*)  exit 1 ;;
     esac
     ;;
 esac
@@ -136,12 +148,23 @@ GH
     # accidental call cannot escape to the real binary.
     printf '#!/usr/bin/env bash\nexit 0\n' >"$stubdir/gum"
     chmod +x "$stubdir/gum"
+
+    # A PATH holding only what the script needs, so the no-gum case can drop gum
+    # without a real one further down $PATH shadowing its absence.
+    nogum="$sandbox/nogum"
+    mkdir -p "$nogum"
+    for tool in zsh bash cat jq grep cut column mktemp; do
+      ln -sf "$(command -v "$tool")" "$nogum/$tool"
+    done
+    ln -sf "$stubdir/claude" "$nogum/claude"
+    ln -sf "$stubdir/gh" "$nogum/gh"
   }
   BeforeEach 'setup'
 
   # `zsh -f` skips ~/.zshenv, which after bootstrap re-runs `brew shellenv` and
   # reorders PATH, pushing $stubdir below a real claude/gh and shadowing the stubs.
   run_prune() { PATH="$stubdir:$PATH" zsh -f "$prune" "$@"; }
+  run_prune_nogum() { PATH="$nogum" zsh -f "$prune" "$@"; }
 
   It "classifies each completed agent and removes nothing"
     When call run_prune --dry-run
@@ -154,8 +177,17 @@ GH
     The output should include "#2 open"
     The output should include "keep"
     The output should include "no PRs"
-    The output should include "2 agents removable (1 kept: open PRs, 1 skipped: no PRs)"
+    The output should include "2 agents removable (2 kept, 1 skipped: no PRs)"
     The contents of file "$CLAUDE_RM_LOG" should equal ""
+  End
+
+  # A failed branch query is empty output, same as a branch with no PR. Reading
+  # it as "no PRs" would let the agent's merged summary ref carry it to stale.
+  It "keeps an agent whose branch query failed"
+    When call run_prune --dry-run
+    The status should be success
+    The output should include "lookup failed"
+    The output should not include "flaky001  flaky agent  stale"
   End
 
   It "resolves a bare PR ref against the agent's own repo"
@@ -179,6 +211,16 @@ GH
     The contents of file "$CLAUDE_RM_LOG" should include "rm bare0001"
     The contents of file "$CLAUDE_RM_LOG" should not include "rm open0001"
     The contents of file "$CLAUDE_RM_LOG" should not include "rm lost0001"
+    The contents of file "$CLAUDE_RM_LOG" should not include "rm flaky001"
+  End
+
+  # Without gum there is no checklist to approve the batch, so removing nothing
+  # while reporting success would read as "nothing was stale".
+  It "fails loudly when interactive selection has no gum"
+    When call run_prune_nogum
+    The status should equal 1
+    The stderr should include "gum is required"
+    The contents of file "$CLAUDE_RM_LOG" should equal ""
   End
 
   It "rejects an unknown option"

--- a/claude/spec/claude_prune_agents_spec.sh
+++ b/claude/spec/claude_prune_agents_spec.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016,SC2086
+#
+# Locks the claude-prune-agents removal invariant against a silent regression:
+# an agent is removable only when every PR it produced has left the open state.
+# classify_agent (the source of truth) is exercised by sourcing
+# bin/claude-prune-agents under the ZSH_EVAL_CONTEXT guard, which defines the
+# functions without running the prune. The dry-run case is black-box: PATH-shim
+# stubs for claude/gh/gum feed canned agent JSON and PR states to the real
+# script, following scripts/spec/dotfiles_sync_spec.sh.
+
+prune="$SHELLSPEC_PROJECT_ROOT/../bin/claude-prune-agents"
+
+run_classify() { zsh -fc 'source "$1"; shift; classify_agent "$@"' _ "$prune" "$@"; }
+
+Describe "classify_agent decision matrix"
+  # PR states (space separated) -> action reason. NOPR is the sentinel for an
+  # agent with no discoverable PR, which reaches classify_agent as zero args.
+  Parameters
+    "NOPR"             "skip"   "no PRs"
+    "OPEN"             "keep"   "open PR"
+    # One open PR outranks any number of terminal ones: work is still in flight.
+    "MERGED OPEN"      "keep"   "open PR"
+    "MERGED"           "stale"  "merged"
+    "MERGED MERGED"    "stale"  "merged"
+    # Closed-unmerged does not block, so a terminal mix is still removable.
+    "MERGED CLOSED"    "stale"  "merged, closed"
+    "CLOSED"           "stale"  "closed"
+    # An unmodeled state can never delete an agent.
+    "DRAFTED"          "keep"   "unknown PR state"
+  End
+
+  Example "[$1] -> $2 ($3)"
+    states="$1"; [ "$states" = NOPR ] && states=""
+    When call run_classify $states
+    The output should equal "$(printf '%s\t%s' "$2" "$3")"
+    The status should be success
+  End
+End
+
+Describe "split_worktree_path"
+  run_split() { zsh -fc 'source "$1"; shift; split_worktree_path "$@"' _ "$prune" "$@"; }
+
+  Parameters
+    "/src/repo/.worktrees/feature-x"          "/src/repo"  "feature-x"
+    "/src/repo/.claude/worktrees/feature-x"   "/src/repo"  "feature-x"
+  End
+
+  Example "$1 splits into $2 and $3"
+    When call run_split "$1"
+    The output should equal "$(printf '%s\t%s' "$2" "$3")"
+  End
+
+  It "fails on a path that is not a worktree"
+    When call run_split "/src/repo"
+    The status should be failure
+    The output should equal ""
+  End
+End
+
+Describe "claude-prune-agents --dry-run (black-box)"
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/claude-prune-agents"
+    stubdir="$sandbox/stub"
+    repo="$sandbox/repo"
+    export CLAUDE_RM_LOG="$sandbox/removed.log"
+    rm -rf "$sandbox"
+    mkdir -p "$stubdir" "$repo/.worktrees"
+    : >"$CLAUDE_RM_LOG"
+
+    # The script reads each agent's summary from $HOME/.claude/jobs/<id>/state.json.
+    export HOME="$sandbox"
+
+    # merged-agent worked in a worktree, so its branch resolves a merged PR.
+    # open-agent's branch resolves an open PR. bare-agent has no worktree and a
+    # summary whose bare #77 ref resolves against its cwd repo. lost-agent has
+    # neither a worktree nor a resolvable repo, so it has no discoverable PR.
+    write_state() {
+      mkdir -p "$sandbox/.claude/jobs/$1"
+      printf '{"worktreePath":"%s","detail":"%s","output":{"result":""}}\n' \
+        "$2" "$3" >"$sandbox/.claude/jobs/$1/state.json"
+    }
+    write_state merged01 "$repo/.worktrees/merged-branch" "shipped it"
+    write_state open0001 "$repo/.worktrees/open-branch"   "shipped it"
+    write_state bare0001 ""                               "shipped as PR #77"
+    write_state lost0001 ""                               "nothing to see"
+
+    cat >"$sandbox/agents.json" <<JSON
+[
+  {"id":"merged01","cwd":"$repo","kind":"background","startedAt":1,"name":"merged agent","state":"done"},
+  {"id":"open0001","cwd":"$repo","kind":"background","startedAt":1,"name":"open agent","state":"done"},
+  {"id":"bare0001","cwd":"$repo","kind":"background","startedAt":1,"name":"bare ref agent","state":"done"},
+  {"id":"lost0001","cwd":"$sandbox/gone","kind":"background","startedAt":1,"name":"lost agent","state":"done"},
+  {"id":"working1","cwd":"$repo","kind":"background","startedAt":1,"name":"busy agent","state":"working"},
+  {"pid":123,"cwd":"$repo","kind":"interactive","startedAt":1,"name":"live session","status":"idle"}
+]
+JSON
+
+    # claude stub: `agents --json --all` emits the fixture; `rm` only logs, so a
+    # dry-run that wrongly removed would leave a trace here.
+    cat >"$stubdir/claude" <<'CLAUDE'
+#!/usr/bin/env bash
+case "$1" in
+  agents) cat "$AGENTS_JSON" ;;
+  rm)     printf 'rm %s\n' "$2" >>"$CLAUDE_RM_LOG" ;;
+esac
+exit 0
+CLAUDE
+    chmod +x "$stubdir/claude"
+    export AGENTS_JSON="$sandbox/agents.json"
+
+    # gh stub: repo view names the repo, pr list resolves a branch, pr view
+    # resolves a bare ref. Unknown branches and numbers print nothing, matching
+    # real gh's empty/nonzero result for a branch or ref with no PR.
+    cat >"$stubdir/gh" <<'GH'
+#!/usr/bin/env bash
+case "$2" in
+  view)
+    case "$1" in
+      repo) echo "test/repo" ;;
+      pr)   [ "$3" = "77" ] && echo "MERGED" ;;
+    esac
+    ;;
+  list)
+    case "$*" in
+      *merged-branch*) printf '1\tMERGED\n' ;;
+      *open-branch*)   printf '2\tOPEN\n' ;;
+    esac
+    ;;
+esac
+exit 0
+GH
+    chmod +x "$stubdir/gh"
+
+    # gum stub: unused on the non-interactive dry-run path, present so an
+    # accidental call cannot escape to the real binary.
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stubdir/gum"
+    chmod +x "$stubdir/gum"
+  }
+  BeforeEach 'setup'
+
+  # `zsh -f` skips ~/.zshenv, which after bootstrap re-runs `brew shellenv` and
+  # reorders PATH, pushing $stubdir below a real claude/gh and shadowing the stubs.
+  run_prune() { PATH="$stubdir:$PATH" zsh -f "$prune" "$@"; }
+
+  It "classifies each completed agent and removes nothing"
+    When call run_prune --dry-run
+    The status should be success
+    The output should include "DECISION"
+    The output should include "merged01"
+    The output should include "#1 merged"
+    The output should include "stale"
+    The output should include "open0001"
+    The output should include "#2 open"
+    The output should include "keep"
+    The output should include "no PRs"
+    The output should include "2 agents removable (1 kept: open PRs, 1 skipped: no PRs)"
+    The contents of file "$CLAUDE_RM_LOG" should equal ""
+  End
+
+  It "resolves a bare PR ref against the agent's own repo"
+    When call run_prune --dry-run
+    The status should be success
+    The output should include "#77 merged"
+  End
+
+  It "leaves agents that are not done alone"
+    When call run_prune --dry-run
+    The status should be success
+    The output should not include "working1"
+    The output should not include "live session"
+  End
+
+  It "removes every stale agent under --force"
+    When call run_prune --force
+    The status should be success
+    The output should include "2 agents removed"
+    The contents of file "$CLAUDE_RM_LOG" should include "rm merged01"
+    The contents of file "$CLAUDE_RM_LOG" should include "rm bare0001"
+    The contents of file "$CLAUDE_RM_LOG" should not include "rm open0001"
+    The contents of file "$CLAUDE_RM_LOG" should not include "rm lost0001"
+  End
+
+  It "rejects an unknown option"
+    When call run_prune --nope
+    The status should equal 1
+    The stderr should include "unknown option"
+    The contents of file "$CLAUDE_RM_LOG" should equal ""
+  End
+End


### PR DESCRIPTION
Adds `claude-prune-agents`, the agent-side counterpart to `bin/wt-prune`.
Completed background agents accumulate indefinitely, and most of them shipped a
PR that has since merged, so they sit in the agent view as dead weight with no
way to clear them in bulk.

The staleness rule is one open PR keeps the agent. Everything terminal (merged,
or closed unmerged) is removable, and an agent with no discoverable PR is
reported but never auto-removed. Removal goes through `claude rm`, which owns
the agent's worktree and refuses when there are unpushed commits, so this script
deletes nothing by hand.

PR discovery started as "resolve the branch from the agent's `cwd`", which finds
nothing in practice: a finished agent reports `cwd` as the repo root even when it
worked in a worktree. The branch actually lives in `state.json`'s `worktreePath`,
which is already read for the agent's summary text and survives the worktree
directory being deleted. That is unioned with the PR references in the summary
itself, which is the only signal for agents that ran outside a worktree. Bare
`#N` refs resolve against the agent's own repo and are dropped when it has none,
since a bare number against the wrong repo resolves to an unrelated PR.

Verified against the real agent list, which covers all three outcomes:

```
f8238124  activity hub                 6d   #21 merged                                stale  merged
bddcc133  adopt-astro-7-surface        1d   #548 merged, #549 merged, #553 merged...  stale  merged
daadc1b3  track-in-flight-agent-jobs   12m  #1088 open                                keep   open PR
3a99bade  fix-stream-silent-diagnosis  16h  -                                         skip   no PRs
```

I stopped short of a real (non-dry-run) removal, since deleting agent sessions is
unrecoverable and the `--force` path is covered by the black-box test with a
`claude rm` stub.

The new `claude/spec` suite is picked up by CI's existing `*/.shellspec` sweep.
