### PR TITLE
herdr: follow the terminal's light/dark appearance

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -3,10 +3,11 @@
 
 onboarding = false
 
-[terminal]
-default_shell = "zsh"
-shell_mode = "auto"
-new_cwd = "follow"
+[update]
+# The version is pinned in mise.toml and bumped by Renovate, so a background
+# check can only ever nag about a version this machine won't install.
+# manifest_check stays on: that's the agent-detection manifest, not the binary.
+version_check = false
 
 [keys]
 # Match tmux's C-s so muscle memory carries over; when nested, double the
@@ -14,11 +15,27 @@ new_cwd = "follow"
 prefix = "ctrl+s"
 
 [theme]
-name = "catppuccin"
+# ghostty already flips Mocha/Latte with the system appearance and reports the
+# change to the pane (terminal/ghostty.config), so herdr's chrome can follow the
+# same signal instead of needing a theme-sync-herdr script. Picking a theme by
+# hand in herdr's settings turns auto_switch back off.
+auto_switch = true
+light_name = "catppuccin-latte"
+dark_name = "catppuccin"
 
 [ui.toast]
 # Surface agent state changes (blocked / working / done) as native toasts.
 delivery = "herdr"
+
+# Claude Code writes what it's doing to the terminal title. The default agent
+# row is just ["agent"], which is the same word on every entry; trading it for
+# the title makes the sidebar answer "what is each agent doing" at a glance.
+# An override replaces the default rows rather than extending them.
+[ui.sidebar.agents.rows_by_agent]
+claude = [
+  ["state_icon", "workspace", "tab"],
+  ["agent", "terminal_title_stripped"],
+]
 
 # --- Plugin keybindings ----------------------------------------------------
 # Plugins themselves are installed by install.sh. The command IDs below come


### PR DESCRIPTION
ghostty already switches Catppuccin Mocha/Latte with the system appearance and reports the change to the pane, so `theme.auto_switch` lets herdr's own chrome follow the same signal — no `theme-sync-herdr` script needed, unlike the tools in `theme/bin/`.

`light_name` and `dark_name` are both unset by default. Naming them beats relying on herdr's sibling-theme inference, which the docs only spell out for tokyo-night and gruvbox, never for catppuccin. Worth knowing: picking a theme by hand in herdr's settings turns `auto_switch` back off.

Two other settings from the [config reference](https://herdr.dev/docs/config-reference/) where the default was wrong for this setup:

- **`update.version_check = false`** — `herdr/mise.toml` pins the version and Renovate bumps it, so a background check can only nag about a version this machine won't install. `manifest_check` stays on: that's agent detection, not the binary.
- **`ui.sidebar.agents.rows_by_agent.claude`** — the default agent row is just `["agent"]`, the same word on every entry. Swapping in `terminal_title_stripped` makes the sidebar answer what each agent is doing.

`[terminal]` is gone: `shell_mode` and `new_cwd` restated herdr's defaults outright, and `default_shell` defaults to `""`, which already means `$SHELL`. `theme.name` went the same way. No keybindings were added — the prefix was already aligned to tmux's `C-s`.

## Testing

Config parses as TOML and every key path/value was checked against the config reference. herdr isn't installed in this session, so the settings are unexercised against the real binary — herdr falls back to a safe default with a startup warning on anything invalid, so the failure mode is a warning rather than a broken config.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiQSJZQUvesjW68YEPVuc2)_