### PR TITLE
scripts: read findings from a pipeline instead of a here-document

### DIFF
--- a/scripts/lint-expired
+++ b/scripts/lint-expired
@@ -24,80 +24,90 @@ today="${LINT_EXPIRED_TODAY:-$(date +%Y-%m-%d)}"
 today_num=$(echo "$today" | tr -d -)
 
 marker='EXPIRES:'
-expired=""
-expired_count=0
-malformed=""
+tab=$(printf '\t')
 
 matches=$(git grep -n -- "$marker" || true)
 
-# A here-doc rather than a pipe, so the counters survive the loop.
-while IFS=: read -r file line rest; do
-  [ -n "$file" ] || continue
+# Emit one tagged record per finding rather than accumulating into variables,
+# which a pipeline's subshell would discard. A here-document would keep the
+# variables, but bash stages one through a temp file whose location it picks
+# itself, and where that path is denied the read fails while the script carries
+# on to exit 0. A clean report for a repo full of expired markers is the one
+# outcome this check must never produce, so it does not depend on that write.
+classify_matches() {
+  while IFS=: read -r file line rest; do
+    [ -n "$file" ] || continue
 
-  # This script and its spec both document the marker, so they match themselves.
-  case "$file" in
-    scripts/lint-expired | scripts/spec/lint_expired_spec.sh) continue ;;
-  esac
-
-  date_field=$(printf '%s\n' "$rest" |
-    sed -n "s/.*${marker}[[:space:]]*\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\).*/\1/p")
-
-  # A typo'd date that silently never fires would defeat the point, so treat an
-  # unparseable marker as a failure rather than skipping it. Checking the month
-  # and day ranges independently would admit dates like 2026-02-31, so the day
-  # is measured against the length of that specific month.
-  day_limit=0
-  if [ -n "$date_field" ]; then
-    # Zero padding reads as octal in arithmetic, so strip it first.
-    year=$(echo "$date_field" | cut -d- -f1)
-    month=$(echo "$date_field" | cut -d- -f2 | sed 's/^0//')
-    day=$(echo "$date_field" | cut -d- -f3 | sed 's/^0//')
-
-    case "$month" in
-      1 | 3 | 5 | 7 | 8 | 10 | 12) day_limit=31 ;;
-      4 | 6 | 9 | 11) day_limit=30 ;;
-      2)
-        day_limit=28
-        if [ $((year % 4)) -eq 0 ] &&
-          { [ $((year % 100)) -ne 0 ] || [ $((year % 400)) -eq 0 ]; }; then
-          day_limit=29
-        fi
-        ;;
+    # This script and its spec both document the marker, so they match themselves.
+    case "$file" in
+      scripts/lint-expired | scripts/spec/lint_expired_spec.sh) continue ;;
     esac
-  fi
 
-  if [ "$day_limit" -eq 0 ] || [ "$day" -lt 1 ] || [ "$day" -gt "$day_limit" ]; then
-    malformed="$malformed  $file:$line
-"
-    continue
-  fi
+    date_field=$(printf '%s\n' "$rest" |
+      sed -n "s/.*${marker}[[:space:]]*\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\).*/\1/p")
 
-  if [ "$(echo "$date_field" | tr -d -)" -lt "$today_num" ]; then
-    reason=$(printf '%s\n' "$rest" |
-      sed -n "s/.*${marker}[[:space:]]*[0-9-]\{10\}[[:space:]]*//p")
-    expired_count=$((expired_count + 1))
-    expired="$expired  $file:$line  $marker $date_field
-"
-    [ -n "$reason" ] && expired="$expired    $reason
-"
-  fi
-done <<EOF
-$matches
-EOF
+    # A typo'd date that silently never fires would defeat the point, so treat
+    # an unparseable marker as a failure rather than skipping it. Checking the
+    # month and day ranges independently would admit dates like 2026-02-31, so
+    # the day is measured against the length of that specific month.
+    day_limit=0
+    if [ -n "$date_field" ]; then
+      # Zero padding reads as octal in arithmetic, so strip it first.
+      year=$(echo "$date_field" | cut -d- -f1)
+      month=$(echo "$date_field" | cut -d- -f2 | sed 's/^0//')
+      day=$(echo "$date_field" | cut -d- -f3 | sed 's/^0//')
+
+      case "$month" in
+        1 | 3 | 5 | 7 | 8 | 10 | 12) day_limit=31 ;;
+        4 | 6 | 9 | 11) day_limit=30 ;;
+        2)
+          day_limit=28
+          if [ $((year % 4)) -eq 0 ] &&
+            { [ $((year % 100)) -ne 0 ] || [ $((year % 400)) -eq 0 ]; }; then
+            day_limit=29
+          fi
+          ;;
+      esac
+    fi
+
+    if [ "$day_limit" -eq 0 ] || [ "$day" -lt 1 ] || [ "$day" -gt "$day_limit" ]; then
+      printf 'M%s%s:%s\n' "$tab" "$file" "$line"
+      continue
+    fi
+
+    if [ "$(echo "$date_field" | tr -d -)" -lt "$today_num" ]; then
+      reason=$(printf '%s\n' "$rest" |
+        sed -n "s/.*${marker}[[:space:]]*[0-9-]\{10\}[[:space:]]*//p")
+      printf 'E%s%s:%s%s%s%s%s\n' "$tab" "$file" "$line" "$tab" "$date_field" "$tab" "$reason"
+    fi
+  done
+}
+
+records=$(printf '%s\n' "$matches" | classify_matches)
+
+malformed=$(printf '%s\n' "$records" | grep "^M${tab}" | cut -f2- || true)
+expired=$(printf '%s\n' "$records" | grep "^E${tab}" | cut -f2- || true)
 
 status=0
 
 if [ -n "$malformed" ]; then
   echo "ERROR: malformed $marker marker (expected $marker YYYY-MM-DD reason):" >&2
-  printf '%s' "$malformed" >&2
+  printf '%s\n' "$malformed" | sed 's/^/  /' >&2
   status=1
 fi
 
 if [ -n "$expired" ]; then
+  expired_count=$(printf '%s\n' "$expired" | grep -c . || true)
   noun="migrations are"
   [ "$expired_count" -eq 1 ] && noun="migration is"
   echo "ERROR: $expired_count $noun past the expiry date." >&2
-  printf '%s' "$expired" >&2
+  printf '%s\n' "$expired" | while IFS="$tab" read -r location date_field reason; do
+    [ -n "$location" ] || continue
+    echo "  $location  $marker $date_field" >&2
+    if [ -n "$reason" ]; then
+      echo "    $reason" >&2
+    fi
+  done
   echo "  Remove it, or push the date out because the reason still holds." >&2
   status=1
 fi

--- a/scripts/spec/dotfiles_sync_spec.sh
+++ b/scripts/spec/dotfiles_sync_spec.sh
@@ -13,22 +13,27 @@ Describe "dotfiles-sync exit status"
     mkdir -p "$stubdir"
 
     # gum stub: `gum spin … -- cmd` runs cmd; `gum log … msg` echoes msg.
-    cat > "$stubdir/gum" <<'GUM'
-#!/usr/bin/env bash
-case "$1" in
-  spin)
-    shift
-    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
-    [ "$1" = "--" ] && shift
-    exec "$@"
-    ;;
-  log)
-    # Real gum log writes to stderr; match that so command substitution in
-    # callers keeps log lines off the captured stdout rev.
-    printf '%s\n' "${@: -1}" >&2
-    ;;
-esac
-GUM
+    # Written with printf rather than a here-document. bash stages a
+    # here-document through a temp file whose location it picks itself, so
+    # under a sandbox that denies that path it fails with "cannot create temp
+    # file for here document" and the stub never gets written.
+    # shellcheck disable=SC2016 # the stub's own $1 and $@, not this shell's
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'case "$1" in' \
+      '  spin)' \
+      '    shift' \
+      '    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done' \
+      '    [ "$1" = "--" ] && shift' \
+      '    exec "$@"' \
+      '    ;;' \
+      '  log)' \
+      '    # Real gum log writes to stderr; match that so command substitution' \
+      '    # in callers keeps log lines off the captured stdout rev.' \
+      '    printf "%s\n" "${@: -1}" >&2' \
+      '    ;;' \
+      'esac' \
+      > "$stubdir/gum"
     chmod +x "$stubdir/gum"
 
     # notify shells out to osascript on macOS; stub it so the failure path


### PR DESCRIPTION
Replaces the two here-document-fed read loops in `scripts/` with pipelines.

bash stages a here-document through a temp file whose location it picks itself. Where that path is denied it prints `cannot create temp file for here document` to stderr and the reading loop sees nothing, but the script keeps going.

`scripts/spec/dotfiles_sync_spec.sh` hit this for real. Both of its examples fail under the Claude Code sandbox because the `gum` stub never gets written, which is how I found the pattern. The suite goes from 40/42 to 42/42 there.

`scripts/lint-expired` had the same construct with a worse consequence. Its reporting loop read the findings through a here-document, so a failed stage would leave it reporting clean and exiting 0 for a repo full of expired markers. That silent pass is the one outcome the check exists to prevent, so it should not depend on a temp file write succeeding.

The loop now lives in a function whose output a pipeline captures, emitting one tab-tagged record per finding rather than accumulating into variables a subshell would discard. Moving it into a function is also what keeps the `case` statements parseable: bash 3.2 reads a `case` pattern's unbalanced `)` as the end of an enclosing `$( )`, and a function body is parsed outside the substitution.

## Verification

Output is unchanged. I ran the previous and rewritten versions against this repo with `LINT_EXPIRED_TODAY=2027-01-01` to force both `macos/install.sh` markers past due, and the reports are byte-identical.

No test covers the failure directly. Reproducing it needs both `$TMPDIR` and the `/tmp` fallback to be unwritable at once: bash checks `$TMPDIR` for writability and quietly falls back, so pointing it at a missing or mode-500 directory does not do it. I wrote a `$TMPDIR` regression test first and dropped it after confirming it passed against the unfixed script, which made it worse than no test.
