### PR TITLE
shell-history: stop relying on caller-chosen temp paths

### DIFF
--- a/.claude/skills/shell-history/scripts/query.sh
+++ b/.claude/skills/shell-history/scripts/query.sh
@@ -127,11 +127,13 @@ DB_SQL="${DB//\'/\'\'}"
 # In-memory DuckDB (no path arg): attach the source read-only, build the view
 # layer, bind params, then read the query. Nothing persists to disk.
 # .read paths are single-quoted so a space in the path can't split the command.
-duckdb <<SQL
-INSTALL sqlite; LOAD sqlite;
-ATTACH '$DB_SQL' AS atuin (TYPE sqlite, READ_ONLY);
-.read '$VIEWS'
-SET VARIABLE cutoff = $CUTOFF;
-SET VARIABLE "limit" = $LIMIT;
-.read '$QUERY_FILE'
-SQL
+# Piped rather than fed by here-doc: bash 3.2 stages a here-doc through a temp
+# file in the cwd or /var/tmp, so a read-only cwd breaks an otherwise fine run.
+printf '%s\n' \
+  'INSTALL sqlite; LOAD sqlite;' \
+  "ATTACH '$DB_SQL' AS atuin (TYPE sqlite, READ_ONLY);" \
+  ".read '$VIEWS'" \
+  "SET VARIABLE cutoff = $CUTOFF;" \
+  "SET VARIABLE \"limit\" = $LIMIT;" \
+  ".read '$QUERY_FILE'" |
+  duckdb

--- a/.claude/skills/shell-history/scripts/spec/spec_helper.sh
+++ b/.claude/skills/shell-history/scripts/spec/spec_helper.sh
@@ -20,11 +20,9 @@ shellspec_spec_helper_configure() {
     now=$(( $(date +%s) * 1000000000 ))
     old=$(( ($(date +%s) - 400 * 86400) * 1000000000 ))
 
-    # bash 3.2 stages a here-document through a temp file of its own choosing,
-    # which lands outside the fixture dir and reintroduces the same denial. Write
-    # the script into the fixture dir instead, where the path is already known
-    # good.
-    local sql="$FIXTURE_DIR/fixture.sql"
+    # Piped rather than fed by here-doc, for the same reason as query.sh: bash
+    # 3.2 stages a here-doc through a temp file in the cwd or /var/tmp, so a
+    # read-only cwd breaks an otherwise fine run.
     printf '%s\n' \
       'INSTALL sqlite; LOAD sqlite;' \
       "ATTACH '$ATUIN_HISTORY_DB' AS fx (TYPE sqlite);" \
@@ -39,10 +37,8 @@ shellspec_spec_helper_configure() {
       "  ($now, 'npm test && npm run build')," \
       "  ($now, 'cat foo | grep bar')," \
       "  ($old, 'svn commit -m old');" \
-      "INSERT INTO fx.history (timestamp, command, deleted_at) VALUES ($now, 'secret token abc', $now);" \
-      > "$sql"
-
-    duckdb < "$sql"
+      "INSERT INTO fx.history (timestamp, command, deleted_at) VALUES ($now, 'secret token abc', $now);" |
+      duckdb
   }
 
   cleanup_fixture() {

--- a/.claude/skills/shell-history/scripts/spec/spec_helper.sh
+++ b/.claude/skills/shell-history/scripts/spec/spec_helper.sh
@@ -20,22 +20,29 @@ shellspec_spec_helper_configure() {
     now=$(( $(date +%s) * 1000000000 ))
     old=$(( ($(date +%s) - 400 * 86400) * 1000000000 ))
 
-    duckdb << SQL
-INSTALL sqlite; LOAD sqlite;
-ATTACH '$ATUIN_HISTORY_DB' AS fx (TYPE sqlite);
-CREATE TABLE fx.history (
-  id VARCHAR, timestamp BIGINT, duration BIGINT, exit BIGINT,
-  command VARCHAR, cwd VARCHAR, session VARCHAR, hostname VARCHAR,
-  deleted_at BIGINT, author VARCHAR, intent VARCHAR
-);
-INSERT INTO fx.history (timestamp, command) SELECT $now, 'git push' FROM range(12);
-INSERT INTO fx.history (timestamp, command) SELECT $now, 'docker build -t app .' FROM range(3);
-INSERT INTO fx.history (timestamp, command) VALUES
-  ($now, 'npm test && npm run build'),
-  ($now, 'cat foo | grep bar'),
-  ($old, 'svn commit -m old');
-INSERT INTO fx.history (timestamp, command, deleted_at) VALUES ($now, 'secret token abc', $now);
-SQL
+    # bash 3.2 stages a here-document through a temp file of its own choosing,
+    # which lands outside the fixture dir and reintroduces the same denial. Write
+    # the script into the fixture dir instead, where the path is already known
+    # good.
+    local sql="$FIXTURE_DIR/fixture.sql"
+    printf '%s\n' \
+      'INSTALL sqlite; LOAD sqlite;' \
+      "ATTACH '$ATUIN_HISTORY_DB' AS fx (TYPE sqlite);" \
+      'CREATE TABLE fx.history (' \
+      '  id VARCHAR, timestamp BIGINT, duration BIGINT, exit BIGINT,' \
+      '  command VARCHAR, cwd VARCHAR, session VARCHAR, hostname VARCHAR,' \
+      '  deleted_at BIGINT, author VARCHAR, intent VARCHAR' \
+      ');' \
+      "INSERT INTO fx.history (timestamp, command) SELECT $now, 'git push' FROM range(12);" \
+      "INSERT INTO fx.history (timestamp, command) SELECT $now, 'docker build -t app .' FROM range(3);" \
+      'INSERT INTO fx.history (timestamp, command) VALUES' \
+      "  ($now, 'npm test && npm run build')," \
+      "  ($now, 'cat foo | grep bar')," \
+      "  ($old, 'svn commit -m old');" \
+      "INSERT INTO fx.history (timestamp, command, deleted_at) VALUES ($now, 'secret token abc', $now);" \
+      > "$sql"
+
+    duckdb < "$sql"
   }
 
   cleanup_fixture() {

--- a/.claude/skills/shell-history/scripts/spec/spec_helper.sh
+++ b/.claude/skills/shell-history/scripts/spec/spec_helper.sh
@@ -10,7 +10,10 @@ shellspec_spec_helper_configure() {
   # "old" row sits ~400 days back to exercise the --recent cutoff. One row is
   # soft-deleted (deleted_at set) to confirm it is filtered out.
   setup_fixture() {
-    FIXTURE_DIR=$(mktemp -d)
+    # macOS mktemp ignores $TMPDIR unless given an explicit path template, so a
+    # bare `mktemp -d` lands in the Darwin per-user temp dir. Anchor to
+    # shellspec's own run directory, which does honor $TMPDIR.
+    FIXTURE_DIR=$(mktemp -d "$SHELLSPEC_TMPBASE/fixture.XXXXXX")
     export ATUIN_HISTORY_DB="$FIXTURE_DIR/history.db"
 
     local now old


### PR DESCRIPTION
Fixes the `shell-history` shellspec suite erroring out locally before it could assert anything. Two separate causes, both about where a temp file lands.

`setup_fixture` built its atuin fixture in a bare `mktemp -d`. On macOS that ignores `$TMPDIR` unless mktemp is given an explicit path template, so it always resolved to the Darwin per-user temp dir under `/var/folders/.../T`. Claude Code's sandbox grants `$TMPDIR` but not that path, so the before hook died with `mkdtemp failed ... Operation not permitted` and took every example down with it. An explicit template under `$SHELLSPEC_TMPBASE` keeps the fixture inside shellspec's own per-run directory, which does honor `$TMPDIR`.

That alone left the suite just as red. Both `spec_helper.sh` and `query.sh` fed duckdb through a here-document, and bash stages one through a temp file of its own choosing, which fails the same way. Both now pipe the SQL in with `printf` instead.

The `query.sh` half is not a test concern. That script is what the `shell-history` skill runs, and it runs under the sandbox that denies the path, so the skill was broken for the consumer it exists to serve. The here-document also quietly contradicted the comment directly above it promising that nothing persists to disk. A pipe makes that true.

Nothing about what the specs assert changed, and no assertion was loosened.

## Testing

The suite passes in `.claude/skills/shell-history/scripts`, sandboxed. Verified by A/B against unmodified `main` under the same conditions, which fails identically before the change. The `shellspec` pre-commit hook now passes too, which was the practical motivation: it had been erroring on every unrelated `.sh` edit.

The runners were never affected, since CI is not sandboxed. This is a local-only failure that CI could not have caught.
