### PR TITLE
ci: disable the Linux Homebrew sandbox during bootstrap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,15 @@ jobs:
         # remove stale packages from cache without prompting for confirmation
         # (plain HOMEBREW_BUNDLE_INSTALL_CLEANUP now requires --force/$HOMEBREW_ASK)
         HOMEBREW_BUNDLE_FORCE_INSTALL_CLEANUP: '1'
+        # Homebrew/brew#22240 made Homebrew build unbottled formulae inside a
+        # rootless bwrap sandbox on Linux. Mktemp#run chowns its staging dir to
+        # the brew file's group, that gid is unmapped in the sandbox's user
+        # namespace, and chown(2) answers EINVAL where Mktemp rescues only
+        # EPERM, so every source install dies with "EINVAL @ apply2files".
+        # That PR added the sandbox and does not describe this failure, which
+        # is unreported upstream. Drop this once the Landlock backend (added in
+        # 6.0.13, opt-in behind $HOMEBREW_SANDBOX_LINUX_LANDLOCK) is default.
+        HOMEBREW_NO_SANDBOX_LINUX: '1'
         # skip deps installed without homebrew in https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
         HOMEBREW_BUNDLE_BREW_SKIP: >
           awscli
@@ -97,6 +106,17 @@ jobs:
           python@3.11
           python@3.12
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: TEMP probe sandbox chown
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        id
+        brew_gid=$(stat -c '%g' /home/linuxbrew/.linuxbrew/bin/brew)
+        echo "brew file gid: $brew_gid"
+        bwrap --unshare-user --unshare-ipc --unshare-pid --unshare-uts \
+          --ro-bind / / --dev /dev --proc /proc --bind /var/tmp /var/tmp \
+          -- sh -c "id; d=\$(mktemp -d /var/tmp/probe.XXXXXX); \
+            chown :\$(id -g) \"\$d\" && echo 'chown to egid ok'; \
+            chown :$brew_gid \"\$d\" && echo 'chown to brew gid ok'" || true
     # actions/checkout writes credentials to ~/.gitconfig, which takes
     # precedence over the XDG path (~/.config/git/config) where
     # install-symlinks places the dotfiles git config.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,7 @@ jobs:
         id
         brew_gid=$(stat -c '%g' /home/linuxbrew/.linuxbrew/bin/brew)
         echo "brew file gid: $brew_gid"
+        sudo apt-get install -y bubblewrap
         bwrap --unshare-user --unshare-ipc --unshare-pid --unshare-uts \
           --ro-bind / / --dev /dev --proc /proc --bind /var/tmp /var/tmp \
           -- sh -c "id; d=\$(mktemp -d /var/tmp/probe.XXXXXX); \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,12 +87,13 @@ jobs:
         HOMEBREW_BUNDLE_FORCE_INSTALL_CLEANUP: '1'
         # Homebrew/brew#22240 made Homebrew build unbottled formulae inside a
         # rootless bwrap sandbox on Linux. Mktemp#run chowns its staging dir to
-        # the brew file's group, that gid is unmapped in the sandbox's user
-        # namespace, and chown(2) answers EINVAL where Mktemp rescues only
-        # EPERM, so every source install dies with "EINVAL @ apply2files".
-        # That PR added the sandbox and does not describe this failure, which
-        # is unreported upstream. Drop this once the Landlock backend (added in
-        # 6.0.13, opt-in behind $HOMEBREW_SANDBOX_LINUX_LANDLOCK) is default.
+        # bin/brew's group, which the image ships as docker, a supplementary
+        # group. bwrap maps only the primary gid, so chown(2) answers EINVAL
+        # where Mktemp rescues only EPERM and every source install dies with
+        # "EINVAL @ apply2files". That PR added the sandbox and does not
+        # describe this failure, which is unreported upstream. Drop this once
+        # the Landlock backend (6.0.13, currently opt-in behind
+        # $HOMEBREW_SANDBOX_LINUX_LANDLOCK) becomes the default.
         HOMEBREW_NO_SANDBOX_LINUX: '1'
         # skip deps installed without homebrew in https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
         HOMEBREW_BUNDLE_BREW_SKIP: >
@@ -106,27 +107,6 @@ jobs:
           python@3.11
           python@3.12
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: TEMP probe sandbox chown
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        id
-        brew_gid=$(stat -c '%g' /home/linuxbrew/.linuxbrew/bin/brew)
-        echo "brew file gid: $brew_gid"
-        sudo apt-get install -y bubblewrap
-        # 127 is the docker group, a supplementary group of runner and the gid
-        # the image ships bin/brew with before any cache restore rewrites it.
-        # shellcheck disable=SC2016 # the inner sh -c does the expanding
-        probe='id
-          d=$(mktemp -d /var/tmp/probe.XXXXXX)
-          for g in $(id -g) 127; do
-            chown :$g "$d" && echo "chown to gid $g ok" || echo "chown to gid $g failed"
-          done'
-        echo "--- outside the sandbox"
-        sh -c "$probe"
-        echo "--- inside the sandbox"
-        bwrap --unshare-user --unshare-ipc --unshare-pid --unshare-uts \
-          --ro-bind / / --dev /dev --proc /proc --bind /var/tmp /var/tmp \
-          -- sh -c "$probe" || true
     # actions/checkout writes credentials to ~/.gitconfig, which takes
     # precedence over the XDG path (~/.config/git/config) where
     # install-symlinks places the dotfiles git config.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,11 +113,20 @@ jobs:
         brew_gid=$(stat -c '%g' /home/linuxbrew/.linuxbrew/bin/brew)
         echo "brew file gid: $brew_gid"
         sudo apt-get install -y bubblewrap
+        # 127 is the docker group, a supplementary group of runner and the gid
+        # the image ships bin/brew with before any cache restore rewrites it.
+        # shellcheck disable=SC2016 # the inner sh -c does the expanding
+        probe='id
+          d=$(mktemp -d /var/tmp/probe.XXXXXX)
+          for g in $(id -g) 127; do
+            chown :$g "$d" && echo "chown to gid $g ok" || echo "chown to gid $g failed"
+          done'
+        echo "--- outside the sandbox"
+        sh -c "$probe"
+        echo "--- inside the sandbox"
         bwrap --unshare-user --unshare-ipc --unshare-pid --unshare-uts \
           --ro-bind / / --dev /dev --proc /proc --bind /var/tmp /var/tmp \
-          -- sh -c "id; d=\$(mktemp -d /var/tmp/probe.XXXXXX); \
-            chown :\$(id -g) \"\$d\" && echo 'chown to egid ok'; \
-            chown :$brew_gid \"\$d\" && echo 'chown to brew gid ok'" || true
+          -- sh -c "$probe" || true
     # actions/checkout writes credentials to ~/.gitconfig, which takes
     # precedence over the XDG path (~/.config/git/config) where
     # install-symlinks places the dotfiles git config.


### PR DESCRIPTION
`bootstrap (linux)` has failed on `main` and on every open PR since 2026-07-15. Seven formulae die during `brew bundle`, each with the same error against its own staging directory:

```
==> Installing bun from oven-sh/bun
An exception occurred within a child process:
  Errno::EINVAL: Invalid argument @ apply2files - /var/tmp/bun-20260729-2-9dotf0
`brew bundle` failed! 7 Brewfile dependencies failed to install
```

## Why

Homebrew runs formula source installs on Linux inside a rootless `bwrap` sandbox, added in [Homebrew/brew#22240](https://github.com/Homebrew/brew/pull/22240) and made the default in [#22370](https://github.com/Homebrew/brew/pull/22370). `Mktemp#run` stages every source install and, before yielding, does this:

```ruby
group_id = if HOMEBREW_ORIGINAL_BREW_FILE.grpowned?
  HOMEBREW_ORIGINAL_BREW_FILE.stat.gid
else
  Process.gid
end
begin
  @tmpdir.chown(nil, group_id)
rescue Errno::EPERM
```

`bin/brew` ships in the runner image with group `docker` (gid 127), which is a *supplementary* group of `runner`, not its primary group. Ruby's `File.grpowned?` is `rb_group_member`, which matches supplementary groups, so `Mktemp` takes the first branch and picks up gid 127. `bwrap --unshare-user` maps only the primary gid and collapses supplementary groups to `nogroup`, leaving 127 unmapped. `chown(2)` to an unmapped gid fails in `make_kgid` before any permission check, so it returns `EINVAL` rather than `EPERM`, the `rescue` does not catch it, and the exception escapes the sandboxed build child.

The `-2-` in every staging path is the PID inside the sandbox's PID namespace, which is the tell that this runs under `bwrap`.

`HOMEBREW_NO_SANDBOX_LINUX` is Homebrew's documented opt-out, shipped alongside the sandbox itself in 5.1.12. It turns off build-time isolation only, so every package still installs and every downstream assertion still runs.

## What makes these seven special

Not the tap, and not the platform. `brew info --json=v2` reports `bottle.stable` absent for all six that are tappable here, and `withgraphite/tap/graphite` has no `bottle do` block in its formula source. There is no bottle to pour on any platform, so each one stages through `Mktemp`. The ~60 formulae that pour bottles never reach that code.

The same seven install cleanly in `bootstrap (macos)` on the identical run, through the identical `Mktemp` chown. macOS sandboxes with `sandbox-exec`, which creates no user namespace, so the chown succeeds there. Formula and platform support are held constant across the two jobs and only the sandbox backend differs.

## What unmasked it

The bug has been latent since the sandbox landed in 5.1.12 on 2026-05-16. CI did not hit it because the restored `/home/linuxbrew/.linuxbrew` cache already held these kegs, so the last passing run reported `Using schpet/tap/linear` rather than `Installing`. On the first failing run the Homebrew cache was gone (`Cache not found for input keys: homebrew-v3-Linux-…, homebrew-v2-Linux-`) and `brew bundle` had to build them for the first time since May. Homebrew was 6.0.6 on both runs, so the brew version did not change.

It has been self-sustaining since: the job fails, `actions/cache` does not save on failure, the next run is cold again.

The cache also explains why only cold runs break. A cache restore extracts as `runner`, which rewrites `bin/brew`'s group from the image's `docker` (127) to `runner` (1001). 1001 is the primary gid, which `bwrap` does map, so on a warm run the chown would have succeeded anyway. Measured on this branch: gid 127 before any cache existed, gid 1001 on the next run.

## Verified

- `bootstrap (linux)` passes. Run `30464284321` is the meaningful one: cold Homebrew cache, so all seven actually installed from source rather than restoring from a keg, with no `apply2files` error. `bootstrap (macos)`, both `skill tests` legs, `lint`, `zprof formatter`, and `fzf-links schemes` stayed green.
- The kernel-level mechanism was **confirmed by measurement**, not just reasoned. A temporary probe ran the same `chown` inside and outside a `bwrap` namespace built with Homebrew's own flags:

  ```
  --- outside the sandbox
  uid=1001(runner) gid=1001(runner) groups=1001(runner),4(adm),100(users),101(systemd-journal),127(docker)
  chown to gid 1001 ok
  chown to gid 127 ok
  --- inside the sandbox
  uid=1001(runner) gid=1001(runner) groups=1001(runner),65534(nogroup)
  chown to gid 1001 ok
  chown: changing group of '/var/tmp/probe.ygPj3P': Invalid argument
  chown to gid 127 failed
  ```

  Supplementary groups collapse to `nogroup` inside the namespace, the mapped primary gid still chowns fine, and the unmapped supplementary gid fails with `EINVAL`. That is exactly the error `Mktemp` does not rescue. The probe was removed once it produced this.
- `git diff 6.0.11..HEAD -- mktemp.rb` against a local 6.0.13 checkout is empty, so upgrading Homebrew alone does not fix this. The Landlock backend that would avoid the user namespace arrived in 6.0.13, is opt-in behind `HOMEBREW_SANDBOX_LINUX_LANDLOCK`, and does not exist in the 6.0.11 CI runs.
- The `rescue Errno::EPERM` is read from `Library/Homebrew/mktemp.rb` in a local 6.0.13 checkout, at lines 83-84 of `Mktemp#run`, not inferred from the error text.
- Searched `Homebrew/brew` issues for `apply2files`, `EINVAL`, and the `Mktemp` chown. Nothing matches. This is not reported upstream, so the comment cites the PR that introduced the behavior and says so rather than implying an acknowledged bug.

One caveat on the second and third runs of this branch: once run `30464284321` passed it saved a Homebrew cache, so later runs logged `Using schpet/tap/linear` rather than `Installing` and did not re-exercise the source path. They are not independent confirmations of the fix.

## Narrower options that do not work

- **Per-formula opt-out.** None exists. `brew install` has no sandbox flag and `HOMEBREW_NO_SANDBOX_LINUX` is read from the process environment, while `brew bundle` installs everything under one process tree.
- **The existing `HOMEBREW_BUNDLE_BREW_SKIP` list.** Fixes three of seven at best. Only `peekaboo` (`depends_on macos: :sequoia`), `speedtest`, and `dark-notify` are macOS-only. `linear`, `graphite`, `bun`, and `tuicr` ship genuine Linux binaries, still stage through `Mktemp`, and still fail. The skip list is also the wrong home for it: it sits in the Bootstrap step's `env` and that step has no `if`, so it applies to both matrix legs and would stop installing these on macOS too. "macOS-only" belongs in the topic Brewfile as `if OS.mac?`, which `macos/Brewfile` already does.
- **Upgrading Homebrew in CI.** Does not fix `mktemp.rb`, and adopting Landlock would mean forcing an upgrade past 6.0.13 on top of an opt-in flag.

## What this gives up

Build-time network denial and filesystem confinement for the seven source installs in the Linux job. Bottle pours were never sandboxed. The runner is a single-use ephemeral VM and these are the same formulae that install unsandboxed on the machines this repo configures, so the isolation lost is narrow.

## Follow-ups, not in this PR

- `speedtest`, `dark-notify`, and `peekaboo` install macOS binaries on Linux, so the Linux job now produces three unrunnable binaries and calls it success. `peekaboo` even carries `depends_on macos: :sequoia`, which Homebrew never evaluated in the passing run. They want the `if OS.mac?` treatment that `macos/Brewfile` already uses.
- Repo cache usage sits at 9.0 GB against GitHub's 10 GB limit, almost entirely four `homebrew-v3-macOS-*` entries of roughly 2 GB each, one per `Brewfile` hash. Zero Linux entries survive. Until that is trimmed the Linux job will keep taking the cold path.
