### PR TITLE
atuin: add catppuccin mocha theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "system/btop-catppuccin"]
 	path = system/btop-catppuccin
 	url = https://github.com/catppuccin/btop.git
+[submodule "atuin/catppuccin"]
+	path = atuin/catppuccin
+	url = https://github.com/catppuccin/atuin.git

--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -7,3 +7,9 @@ enter_accept = true
 [sync]
 ## Use the sync v2 record store.
 records = true
+
+[theme]
+## Catppuccin Mocha (Mauve accent), vendored via the catppuccin/ submodule and
+## symlinked into ~/.config/atuin/themes/. Matches the mocha/mauve palette used
+## across the tmux and terminal topics.
+name = "catppuccin-mocha-mauve"

--- a/atuin/symlinks.conf
+++ b/atuin/symlinks.conf
@@ -1,1 +1,2 @@
 config.toml:$XDG_CONFIG_HOME/atuin/config.toml
+catppuccin/themes/mocha/catppuccin-mocha-mauve.toml:$XDG_CONFIG_HOME/atuin/themes/catppuccin-mocha-mauve.toml


### PR DESCRIPTION
Themes atuin's history TUI with Catppuccin, following the same vendoring pattern as `bat/catppuccin` and `system/btop-catppuccin`: the [catppuccin/atuin](https://github.com/catppuccin/atuin) repo comes in as a git submodule and the chosen theme file is symlinked into `~/.config/atuin/themes/`. Renovate's `git-submodules` manager picks it up automatically, no extra config.

Picked `catppuccin-mocha-mauve` to match the rest of the setup: mocha is the dark flavor used by yazi, fzf, and tmux, and mauve is tmux's accent. atuin's `[theme] name` is a single value with no light/dark auto-switch, so unlike bat this vendors just the one active theme rather than all four flavors.

Verified atuin parses the config and theme file cleanly against an isolated `XDG_CONFIG_HOME` mirroring the symlink layout. The palette itself only renders in the interactive search TUI.
