### PR TITLE
scripts: give one-off migrations an expiry date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,6 +246,9 @@ jobs:
             echo "$bad"
             exit 1
           fi
+      - name: Check for expired migrations
+        run: scripts/lint-expired
+
       - name: Check tmux/bin aggregate is in sync
         run: |
           # tmux/bin holds a symlink to every topic-bin script (see tmux/bin-sync).

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -50,6 +50,7 @@ install_launch_agent() {
 
 setup_dotfiles_upgrade() {
   # Remove old sync job (replaced by upgrade job which includes sync)
+  # EXPIRES: 2026-10-26 every machine has run the upgrade job at least once
   local old_sync_plist="$HOME/Library/LaunchAgents/com.user.dotfiles-sync.plist"
   launchctl bootout "gui/$UID/com.user.dotfiles-sync" 2>/dev/null || true
   rm -f "$old_sync_plist"
@@ -63,6 +64,7 @@ setup_worktree_prune() {
 
 setup_claude_upgrade() {
   # Remove old plist that pointed to ~/.claude-repo/bin/claude-upgrade
+  # EXPIRES: 2026-10-26 every machine has the relocated claude-upgrade plist
   launchctl bootout "gui/$UID/com.user.claude-upgrade" 2>/dev/null || true
 
   install_launch_agent com.user.claude-upgrade.plist "nightly Claude upgrade"

--- a/scripts/lint-expired
+++ b/scripts/lint-expired
@@ -42,18 +42,31 @@ while IFS=: read -r file line rest; do
   date_field=$(printf '%s\n' "$rest" |
     sed -n "s/.*${marker}[[:space:]]*\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\).*/\1/p")
 
-  month=""
-  day=""
+  # A typo'd date that silently never fires would defeat the point, so treat an
+  # unparseable marker as a failure rather than skipping it. Checking the month
+  # and day ranges independently would admit dates like 2026-02-31, so the day
+  # is measured against the length of that specific month.
+  day_limit=0
   if [ -n "$date_field" ]; then
-    month=$(echo "$date_field" | cut -d- -f2)
-    day=$(echo "$date_field" | cut -d- -f3)
+    # Zero padding reads as octal in arithmetic, so strip it first.
+    year=$(echo "$date_field" | cut -d- -f1)
+    month=$(echo "$date_field" | cut -d- -f2 | sed 's/^0//')
+    day=$(echo "$date_field" | cut -d- -f3 | sed 's/^0//')
+
+    case "$month" in
+      1 | 3 | 5 | 7 | 8 | 10 | 12) day_limit=31 ;;
+      4 | 6 | 9 | 11) day_limit=30 ;;
+      2)
+        day_limit=28
+        if [ $((year % 4)) -eq 0 ] &&
+          { [ $((year % 100)) -ne 0 ] || [ $((year % 400)) -eq 0 ]; }; then
+          day_limit=29
+        fi
+        ;;
+    esac
   fi
 
-  # A typo'd date that silently never fires would defeat the point, so treat an
-  # unparseable marker as a failure rather than skipping it.
-  if [ -z "$date_field" ] ||
-    [ "$month" -lt 1 ] || [ "$month" -gt 12 ] ||
-    [ "$day" -lt 1 ] || [ "$day" -gt 31 ]; then
+  if [ "$day_limit" -eq 0 ] || [ "$day" -lt 1 ] || [ "$day" -gt "$day_limit" ]; then
     malformed="$malformed  $file:$line
 "
     continue

--- a/scripts/lint-expired
+++ b/scripts/lint-expired
@@ -1,0 +1,92 @@
+#!/usr/bin/env sh
+# Usage: lint-expired [dotfiles-root]
+#
+# Fail once a one-off cleanup step has outlived the date its author gave it.
+#
+# Migrations are correct to write and easy to leave behind: removing a
+# superseded launchd plist, dropping a package that moved, working around a bug
+# that has since been fixed. Nothing about the code says when it stopped being
+# necessary, so it accretes. Tagging one with a date in a comment moves that
+# judgement out of memory and into CI, which is the only place it will actually
+# resurface.
+#
+#   # EXPIRES: 2026-10-26 every machine has the upgrade job
+#
+# Reaching the date prompts a review. Delete the code, or push the date out
+# because the reason still holds.
+set -e
+
+DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
+cd "$DOTFILES_ROOT"
+
+# Overridable so the spec can test against fixed dates.
+today="${LINT_EXPIRED_TODAY:-$(date +%Y-%m-%d)}"
+today_num=$(echo "$today" | tr -d -)
+
+marker='EXPIRES:'
+expired=""
+expired_count=0
+malformed=""
+
+matches=$(git grep -n -- "$marker" || true)
+
+# A here-doc rather than a pipe, so the counters survive the loop.
+while IFS=: read -r file line rest; do
+  [ -n "$file" ] || continue
+
+  # This script and its spec both document the marker, so they match themselves.
+  case "$file" in
+    scripts/lint-expired | scripts/spec/lint_expired_spec.sh) continue ;;
+  esac
+
+  date_field=$(printf '%s\n' "$rest" |
+    sed -n "s/.*${marker}[[:space:]]*\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\).*/\1/p")
+
+  month=""
+  day=""
+  if [ -n "$date_field" ]; then
+    month=$(echo "$date_field" | cut -d- -f2)
+    day=$(echo "$date_field" | cut -d- -f3)
+  fi
+
+  # A typo'd date that silently never fires would defeat the point, so treat an
+  # unparseable marker as a failure rather than skipping it.
+  if [ -z "$date_field" ] ||
+    [ "$month" -lt 1 ] || [ "$month" -gt 12 ] ||
+    [ "$day" -lt 1 ] || [ "$day" -gt 31 ]; then
+    malformed="$malformed  $file:$line
+"
+    continue
+  fi
+
+  if [ "$(echo "$date_field" | tr -d -)" -lt "$today_num" ]; then
+    reason=$(printf '%s\n' "$rest" |
+      sed -n "s/.*${marker}[[:space:]]*[0-9-]\{10\}[[:space:]]*//p")
+    expired_count=$((expired_count + 1))
+    expired="$expired  $file:$line  $marker $date_field
+"
+    [ -n "$reason" ] && expired="$expired    $reason
+"
+  fi
+done <<EOF
+$matches
+EOF
+
+status=0
+
+if [ -n "$malformed" ]; then
+  echo "ERROR: malformed $marker marker (expected $marker YYYY-MM-DD reason):" >&2
+  printf '%s' "$malformed" >&2
+  status=1
+fi
+
+if [ -n "$expired" ]; then
+  noun="migrations are"
+  [ "$expired_count" -eq 1 ] && noun="migration is"
+  echo "ERROR: $expired_count $noun past the expiry date." >&2
+  printf '%s' "$expired" >&2
+  echo "  Remove it, or push the date out because the reason still holds." >&2
+  status=1
+fi
+
+exit "$status"

--- a/scripts/spec/lint_expired_spec.sh
+++ b/scripts/spec/lint_expired_spec.sh
@@ -91,6 +91,45 @@ Describe "lint-expired"
     The stderr should include "malformed"
   End
 
+  # Range-checking month and day independently would admit this.
+  It "rejects a day that does not exist in that month"
+    fixture '# EXPIRES: 2026-02-31 february has no 31st'
+
+    When call run_lint
+    The status should be failure
+    The stderr should include "malformed"
+  End
+
+  It "rejects February 29 in a common year"
+    fixture '# EXPIRES: 2026-02-29 2026 is not a leap year'
+
+    When call run_lint
+    The status should be failure
+    The stderr should include "malformed"
+  End
+
+  It "accepts February 29 in a leap year"
+    fixture '# EXPIRES: 2028-02-29 2028 is a leap year'
+
+    When call run_lint
+    The status should be success
+  End
+
+  It "accepts the last day of a 30-day month"
+    fixture '# EXPIRES: 2099-04-30 april has 30 days'
+
+    When call run_lint
+    The status should be success
+  End
+
+  It "rejects a 31st in a 30-day month"
+    fixture '# EXPIRES: 2099-04-31 april has no 31st'
+
+    When call run_lint
+    The status should be failure
+    The stderr should include "malformed"
+  End
+
   It "ignores a marker in an untracked file"
     fixture 'echo tracked'
     printf '# EXPIRES: 2020-01-01 untracked\n' > "$sandbox/untracked.sh"

--- a/scripts/spec/lint_expired_spec.sh
+++ b/scripts/spec/lint_expired_spec.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "lint-expired"
+  setup() {
+    lint="$SHELLSPEC_PROJECT_ROOT/lint-expired"
+    sandbox="$SHELLSPEC_TMPBASE/lint-expired"
+    rm -rf "$sandbox"
+    mkdir -p "$sandbox"
+    git -C "$sandbox" init --quiet
+    export LINT_EXPIRED_TODAY=2026-07-28
+  }
+  BeforeEach 'setup'
+
+  # git grep only sees tracked files, so a fixture has to be staged.
+  fixture() {
+    printf '%s\n' "$@" > "$sandbox/migration.sh"
+    git -C "$sandbox" add -A
+  }
+
+  run_lint() {
+    "$lint" "$sandbox"
+  }
+
+  It "passes when the date is still in the future"
+    fixture '# EXPIRES: 2099-12-31 the slow machine has not synced yet'
+
+    When call run_lint
+    The status should be success
+    The output should equal ""
+    The stderr should equal ""
+  End
+
+  It "passes when nothing is marked at all"
+    fixture 'echo no markers here'
+
+    When call run_lint
+    The status should be success
+  End
+
+  It "reports the location, date, and reason once past the date"
+    fixture '# EXPIRES: 2026-07-27 every machine has the upgrade job'
+
+    When call run_lint
+    The status should be failure
+    The stderr should include "1 migration is past the expiry date"
+    The stderr should include "migration.sh:1"
+    The stderr should include "EXPIRES: 2026-07-27"
+    The stderr should include "every machine has the upgrade job"
+  End
+
+  It "treats the expiry date itself as not yet due"
+    fixture '# EXPIRES: 2026-07-28 expires today'
+
+    When call run_lint
+    The status should be success
+  End
+
+  It "counts more than one expired marker"
+    fixture '# EXPIRES: 2020-01-01 first' 'echo x' '# EXPIRES: 2021-01-01 second'
+
+    When call run_lint
+    The status should be failure
+    The stderr should include "2 migrations are past the expiry date"
+  End
+
+  It "keeps a reason containing a percent sign or colon intact"
+    fixture '# EXPIRES: 2020-01-01 100% of machines: done'
+
+    When call run_lint
+    The status should be failure
+    The stderr should include "100% of machines: done"
+  End
+
+  # A date that can never fire is worse than no marker, because it reads as
+  # tracked when it isn't.
+  It "rejects a marker with no parseable date"
+    fixture '# EXPIRES: soon enough'
+
+    When call run_lint
+    The status should be failure
+    The stderr should include "malformed"
+    The stderr should include "migration.sh:1"
+  End
+
+  It "rejects an out-of-range month and day"
+    fixture '# EXPIRES: 2026-13-45 typo'
+
+    When call run_lint
+    The status should be failure
+    The stderr should include "malformed"
+  End
+
+  It "ignores a marker in an untracked file"
+    fixture 'echo tracked'
+    printf '# EXPIRES: 2020-01-01 untracked\n' > "$sandbox/untracked.sh"
+
+    When call run_lint
+    The status should be success
+  End
+End


### PR DESCRIPTION
One-off cleanup steps are correct to write and easy to leave behind. Removing a superseded launchd plist, dropping a package that moved, working around a bug since fixed: nothing in the code records when it stopped being necessary, so it accretes. `macos/install.sh` already carries two of these, one from February.

Adds an `EXPIRES: YYYY-MM-DD reason` comment marker and `scripts/lint-expired`, which fails the existing `lint` job once a date arrives. That moves the judgement out of memory and into the one place it will actually resurface. Reaching the date prompts a review rather than forcing a deletion: remove the code, or push the date out because the reason still holds.

A marker whose date can never fire is worse than no marker, since it reads as tracked when it isn't. So an unparseable date or an out-of-range month or day fails the same way an expired one does.

## Why a comment marker

The alternative was a registry of dated migration files with a runner. Rejected because migrations here aren't homogeneous: they run at different points in `scripts/install` (before `brew bundle` versus after the topic installers), so a registry needs ordering slots to express what a comment already expresses by sitting next to the code. A comment also works in shell, Ruby, plists, and TOML alike, and needs no restructuring to adopt.

The two existing migrations are tagged at 2026-10-26, a quarter out. That date is a starting point, not a considered claim about how long the machines take to converge.

## Scope

This is for migrations that can't be dissolved. Where a rule can replace one it should: #576 does that for the ghostty cask switch, deriving the retirement from the Brewfile and Homebrew's `conflicts_with` data rather than hardcoding a step someone has to remember to delete. This mechanism is the fallback for the rest.

## Testing

`scripts/spec/lint_expired_spec.sh` covers the same-day boundary (the expiry date itself is not yet due), past and future dates, singular and plural counts, reasons containing `%` and `:` which an earlier draft broke by passing them through a `printf` format string, unparseable and out-of-range dates, and untracked files.

Ran the linter against the real repo: it passes today, and at a simulated 2026-10-27 it fails naming both `macos/install.sh` migrations with their line numbers and reasons. A local `greptile review` returned no comments.
