### PR TITLE
zoxide: track all navigations via --cmd cd

### DIFF
--- a/terminal/completion.zsh
+++ b/terminal/completion.zsh
@@ -1,3 +1,3 @@
 #!/usr/bin/env zsh
 
-compdef __zoxide_z_complete z
+compdef __zoxide_z_complete cd

--- a/terminal/zoxide.zsh
+++ b/terminal/zoxide.zsh
@@ -1,5 +1,5 @@
 #!/usr/bin/env zsh
 
 if (( $+commands[zoxide] )); then
-  eval "$(zoxide init zsh)"
+  eval "$(zoxide init zsh --cmd cd)"
 fi


### PR DESCRIPTION
Replaces zoxide's `z`/`zi` commands with `--cmd cd`, so zoxide shadows `cd` itself. Every directory change now updates the frecency database, so ranking reflects actual navigation rather than only the paths I reached through an explicit `z` jump. `cd <path>` behaves like the builtin. `cdi` opens the interactive picker.

The completion registration in `completion.zsh` retargets from `z` to `cd` to match. Completions are deferred here, so zoxide's own `compdef` (emitted during init, before `compinit` runs) is a no-op and this line is what actually wires it up. The function name stays `__zoxide_z_complete`. That's the name zoxide still emits under `--cmd cd`, confirmed against its generated output.
