### PR TITLE
activitywatch: import iOS screen time via aw-import-screentime

### DIFF
--- a/activitywatch/aw-import-screentime.toml
+++ b/activitywatch/aw-import-screentime.toml
@@ -1,0 +1,13 @@
+# aw-import-screentime decodes the iOS/iPadOS App.InFocus streams that Screen
+# Time's "Share Across Devices" syncs into ~/Library/Biome, and inserts them as
+# one ActivityWatch bucket per device.
+
+[watch]
+# Discover devices by enumerating the synced stream directories. The default
+# discovery filters Biome's DevicePeer table on platform=2, which silently omits
+# devices this Mac really does sync: two iPhones of the same model here are
+# registered as platform 2 and platform 1.
+all_devices = true
+
+# Storefront for the App Store lookup that turns bundle ids into app names.
+storefront = ["us"]

--- a/activitywatch/aw-import-screentime.toml
+++ b/activitywatch/aw-import-screentime.toml
@@ -4,9 +4,10 @@
 
 [watch]
 # Discover devices by enumerating the synced stream directories. The default
-# discovery filters Biome's DevicePeer table on platform=2, which silently omits
-# devices this Mac really does sync: two iPhones of the same model here are
-# registered as platform 2 and platform 1.
+# discovery filters Biome's DevicePeer table on platform=2, which finds the
+# iPhone but not the iPad: the iPad is filed under platform=1, while the
+# platform=7 rows that look like iPadOS carry no data at all. No single platform
+# value selects both devices.
 all_devices = true
 
 # Storefront for the App Store lookup that turns bundle ids into app names.

--- a/activitywatch/install.sh
+++ b/activitywatch/install.sh
@@ -61,9 +61,24 @@ else
   gum log --level warn "uv not found; skipping aw-import-screentime (run scripts/install after mise install)"
 fi
 
+# Gated on the binary because a KeepAlive agent with a missing exec target
+# respawns forever. That gate has to live here, not in macos/install.sh, which
+# may run first.
+# shellcheck source=../macos/lib/launch-agent.sh
+source "$ZSH/macos/lib/launch-agent.sh"
+
+if [[ -x "$HOME/.local/bin/aw-import-screentime" ]]; then
+  install_launch_agent com.user.aw-import-screentime.plist "Screen Time import" || true
+else
+  gum log --level warn "aw-import-screentime not installed, skipping Screen Time import agent"
+  remove_launch_agent com.user.aw-import-screentime.plist
+fi
+
 # The LaunchAgent runs the importer through /bin/zsh, so zsh is the process TCC
 # holds responsible for reading the Biome store.
 if [[ -z "${NONINTERACTIVE-}" ]]; then
   gum log --level info "Screen Time import one-time setup:"
   gum log --level info "  Grant Full Disk Access to /bin/zsh: System Settings > Privacy & Security > Full Disk Access (reads ~/Library/Biome)"
 fi
+
+exit "${launchd_failed:-0}"

--- a/activitywatch/install.sh
+++ b/activitywatch/install.sh
@@ -40,11 +40,12 @@ fi
 # tablet usage land in the same db as the Mac's capture.
 #
 # Pinned to a fork: upstream discovers devices by filtering DevicePeer on
-# platform=2, which drops one of this Mac's iPhones (Apple registers identical
-# hardware under differing platform values). The fork adds --all-devices, which
+# platform=2, which finds the iPhone but not the iPad. Biome files the iPad
+# under platform=1 and reserves platform=7 for rows that carry no data, so no
+# single platform value selects both. The fork adds --all-devices, which
 # enumerates the synced stream directories instead. Repoint at upstream once
 # that lands there.
-AW_IMPORT_SCREENTIME_REF="git+https://github.com/bendrucker/aw-import-screentime@6a8d7dcbe18be271adc6d90ac48f20727a684ba0"
+AW_IMPORT_SCREENTIME_REF="git+https://github.com/bendrucker/aw-import-screentime@7e961063f80f1410b3ac6a2aa28318dee332690b"
 
 if command -v uv >/dev/null 2>&1; then
   uv tool install "$AW_IMPORT_SCREENTIME_REF"

--- a/activitywatch/install.sh
+++ b/activitywatch/install.sh
@@ -45,7 +45,7 @@ fi
 # single platform value selects both. The fork adds --all-devices, which
 # enumerates the synced stream directories instead. Repoint at upstream once
 # that lands there.
-AW_IMPORT_SCREENTIME_REF="git+https://github.com/bendrucker/aw-import-screentime@7e961063f80f1410b3ac6a2aa28318dee332690b"
+AW_IMPORT_SCREENTIME_REF="git+https://github.com/bendrucker/aw-import-screentime@ea672badfa1ba2c33361a7722105d642b01726fa"
 
 if command -v uv >/dev/null 2>&1; then
   uv tool install "$AW_IMPORT_SCREENTIME_REF"

--- a/activitywatch/install.sh
+++ b/activitywatch/install.sh
@@ -34,3 +34,27 @@ if [[ -z "${NONINTERACTIVE-}" ]]; then
   gum log --level info "  1. Grant Accessibility to ActivityWatch: System Settings > Privacy & Security > Accessibility (window titles need it)"
   gum log --level info "  2. Launch it once from this terminal so the prompt fires: open -a ActivityWatch"
 fi
+
+# Screen Time syncs each iOS/iPadOS device's app-focus history to this Mac, and
+# aw-import-screentime decodes it into ActivityWatch's own buckets so phone and
+# tablet usage land in the same db as the Mac's capture.
+#
+# Pinned to a fork: upstream discovers devices by filtering DevicePeer on
+# platform=2, which drops one of this Mac's iPhones (Apple registers identical
+# hardware under differing platform values). The fork adds --all-devices, which
+# enumerates the synced stream directories instead. Repoint at upstream once
+# that lands there.
+AW_IMPORT_SCREENTIME_REF="git+https://github.com/bendrucker/aw-import-screentime@6a8d7dcbe18be271adc6d90ac48f20727a684ba0"
+
+if command -v uv >/dev/null 2>&1; then
+  uv tool install "$AW_IMPORT_SCREENTIME_REF"
+else
+  gum log --level warn "uv not found; skipping aw-import-screentime (run scripts/install after mise install)"
+fi
+
+# The LaunchAgent runs the importer through /bin/zsh, so zsh is the process TCC
+# holds responsible for reading the Biome store.
+if [[ -z "${NONINTERACTIVE-}" ]]; then
+  gum log --level info "Screen Time import one-time setup:"
+  gum log --level info "  Grant Full Disk Access to /bin/zsh: System Settings > Privacy & Security > Full Disk Access (reads ~/Library/Biome)"
+fi

--- a/activitywatch/install.sh
+++ b/activitywatch/install.sh
@@ -48,7 +48,15 @@ fi
 AW_IMPORT_SCREENTIME_REF="git+https://github.com/bendrucker/aw-import-screentime@ea672badfa1ba2c33361a7722105d642b01726fa"
 
 if command -v uv >/dev/null 2>&1; then
-  uv tool install "$AW_IMPORT_SCREENTIME_REF"
+  # `uv tool install` is a no-op once the tool is present at any version, so on
+  # a machine holding upstream, or an older pin, it would silently leave that in
+  # place and the iPad would go missing again. uv records the resolved commit in
+  # its receipt, so compare against that and reinstall only on a mismatch. That
+  # keeps the nightly upgrade from rebuilding on every run.
+  aw_import_screentime_receipt="${XDG_DATA_HOME:-$HOME/.local/share}/uv/tools/aw-import-screentime/uv-receipt.toml"
+  if ! grep -qF "rev=${AW_IMPORT_SCREENTIME_REF##*@}" "$aw_import_screentime_receipt" 2>/dev/null; then
+    uv tool install --force "$AW_IMPORT_SCREENTIME_REF"
+  fi
 else
   gum log --level warn "uv not found; skipping aw-import-screentime (run scripts/install after mise install)"
 fi

--- a/activitywatch/symlinks.conf
+++ b/activitywatch/symlinks.conf
@@ -1,1 +1,2 @@
 aw-qt.toml:~/Library/Application Support/activitywatch/aw-qt/aw-qt.toml
+aw-import-screentime.toml:~/Library/Application Support/activitywatch/aw-import-screentime/aw-import-screentime.toml

--- a/macos/com.user.aw-import-screentime.plist
+++ b/macos/com.user.aw-import-screentime.plist
@@ -15,6 +15,11 @@
     <key>RunAtLoad</key>
     <true/>
 
+    <!-- Unconditional, unlike the PathState guard in com.user.activitywatch.plist.
+         launchd does not expand $HOME in a PathState key and this binary lives
+         under it, so guarding would mean hardcoding one machine's path.
+         macos/install.sh boots the agent out when the binary is absent, leaving
+         only a removal between install runs to respawn until the next one. -->
     <key>KeepAlive</key>
     <true/>
 

--- a/macos/com.user.aw-import-screentime.plist
+++ b/macos/com.user.aw-import-screentime.plist
@@ -16,10 +16,9 @@
     <true/>
 
     <!-- Unconditional, unlike the PathState guard in com.user.activitywatch.plist.
-         launchd does not expand $HOME in a PathState key and this binary lives
-         under it, so guarding would mean hardcoding one machine's path.
-         macos/install.sh boots the agent out when the binary is absent, leaving
-         only a removal between install runs to respawn until the next one. -->
+         activitywatch/install.sh boots the agent out when the binary is absent,
+         leaving only a removal between install runs to respawn until the next
+         one. -->
     <key>KeepAlive</key>
     <true/>
 

--- a/macos/com.user.aw-import-screentime.plist
+++ b/macos/com.user.aw-import-screentime.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.aw-import-screentime</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
+        <string>exec "$HOME/.local/bin/aw-import-screentime" watch</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/aw-import-screentime.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/aw-import-screentime.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -50,22 +50,8 @@ install_launch_agent com.user.activitywatch.plist "ActivityWatch capture"
 # machine without herdr, so it installs in every mode like the watcher above.
 install_launch_agent com.user.herdr-agent-detection.plist "herdr agent detection watcher"
 
-# Imports iOS/iPadOS Screen Time into ActivityWatch's buckets. It watches Biome
-# for changes rather than polling, so it stays resident. Reading Biome needs
-# Full Disk Access for /bin/zsh (see activitywatch/install.sh).
-#
-# activitywatch/install.sh provides the binary and skips it when uv is missing,
-# and scripts/install runs the topic installers in find order. A KeepAlive agent
-# whose exec target is absent respawns forever, so gate on the binary and let a
-# later run pick it up.
-aw_import_screentime="$HOME/.local/bin/aw-import-screentime"
-if [[ -x "$aw_import_screentime" ]]; then
-  install_launch_agent com.user.aw-import-screentime.plist "Screen Time import"
-else
-  gum log --level warn "aw-import-screentime not installed, skipping Screen Time import agent"
-  launchctl bootout "gui/$UID/com.user.aw-import-screentime" 2>/dev/null || true
-  rm -f "$HOME/Library/LaunchAgents/com.user.aw-import-screentime.plist"
-fi
+# The Screen Time import agent is installed by activitywatch/install.sh, which
+# is where its binary comes from.
 
 # Only setup upgrade if we're in separate-directory mode (not a symlink)
 if [[ ! -L "$HOME/.dotfiles" ]]; then

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -50,6 +50,11 @@ install_launch_agent com.user.activitywatch.plist "ActivityWatch capture"
 # machine without herdr, so it installs in every mode like the watcher above.
 install_launch_agent com.user.herdr-agent-detection.plist "herdr agent detection watcher"
 
+# Imports iOS/iPadOS Screen Time into ActivityWatch's buckets. It watches Biome
+# for changes rather than polling, so it stays resident. Reading Biome needs
+# Full Disk Access for /bin/zsh (see activitywatch/install.sh).
+install_launch_agent com.user.aw-import-screentime.plist "Screen Time import"
+
 # Only setup upgrade if we're in separate-directory mode (not a symlink)
 if [[ ! -L "$HOME/.dotfiles" ]]; then
   setup_dotfiles_upgrade

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -53,7 +53,19 @@ install_launch_agent com.user.herdr-agent-detection.plist "herdr agent detection
 # Imports iOS/iPadOS Screen Time into ActivityWatch's buckets. It watches Biome
 # for changes rather than polling, so it stays resident. Reading Biome needs
 # Full Disk Access for /bin/zsh (see activitywatch/install.sh).
-install_launch_agent com.user.aw-import-screentime.plist "Screen Time import"
+#
+# activitywatch/install.sh provides the binary and skips it when uv is missing,
+# and scripts/install runs the topic installers in find order. A KeepAlive agent
+# whose exec target is absent respawns forever, so gate on the binary and let a
+# later run pick it up.
+aw_import_screentime="$HOME/.local/bin/aw-import-screentime"
+if [[ -x "$aw_import_screentime" ]]; then
+  install_launch_agent com.user.aw-import-screentime.plist "Screen Time import"
+else
+  gum log --level warn "aw-import-screentime not installed, skipping Screen Time import agent"
+  launchctl bootout "gui/$UID/com.user.aw-import-screentime" 2>/dev/null || true
+  rm -f "$HOME/Library/LaunchAgents/com.user.aw-import-screentime.plist"
+fi
 
 # Only setup upgrade if we're in separate-directory mode (not a symlink)
 if [[ ! -L "$HOME/.dotfiles" ]]; then

--- a/macos/lib/launch-agent.sh
+++ b/macos/lib/launch-agent.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=bash
-# LaunchAgent installation, sourced by macos/install.sh.
+# LaunchAgent installation, sourced by macos/install.sh and by a topic
+# installer that owns an agent of its own.
 #
 # The nightly com.user.dotfiles-upgrade job runs scripts/install, so this code
 # routinely runs as a descendant of a job it is about to reinstall. launchctl
@@ -118,4 +119,15 @@ install_launch_agent() {
     launchd_failed=1
     return 1
   fi
+}
+
+# Tear a job down and remove its plist. An installer whose agent depends on a
+# binary calls this when the binary is absent, so a KeepAlive agent does not
+# respawn against a missing exec target.
+remove_launch_agent() {
+  local plist_name="$1"
+  local label="${plist_name%.plist}"
+
+  launchctl bootout "gui/$UID/$label" 2>/dev/null || true
+  rm -f "$HOME/Library/LaunchAgents/$plist_name"
 }


### PR DESCRIPTION
Redo of #555. The goal is unchanged: get iOS/iPadOS screen time next to the Mac's ActivityWatch capture. This does it with [`aw-import-screentime`](https://github.com/ActivityWatch/aw-import-screentime), ActivityWatch's own importer, instead of a local decode-and-store pipeline. 890 lines across 12 files becomes 76 across 5.

The importer reads the same Biome `App.InFocus` streams #555 decoded by hand, but writes into aw-server's buckets over the REST API. That deletes the parts of #555 that were really reimplementation: the vendored `ccl_segb` SEGB reader, the inline protobuf decode, the interval stitcher, the per-device watermark, the second SQLite store, and the ruff `vendor/` exclusion. It also means `activitywatch:activity` needs no changes. iOS usage shows up in the db it already attaches, as one bucket per device.

## Devices are discovered from the stream directories

Upstream discovers devices with `SELECT device_identifier FROM DevicePeer WHERE platform = 2`. On this Mac that finds the iPhone and misses the iPad.

Biome files the iPad under `platform = 1`. The four rows that carry `platform = 7`, the value that looks like iPadOS, decode to zero events. So no single platform value selects both real devices, and `--platform 7` finds nothing. `watch` hardcodes platform 2 anyway, with no flag to change it, and `--device` doesn't help either: it's intersected with the discovered set, so naming the missing device returns nothing.

The two devices are genuinely distinct, not one phone registered twice. The platform=2 device runs `com.culturedcode.ThingsiPhone` and the platform=1 device runs `com.culturedcode.ThingsiPad`, and their app profiles diverge accordingly (Reddit and Tumblr on one, Disney+ and Screens on the other). Exactly one of 8873 events is shared between them, so importing both does not double count.

That drops 2351 of 8873 events. So the topic pins a [fork](https://github.com/bendrucker/aw-import-screentime/tree/device-discovery-beyond-devicepeer) that adds `--all-devices`, which enumerates the synced stream directories instead of consulting `DevicePeer`, and makes an explicit `--device` an override rather than a filter. Default behavior is unchanged, the existing tests pass, and the change adds its own. I'd like to send it upstream and repoint the pin at `ActivityWatch/aw-import-screentime` once it lands.

Worth correcting one claim in #555: it justified filesystem discovery partly on "three data-bearing streams absent from `DevicePeer`". Those three decode to zero events. They're empty segment files from devices that no longer sync. The argument holds for one device, the iPad.

## Shape

- `activitywatch/install.sh` installs the pinned importer with `uv tool install`, which is a no-op on re-runs.
- `activitywatch/aw-import-screentime.toml` sets `all_devices` and the App Store storefront, symlinked like the existing `aw-qt.toml`.
- `com.user.aw-import-screentime` supervises `watch`. It's a resident watchdog process on the Biome directories, not a poll, so it's `KeepAlive` rather than #555's hourly `StartInterval`.

`aw-qt` can supervise any `aw-*` binary on `PATH`, which would have avoided a LaunchAgent, but it starts modules with no arguments and the importer needs the `watch` subcommand.

Reading `~/Library/Biome` is TCC-protected. The agent runs through `/bin/zsh`, so that's what needs Full Disk Access. That's the same grant #555 asked for.

## Testing

Against the live Biome store, the pinned build previews 8873 events across both devices (6522 and 2351), spanning 2026-06-23 to 2026-07-21. The config file alone drives the device selection, with no CLI flags, which is what the LaunchAgent relies on. Upstream's suite passes at 20 tests including the 10 new ones, `mypy` reports the same pre-existing errors as before the change, and `plutil -lint`, `shellcheck`, and the pre-commit suite pass here.

Not yet exercised: the actual insert into aw-server. I verified through `events preview`, which is read-only, rather than writing to your live capture db. The first real import happens when you run `scripts/install`.
