### PR TITLE
tailscale: add CLI completions

### DIFF
--- a/tailscale/completion.zsh
+++ b/tailscale/completion.zsh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+
+if (( $+commands[tailscale] )); then
+  eval "$(tailscale completion zsh)"
+fi


### PR DESCRIPTION
Adds zsh completions for the `tailscale` CLI. The new `tailscale/completion.zsh` evals `tailscale completion zsh` in the deferred completion hook, guarded on the command existing, matching the eval-at-load pattern already used by `atuin` and `worktrunk`. This keeps completions current across version bumps without committing a generated file.

`tailscale` is already installed via the `tailscale-app` cask in `system/Brewfile`.
