### PR TITLE
ci: fix Linux Homebrew install-step skew on gcc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ jobs:
       matrix:
         include:
           - name: linux
-            os: ubuntu-22.04
+            # Not 22.04: its glibc predates Homebrew's minimum, so brew builds
+            # its own toolchain there, and gcc's post-install declares an
+            # install step the image's pinned brew lacks.
+            os: ubuntu-latest
           - name: macos
             os: macos-15
     name: bootstrap (${{ matrix.name }})
@@ -53,10 +56,11 @@ jobs:
     - name: Cache Homebrew packages
       uses: actions/cache@v6
       with:
-        key: homebrew-v3-${{ runner.os }}-${{ hashFiles('**/Brewfile') }}
+        # runner.os does not distinguish Ubuntu releases, and the cached prefix
+        # holds brew itself, so a v3 cache would restore 22.04's brew and glibc.
+        key: homebrew-v4-${{ runner.os }}-${{ hashFiles('**/Brewfile') }}
         restore-keys: |
-          homebrew-v3-${{ runner.os }}-
-          homebrew-v2-${{ runner.os }}-
+          homebrew-v4-${{ runner.os }}-
         path: |
           ~/Library/Caches/Homebrew
           /opt/homebrew/Library/Taps
@@ -220,7 +224,9 @@ jobs:
       matrix:
         include:
           - name: linux
-            os: ubuntu-22.04
+            # Not 22.04: its glibc predates Homebrew's minimum, so brew builds
+            # its own toolchain there and these specs need no compiler.
+            os: ubuntu-latest
           - name: macos
             os: macos-15
     name: skill tests (${{ matrix.name }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,15 +89,9 @@ jobs:
         # remove stale packages from cache without prompting for confirmation
         # (plain HOMEBREW_BUNDLE_INSTALL_CLEANUP now requires --force/$HOMEBREW_ASK)
         HOMEBREW_BUNDLE_FORCE_INSTALL_CLEANUP: '1'
-        # Homebrew/brew#22240 made Homebrew build unbottled formulae inside a
-        # rootless bwrap sandbox on Linux. Mktemp#run chowns its staging dir to
-        # bin/brew's group, which the image ships as docker, a supplementary
-        # group. bwrap maps only the primary gid, so chown(2) answers EINVAL
-        # where Mktemp rescues only EPERM and every source install dies with
-        # "EINVAL @ apply2files". That PR added the sandbox and does not
-        # describe this failure, which is unreported upstream. Drop this once
-        # the Landlock backend (6.0.13, currently opt-in behind
-        # $HOMEBREW_SANDBOX_LINUX_LANDLOCK) becomes the default.
+        # Homebrew's Linux bwrap sandbox breaks source installs: it chowns the
+        # build dir to an unmapped supplementary gid and EINVAL is not rescued.
+        # Drop once the Landlock backend (opt-in as of 6.0.13) is the default.
         HOMEBREW_NO_SANDBOX_LINUX: '1'
         # skip deps installed without homebrew in https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
         HOMEBREW_BUNDLE_BREW_SKIP: >

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,6 @@ jobs:
         rm -f /opt/homebrew/bin/openssl
         rm -rf ~/Library/Caches/Homebrew/Backup
         brew link --overwrite openssl@3 || true
-    - name: Print Homebrew configuration
-      run: brew config
     - name: Cache mise installs
       uses: actions/cache@v6
       with:
@@ -78,6 +76,14 @@ jobs:
           ~/.cargo/bin
           ~/.cargo/.crates.toml
           ~/.cargo/.crates2.json
+    # Formulae and casks come from the live API while the image pins brew, so
+    # they use DSL it lacks. Must follow the cache restore, which rewrites
+    # brew's own prefix. Updates brew only: bottles stay pinned by
+    # HOMEBREW_NO_INSTALL_UPGRADE.
+    - name: Update Homebrew
+      run: brew update
+    - name: Print Homebrew configuration
+      run: brew config
     - name: Bootstrap
       run: ./scripts/bootstrap
       env:


### PR DESCRIPTION
Both Linux jobs started failing with no change in this repo. `brew install` died pouring `gcc`:

```
==> Installing shellspec dependency: gcc
==> Pouring gcc--16.1.0.x86_64_linux.bottle.2.tar.gz
Error: unknown install step: configure_gcc_runtime
```

**`main` is broken right now on any cold-cache Linux run.** It looked green as recently as 03:35 only because `bootstrap (linux)` restored a warm Homebrew cache and skipped the `gcc` install entirely. That cache is gone. No green Linux run on this repo should be trusted until this merges.

## Root Cause

`gcc` 16.1.0's post-install declares `configure_gcc_runtime`, an install step Homebrew added in **6.0.13** (released 2026-07-27). The `ubuntu-22.04` image pins **6.0.11**, which rejects the name. Formula definitions come from the live JSON API on every run while the image pins brew itself, so the two drifted apart on their own.

`gcc` is only in the picture because `ubuntu-22.04` ships glibc 2.35, below Homebrew's floor. brew installs its own glibc 2.39 there and pulls `binutils` and `gcc` to link it, which lands in the dependency list of even `gum`, a Go binary:

```
==> Installing dependencies for gum: linux-headers@6.8, glibc, gmp, isl, mpfr,
    libmpc, lz4, xz, zlib-ng-compat, zstd, binutils and gcc
```

## The Fix

Both Linux legs move to `ubuntu-latest`, which is 24.04 and ships glibc 2.39 natively. brew then installs no glibc, no `binutils`, and no `gcc`, so there is no post-install step to skew against. `brew install shellspec duckdb` drops from 16 packages to 4.

Three things make this preferable to `brew update`:

- It removes the failing path instead of updating past it. Nothing in either job compiles anything.
- `ubuntu-22.04` is not older-glibc coverage. brew installs its own glibc 2.39 on top, so everything already links against 2.39 either way. The old image buys a toolchain build and no coverage.
- `brew update` would not have held. The Homebrew cache stores the entire prefix including brew's own source tree, and it restores *after* any update step, so a warm cache would put 6.0.11 back.

`ubuntu-22.04` was never a deliberate choice. It entered in #28 when it was what `ubuntu-latest` resolved to, and #306 copied it into the skill tests.

## Cache Key Bump

`homebrew-v3` -> `v4`, older restore-keys dropped. The key is built from `runner.os`, which does not distinguish Ubuntu releases, and the cached prefix carries brew's own source tree plus its bootstrapped glibc. Without the bump, a cache saved on 22.04 would restore that image's brew and glibc onto the new one and quietly reintroduce the skew. This costs one cold run per platform, macOS included.

## `lint` Needs No Change

It already runs `brew install shellspec ast-grep duckdb` on `ubuntu-latest`, where none of those formulae has a post-install step, so it never reaches the broken code. In the failing run it installed only `libcap` and `bubblewrap` and passed on the same commit that failed elsewhere. Its residual exposure is the generic pinned-brew-versus-live-API skew that every brew-using CI job has, which does not justify a network round trip on every run.

## Verified

- The install step name is absent from the 6.0.11 and 6.0.12 tags of `Library/Homebrew/install_steps/formula_actions.rb` and present in 6.0.13. The 22.04 image reported `HOMEBREW_VERSION: 6.0.11` on a run where the cache missed, so that version is the image's own.
- `Image: ubuntu-24.04` for `ubuntu-latest` versus `Image: ubuntu-22.04`, from the runner logs.
- The `gcc`-via-`glibc`-via-`gum` chain is quoted above from the bootstrap log.

Both jobs were checked for a cache-restored false pass, since a warm cache is what hid this to begin with. `skill-tests` has no Homebrew cache step at all, so its install always runs in full. `bootstrap` is on a freshly bumped key, so its run here is necessarily cold.

## Not Verified

Homebrew's glibc floor comes from observed behavior here: 22.04 falls below it and 24.04 clears it, and the 2.39 brew installs for itself matches 24.04's native version exactly. I never read the version check that enforces it. Nothing in the fix depends on the precise number.

I found no runner deprecation warning for `ubuntu-22.04` in the logs, so I make no claim about its retirement timeline. The argument above stands without it.
