### PR TITLE
herdr: install from Homebrew instead of mise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ This is a personal dotfiles repository for macOS with Linux compatibility. The r
 - **Language versions**: Add `mise.toml` to the relevant topic directory (e.g., `go/mise.toml`)
 - **Build packages**: Use `bin/build-default-packages` script
 
+Homebrew is the default for a new tool. It links into `$HOMEBREW_PREFIX/bin`, a path that survives upgrades and is visible to every process rather than only shells that ran `mise activate`, and `brew bundle` tracks the current release. Use `mise.toml` when the version has to vary by directory, which is what mise resolves per-project: language runtimes and project-pinned tools like `terraform`. Declaring a tool in both is fine. mise's install directories come first on `$PATH`. A mise pin wins where one applies and the Homebrew copy covers everywhere else.
+
 #### Brewfile Aggregation
 
 The root `Brewfile` recursively loads all topic Brewfiles using:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ mise.toml:$XDG_CONFIG_HOME/mise/conf.d/go.toml
 
 mise merges everything in `conf.d/` automatically. Each topic owns its runtime versions without a shared config file. Versions are pinned exactly (never `latest`) so [Renovate](https://github.com/renovatebot/renovate) can track and bump them.
 
+#### Choosing mise or Homebrew for a Tool
+
+Homebrew is the default. It links binaries into `$HOMEBREW_PREFIX/bin`, a path that stays stable across upgrades and is visible to every process, not just shells that ran `mise activate`. `brew bundle` moves each formula to the current release. That suits any tool where the newest version is the right version.
+
+mise handles the case where the version has to vary by directory. It resolves the nearest `mise.toml` walking up from the working directory: a repo pinned to an older Go gets that toolchain, everything else follows the global pin in `conf.d/`. Language runtimes and project-pinned tools like `terraform` need that. A standalone CLI usually doesn't.
+
+Declaring a tool in both places is fine and often useful. mise's activation prepends its install directories ahead of `$HOMEBREW_PREFIX/bin`. The mise version wins wherever a `mise.toml` selects one, and the Homebrew copy covers everywhere else.
+
 ### Dev Mode and Testing
 
 Symlinks point at the installed copy in `~/.dotfiles`. Edits in a development clone don't take effect until synced. To test edits without syncing, the active root is resolved on every shell in [`zsh/active-root.zsh`](zsh/active-root.zsh), with this precedence:

--- a/herdr/Brewfile
+++ b/herdr/Brewfile
@@ -1,6 +1,1 @@
-# herdr-navigator needs herdr 0.7.3+. CI bootstraps with HOMEBREW_NO_AUTO_UPDATE
-# and restores a cached formula index, so a long-lived cache can resolve a
-# version below that floor. The stale-index problem is general to every formula
-# here and gets fixed at the cache, not with a pin: the actions cache was purged
-# so the next run rebuilds from the runner's current index.
 brew 'herdr'

--- a/herdr/Brewfile
+++ b/herdr/Brewfile
@@ -1,0 +1,6 @@
+# herdr-navigator needs herdr 0.7.3+. CI bootstraps with HOMEBREW_NO_AUTO_UPDATE
+# and restores a cached formula index, so a long-lived cache can resolve a
+# version below that floor. The stale-index problem is general to every formula
+# here and gets fixed at the cache, not with a pin: the actions cache was purged
+# so the next run rebuilds from the runner's current index.
+brew 'herdr'

--- a/herdr/mise.toml
+++ b/herdr/mise.toml
@@ -1,7 +1,0 @@
-[tools]
-# Pin via the github backend for a deterministic version. Homebrew-core has
-# herdr but bootstrap doesn't `brew update`, so CI resolved a stale 0.7.1 from
-# the runner's baked-in tap index — below herdr-navigator's 0.7.3+ floor. This
-# pull-from-release pin avoids that and lets Renovate track upgrades. herdr's
-# mise registry shorthand maps to this same source.
-"github:ogulcancelik/herdr" = "0.7.5"

--- a/herdr/symlinks.conf
+++ b/herdr/symlinks.conf
@@ -1,2 +1,1 @@
 config.toml:$XDG_CONFIG_HOME/herdr/config.toml
-mise.toml:$XDG_CONFIG_HOME/mise/conf.d/herdr.toml


### PR DESCRIPTION
Installs `herdr` from Homebrew and drops the mise pin that #572 added.

The `github:` backend puts the binary in a version-numbered directory under `~/.local/share/mise/installs`, reachable only from a shell that ran `mise activate`, and the path moves on every upgrade. Homebrew links into `$HOMEBREW_PREFIX/bin`, which is stable and visible to every process. Nothing here needs herdr's version to vary by directory, which is the one thing a mise pin buys, and tracking the current release is the behavior worth having for a standalone CLI.

That trade wasn't written down anywhere, so the README and `CLAUDE.md` now state it: Homebrew by default, mise when the version has to resolve per-project, both when it helps. Declaring a tool in both places is fine. mise's install directories sort ahead of `$HOMEBREW_PREFIX/bin`, so a mise pin wins where one applies and the Homebrew copy covers everywhere else.

`~/.config/mise/conf.d/herdr.toml` is no longer declared, so `install-symlinks` prunes it on the next run. The orphaned mise install can go with `mise prune`.

## CI Resolves an Old herdr

The pin's original justification was CI-specific: bootstrap runs with `HOMEBREW_NO_AUTO_UPDATE`, and the restored Homebrew cache held an index old enough to resolve herdr 0.7.1, below the plugin floor. I purged the `homebrew-v3-macOS` actions cache (1.92 GiB, last written 2026-07-16) expecting the next run to rebuild from a current index.

It didn't. The run installed 0.7.3, and `persiyanov/herdr-reviewr` declined to install against it:

```
Error: plugin requires Herdr 0.7.5 or newer; current Herdr is 0.7.3
```

So the actions cache was only half the problem. With it cold, `brew bundle` falls back to the runner image's baked-in index, which is also behind. Purging buys one step forward and then re-freezes, since this run saved a fresh cache holding the 0.7.3 index.

The fix is a `brew update` before `brew bundle` in bootstrap. That refreshes the index without touching `HOMEBREW_NO_INSTALL_UPGRADE`, so the relink hazard that comment guards against stays guarded. It's a workflow change affecting every formula, so it belongs in its own PR rather than here.

Merging with the gap open costs CI one herdr plugin. Plugin installs are already non-fatal by design, no test asserts a herdr version, and local `brew bundle` runs with auto-update, so a real machine gets the current release.
