### PR TITLE
ghostty: switch to @tip cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -71,7 +71,7 @@ cask 'disk-drill'
 cask 'dash'
 cask 'figma'
 cask 'geekbench'
-cask 'ghostty'
+cask 'ghostty@tip'
 cask 'google-chrome', args: corporate_cask_args
 cask 'hazel'
 cask 'jordanbaird-ice'


### PR DESCRIPTION
Switches the Ghostty cask to `ghostty@tip`, which tracks upstream builds off `main` rather than tagged releases. Ghostty's release cadence is slow enough that fixes and features land in tip long before they ship in a version.

The tip cask installs to the same `/Applications/Ghostty.app` and auto-updates, so `terminal/symlinks.conf` and the rest of the topic are unaffected.

Stacked on #580, which is what makes the switch possible: `ghostty@tip` declares `conflicts_with cask: "ghostty"` and the plain cask declares the reverse, so `brew bundle` fails on any machine still holding the stable cask rather than migrating. #580 retires the superseded variant before bundle runs.
