### PR TITLE
scripts: retire superseded cask variants before bundle

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -14,6 +14,10 @@ fi
 # Trust declared taps before bundle evaluates their formulae
 ./scripts/install-trust
 
+# Retire cask variants the Brewfile stopped declaring, which bundle can't
+# install over (see the script for why)
+./scripts/install-cask-variants
+
 brew bundle
 
 # Expose brew configuration to installers

--- a/scripts/install-cask-variants
+++ b/scripts/install-cask-variants
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+# Usage: install-cask-variants [dotfiles-root]
+#
+# Homebrew refuses to install a cask that conflicts with an installed one, and
+# every @variant of an app declares conflicts_with against its siblings. So
+# changing which variant the Brewfile declares is a change `brew bundle` cannot
+# carry out on its own, in either direction: it fails until the old variant is
+# gone. Uninstall the variant the Brewfile stopped declaring so bundle can
+# install the one it now does.
+#
+# This is a rule, not a migration, so switching a cask needs no follow-up commit
+# to clean up after it.
+set -e
+
+DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
+
+# shellcheck source=lib/cask-variants.sh
+. "$(dirname "$0")/lib/cask-variants.sh"
+
+[ "$(uname -s)" = "Darwin" ] || exit 0
+command -v brew >/dev/null 2>&1 || exit 0
+
+declared=$(brew bundle list --cask --file "$DOTFILES_ROOT/Brewfile" 2>/dev/null) || declared_failed=1
+installed=$(brew list --cask 2>/dev/null) || installed_failed=1
+
+# Swallowing a failure outright would read as "nothing is superseded" and hand
+# brew bundle a conflict error with none of this context attached. Treating a
+# nonzero status as fatal is just as wrong: brew exits nonzero while still
+# printing a complete list when something incidental fails, such as a cache
+# refresh it could not write. The list is the signal, so the status decides only
+# when there is no list.
+if { [ -n "${declared_failed-}" ] && [ -z "$declared" ]; } ||
+  { [ -n "${installed_failed-}" ] && [ -z "$installed" ]; }; then
+  echo "install-cask-variants: cannot enumerate casks, so a superseded variant would go unnoticed." >&2
+  echo "  brew bundle will fail on the conflict if one is present." >&2
+  exit 1
+fi
+
+superseded=$(cask_variants_superseded "$declared" "$installed")
+
+[ -n "$superseded" ] || exit 0
+
+# jq is installed by the brew bundle that runs after this. A machine with no
+# casks yet has nothing to retire and never reaches this point, so require jq
+# only once there is something to verify, and say so rather than skipping
+# quietly and letting bundle fail on the conflict instead.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "install-cask-variants: these casks are superseded by a variant the Brewfile declares," >&2
+  echo "  but jq is not available to confirm the conflict. brew bundle will fail while they remain:" >&2
+  printf '%s\n' "$superseded" | cut -f1 | sed 's/^/    brew uninstall --cask /' >&2
+  exit 1
+fi
+
+# Confirm every candidate before removing any of them. Interleaving the two
+# would let a metadata failure on the third candidate abort the run with the
+# first two already uninstalled and their replacements not yet installed.
+#
+# The @suffix convention is a strong hint, not proof. Only remove a cask that
+# Homebrew itself reports as conflicting, so an unrelated same-prefix token can
+# never take an app down with it.
+confirmed=$(
+  printf '%s\n' "$superseded" | while IFS="$(printf '\t')" read -r old new; do
+    [ -n "$old" ] || continue
+
+    # Unreadable metadata is a different answer from "they don't conflict", and
+    # collapsing the two would leave the cask in place and hand brew bundle a
+    # conflict error that says nothing about why.
+    if ! info=$(brew info --json=v2 --cask "$new" 2>/dev/null) ||
+      ! conflicts=$(printf '%s\n' "$info" |
+        jq -r '.casks[0].conflicts_with.cask // [] | .[]' 2>/dev/null); then
+      echo "install-cask-variants: cannot read Homebrew metadata for $new, so its conflict with the installed $old is unconfirmed." >&2
+      echo "  brew bundle will fail while $old remains. Run: brew uninstall --cask $old" >&2
+      exit 1
+    fi
+
+    printf '%s\n' "$conflicts" | grep -qxF "$old" || continue
+    printf '%s\t%s\n' "$old" "$new"
+  done
+) || exit 1
+
+# Past this point the machine is already being changed, so a failure part way
+# through is worse than one before it started: brew bundle is what installs the
+# replacements, and aborting would strand whatever was already removed. Carry on
+# and let bundle report anything still conflicting.
+printf '%s\n' "$confirmed" | while IFS="$(printf '\t')" read -r old new; do
+  [ -n "$old" ] || continue
+  echo "install-cask-variants: uninstalling $old, superseded by $new"
+  brew uninstall --cask "$old" ||
+    echo "install-cask-variants: could not uninstall $old, brew bundle will report the conflict" >&2
+done

--- a/scripts/lib/cask-variants.sh
+++ b/scripts/lib/cask-variants.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# Selection logic for install-cask-variants, kept separate so it can be tested
+# without a Homebrew installation.
+
+# Print the installed casks that a declared sibling variant supersedes, as
+# `installed<TAB>declared` pairs. Both arguments are newline-separated lists of
+# cask tokens.
+#
+# Homebrew names app variants with an @suffix: ghostty@tip, claude-code@latest,
+# iterm2@beta. A cask is superseded when it is no longer declared but some other
+# variant of the same app is.
+cask_variants_superseded() {
+  cask_variants_declared="$1"
+  cask_variants_installed="$2"
+
+  printf '%s\n' "$cask_variants_installed" | while IFS= read -r installed; do
+    [ -n "$installed" ] || continue
+
+    if printf '%s\n' "$cask_variants_declared" | grep -qxF "$installed"; then
+      continue
+    fi
+
+    for declared in $cask_variants_declared; do
+      if [ "${declared%%@*}" = "${installed%%@*}" ]; then
+        printf '%s\t%s\n' "$installed" "$declared"
+        break
+      fi
+    done
+  done
+}

--- a/scripts/spec/cask_variants_spec.sh
+++ b/scripts/spec/cask_variants_spec.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "cask-variants.sh"
+  setup() {
+    # shellcheck source=/dev/null
+    source "$SHELLSPEC_PROJECT_ROOT/lib/cask-variants.sh"
+  }
+  BeforeEach 'setup'
+
+  Describe "cask_variants_superseded"
+    It "pairs an installed cask with the declared variant that replaces it"
+      When call cask_variants_superseded "ghostty@tip" "ghostty"
+      The status should be success
+      The output should equal "$(printf 'ghostty\tghostty@tip')"
+    End
+
+    It "retires a variant when the Brewfile moves back to the plain cask"
+      When call cask_variants_superseded "ghostty" "ghostty@tip"
+      The output should equal "$(printf 'ghostty@tip\tghostty')"
+    End
+
+    It "leaves a cask alone while it is still declared"
+      When call cask_variants_superseded "ghostty@tip" "ghostty@tip"
+      The output should equal ""
+    End
+
+    It "ignores an installed cask with no declared sibling"
+      When call cask_variants_superseded "ghostty@tip" "rancher"
+      The output should equal ""
+    End
+
+    It "does not treat a conflicting unrelated app as a sibling"
+      # docker-desktop declares conflicts_with rancher, but they share no base
+      # token, so the variant rule must not select it.
+      When call cask_variants_superseded "docker-desktop" "rancher"
+      The output should equal ""
+    End
+
+    It "matches on the whole base token, not a prefix"
+      When call cask_variants_superseded "docker-desktop" "docker"
+      The output should equal ""
+    End
+
+    It "selects only the superseded entries out of a mixed list"
+      declared=$(printf 'ghostty@tip\nclaude-code@latest\nfirefox')
+      installed=$(printf 'ghostty\nfirefox\nclaude-code')
+
+      When call cask_variants_superseded "$declared" "$installed"
+      The line 1 should equal "$(printf 'ghostty\tghostty@tip')"
+      The line 2 should equal "$(printf 'claude-code\tclaude-code@latest')"
+      The lines of output should equal 2
+    End
+
+    It "handles an empty installed list"
+      When call cask_variants_superseded "ghostty@tip" ""
+      The output should equal ""
+    End
+  End
+End

--- a/scripts/spec/install_cask_variants_spec.sh
+++ b/scripts/spec/install_cask_variants_spec.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# The stub bodies below are written out verbatim, so their expansions are the
+# stub's to resolve at run time.
+# shellcheck disable=SC2329,SC2016
+
+Describe "install-cask-variants"
+  script="$SHELLSPEC_PROJECT_ROOT/install-cask-variants"
+
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/install-cask-variants"
+    rm -rf "$sandbox"
+    mkdir -p "$sandbox/bin"
+    : > "$sandbox/declared"
+    : > "$sandbox/installed"
+    printf '{"casks":[{"conflicts_with":{"cask":[]}}]}\n' > "$sandbox/info.json"
+    : > "$sandbox/uninstalled"
+
+    # The script only runs on macOS, and the suite runs on Linux too.
+    printf '#!/bin/sh\necho Darwin\n' > "$sandbox/bin/uname"
+
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'case "$1 $2" in' \
+      '  "bundle list") cat "$FIXTURES/declared"; [ -f "$FIXTURES/list-nonzero" ] && exit 1; exit 0 ;;' \
+      '  "list --cask") cat "$FIXTURES/installed" ;;' \
+      '  "info --json=v2") cat "$FIXTURES/info-$4.json" 2>/dev/null || cat "$FIXTURES/info.json" ;;' \
+      '  "uninstall --cask") grep -qxF "$3" "$FIXTURES/uninstall-fails" 2>/dev/null && exit 1; echo "$3" >> "$FIXTURES/uninstalled" ;;' \
+      'esac' > "$sandbox/bin/brew"
+
+    chmod +x "$sandbox/bin/uname" "$sandbox/bin/brew"
+
+    # macOS ships /usr/bin/jq, so testing the missing-jq path needs a PATH
+    # holding only what the script legitimately calls.
+    mkdir -p "$sandbox/nojq"
+    cp "$sandbox/bin/uname" "$sandbox/bin/brew" "$sandbox/nojq/"
+    for tool in sh dirname cut sed grep cat; do
+      ln -sf "$(command -v "$tool")" "$sandbox/nojq/$tool"
+    done
+
+    export FIXTURES="$sandbox"
+  }
+  BeforeEach 'setup'
+
+  declared() { printf '%s\n' "$@" > "$sandbox/declared"; }
+  installed() { printf '%s\n' "$@" > "$sandbox/installed"; }
+  conflicts() {
+    printf '{"casks":[{"conflicts_with":{"cask":["%s"]}}]}\n' "$1" > "$sandbox/info.json"
+  }
+  uninstalled() { cat "$sandbox/uninstalled"; }
+
+  # jq is real; only brew and uname are stubbed.
+  run_script() {
+    PATH="$sandbox/bin:$PATH" "$script" "$sandbox"
+  }
+
+  # jq comes from the brew bundle that runs after this script.
+  run_without_jq() {
+    PATH="$sandbox/nojq" "$script" "$sandbox"
+  }
+
+  It "uninstalls the cask a declared variant supersedes"
+    declared ghostty@tip
+    installed ghostty
+    conflicts ghostty
+
+    When call run_script
+    The status should be success
+    The output should include "uninstalling ghostty, superseded by ghostty@tip"
+    The result of function uninstalled should equal "ghostty"
+  End
+
+  It "does nothing when the installed cask is still declared"
+    declared ghostty@tip
+    installed ghostty@tip
+
+    When call run_script
+    The status should be success
+    The output should equal ""
+    The result of function uninstalled should equal ""
+  End
+
+  # Homebrew's own conflict data decides, so the @suffix naming only nominates.
+  It "keeps a same-base cask that Homebrew does not report as conflicting"
+    declared ghostty@tip
+    installed ghostty
+    conflicts something-else
+
+    When call run_script
+    The status should be success
+    The result of function uninstalled should equal ""
+  End
+
+  # Aborting mid-run would leave an app uninstalled with its replacement not yet
+  # installed, so confirmation for every candidate has to finish first.
+  It "uninstalls nothing when a later candidate cannot be confirmed"
+    declared ghostty@tip claude-code@latest
+    installed ghostty claude-code
+    # The first candidate confirms cleanly, so removing before confirming the
+    # rest would take ghostty out and then abort on the second.
+    printf '{"casks":[{"conflicts_with":{"cask":["ghostty"]}}]}\n' > "$sandbox/info-ghostty@tip.json"
+    printf 'not json at all\n' > "$sandbox/info-claude-code@latest.json"
+
+    When call run_script
+    The status should be failure
+    The stderr should include "cannot read Homebrew metadata"
+    The result of function uninstalled should equal ""
+  End
+
+  # Unreadable metadata is a different answer from "they don't conflict".
+  It "fails rather than skipping when the cask metadata cannot be read"
+    declared ghostty@tip
+    installed ghostty
+    printf 'not json at all\n' > "$sandbox/info.json"
+
+    When call run_script
+    The status should be failure
+    The stderr should include "cannot read Homebrew metadata for ghostty@tip"
+    The stderr should include "brew uninstall --cask ghostty"
+    The result of function uninstalled should equal ""
+  End
+
+  It "leaves a conflicting cask alone when it is not a variant of a declared one"
+    declared docker-desktop
+    installed rancher
+    conflicts rancher
+
+    When call run_script
+    The status should be success
+    The result of function uninstalled should equal ""
+  End
+
+  # An empty list from a failed lookup is indistinguishable from "nothing is
+  # superseded", and the latter exits 0.
+  It "fails when the cask lists cannot be enumerated"
+    installed ghostty
+    : > "$sandbox/declared"
+    : > "$sandbox/list-nonzero"
+
+    When call run_script
+    The status should be failure
+    The stderr should include "cannot enumerate casks"
+    The result of function uninstalled should equal ""
+  End
+
+  # brew exits nonzero while still printing a complete list when something
+  # incidental fails, such as a cache refresh it could not write. A usable list
+  # has to win over the status, or bootstrap breaks on a warning.
+  It "proceeds when the lookup prints a full list but exits nonzero"
+    declared ghostty@tip
+    installed ghostty
+    conflicts ghostty
+    : > "$sandbox/list-nonzero"
+
+    When call run_script
+    The status should be success
+    The result of function uninstalled should equal "ghostty"
+  End
+
+  # Once removal has started, aborting strands an app that brew bundle has not
+  # replaced yet, so the run continues and lets bundle report the rest.
+  It "keeps going when one uninstall fails"
+    declared ghostty@tip claude-code@latest
+    installed ghostty claude-code
+    printf '{"casks":[{"conflicts_with":{"cask":["ghostty"]}}]}\n' > "$sandbox/info-ghostty@tip.json"
+    printf '{"casks":[{"conflicts_with":{"cask":["claude-code"]}}]}\n' > "$sandbox/info-claude-code@latest.json"
+    printf 'ghostty\n' > "$sandbox/uninstall-fails"
+
+    When call run_script
+    The status should be success
+    The stderr should include "could not uninstall ghostty"
+    The result of function uninstalled should equal "claude-code"
+  End
+
+  It "exits quietly when nothing is installed"
+    declared ghostty@tip
+    installed
+
+    When call run_script
+    The status should be success
+    The output should equal ""
+  End
+
+  # Skipping quietly here would let brew bundle fail later on the conflict,
+  # which is the failure this script exists to prevent.
+  It "fails with the manual command when jq is unavailable to confirm"
+    declared ghostty@tip
+    installed ghostty
+
+    When call run_without_jq
+    The status should be failure
+    The stderr should include "jq is not available"
+    The stderr should include "brew uninstall --cask ghostty"
+    The result of function uninstalled should equal ""
+  End
+
+  It "does not need jq when there is nothing to retire"
+    declared ghostty@tip
+    installed ghostty@tip
+
+    When call run_without_jq
+    The status should be success
+  End
+End


### PR DESCRIPTION
Switching which variant of a cask the Brewfile declares is a change `brew bundle` cannot carry out on its own. Every `@variant` declares `conflicts_with` against its siblings, and the relationship is symmetric, so bundle fails until the old variant is gone. This bites in both directions: `main` currently declares `ghostty` while this machine has `ghostty@tip` installed, so `scripts/install` from `main` is already broken here.

`scripts/install-cask-variants` runs before `brew bundle` and retires the variant the Brewfile stopped declaring. It derives that from the Brewfile plus Homebrew's own conflict data rather than hardcoding a pair, so switching a cask needs no follow-up commit to clean up after it, and reverting the Brewfile line migrates back with no extra work. #576 is the first user.

## What it will and will not remove

- A cask is a candidate when it is installed, no longer declared, but a sibling variant of the same app is. Matching is on the whole base token, so `docker` never matches `docker-desktop`.
- A candidate is only removed once `brew info --json=v2` reports the declared cask as actually conflicting with it. The `@suffix` naming nominates; Homebrew's data decides.
- It will not remove a conflicting cask that is not a variant of something declared. `docker-desktop` conflicts with `rancher`, and a hand-installed Rancher stays put.

It already covers the other variant casks in the Brewfile: `claude-code@latest`, `iterm2@beta`, `slack`, `transmission`, `vlc`, `gpg-suite`.

## Failing loudly, and knowing when not to

Every branch that cannot confirm something reports it rather than skipping, because a silent skip here just defers a `brew bundle` conflict error that carries none of this context:

- `jq` arrives with the `brew bundle` that runs after this, so it is required only once a candidate exists. A machine with no casks yet never needs it.
- Unreadable cask metadata is a different answer from "they do not conflict", so it fails with the manual `brew uninstall` command instead of falling through the same skip.
- Confirmation for every candidate completes before anything is uninstalled, so a metadata failure on a later cask cannot abort the run with an earlier one already removed.

Two places deliberately do not fail:

- `brew` exits nonzero while still printing a complete list when something incidental fails, such as a cache refresh it could not write. I hit exactly this while testing. So the list is the signal and the status only decides when there is no list. Treating nonzero as fatal would break bootstrap on a warning.
- Once removal has started the machine is already changing, and `brew bundle` is what installs the replacements. Aborting there would strand an app that nothing has replaced yet, so the uninstall pass continues and lets bundle report the rest.

## Testing

`scripts/spec/cask_variants_spec.sh` covers the selection rule: both migration directions, a still-declared cask, an installed cask with no sibling, whole-base-token matching, mixed lists, empty input.

`scripts/spec/install_cask_variants_spec.sh` runs the script against a stubbed `brew`, covering the confirmed removal, a cask Homebrew does not report as conflicting, a conflicting non-variant, unreadable metadata, the confirm-before-removing ordering, a lookup that prints a list but exits nonzero, an uninstall that fails partway, and the missing-`jq` path. macOS ships `/usr/bin/jq`, so that last one builds a curated PATH to exercise the guard honestly.

The ordering case is a real regression test: it fails against the earlier interleaved version and passes against this one.

Ran against live Homebrew state in both directions. On a tree declaring `ghostty@tip` with `ghostty@tip` installed it correctly does nothing. On a tree declaring `ghostty` it correctly identifies `ghostty@tip` as superseded and attempts the removal.
