### PR TITLE
scripts: cut comments back to what the code cannot say

### DIFF
--- a/scripts/install-cask-variants
+++ b/scripts/install-cask-variants
@@ -1,15 +1,9 @@
 #!/usr/bin/env sh
 # Usage: install-cask-variants [dotfiles-root]
 #
-# Homebrew refuses to install a cask that conflicts with an installed one, and
-# every @variant of an app declares conflicts_with against its siblings. So
-# changing which variant the Brewfile declares is a change `brew bundle` cannot
-# carry out on its own, in either direction: it fails until the old variant is
-# gone. Uninstall the variant the Brewfile stopped declaring so bundle can
-# install the one it now does.
-#
-# This is a rule, not a migration, so switching a cask needs no follow-up commit
-# to clean up after it.
+# Every @variant of an app declares conflicts_with against its siblings, so
+# `brew bundle` cannot switch between them on its own: it fails until the old
+# variant is gone. Uninstall the variant the Brewfile stopped declaring.
 set -e
 
 DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
@@ -23,12 +17,9 @@ command -v brew >/dev/null 2>&1 || exit 0
 declared=$(brew bundle list --cask --file "$DOTFILES_ROOT/Brewfile" 2>/dev/null) || declared_failed=1
 installed=$(brew list --cask 2>/dev/null) || installed_failed=1
 
-# Swallowing a failure outright would read as "nothing is superseded" and hand
-# brew bundle a conflict error with none of this context attached. Treating a
-# nonzero status as fatal is just as wrong: brew exits nonzero while still
-# printing a complete list when something incidental fails, such as a cache
-# refresh it could not write. The list is the signal, so the status decides only
-# when there is no list.
+# brew exits nonzero while still printing a complete list when something
+# incidental fails, such as a cache refresh. The list is the signal, so status
+# decides only when there is no list.
 if { [ -n "${declared_failed-}" ] && [ -z "$declared" ]; } ||
   { [ -n "${installed_failed-}" ] && [ -z "$installed" ]; }; then
   echo "install-cask-variants: cannot enumerate casks, so a superseded variant would go unnoticed." >&2
@@ -51,13 +42,11 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-# Confirm every candidate before removing any of them. Interleaving the two
-# would let a metadata failure on the third candidate abort the run with the
-# first two already uninstalled and their replacements not yet installed.
+# Confirm every candidate before removing any, so a metadata failure part way
+# through cannot leave earlier casks uninstalled with nothing reinstalled.
 #
-# The @suffix convention is a strong hint, not proof. Only remove a cask that
-# Homebrew itself reports as conflicting, so an unrelated same-prefix token can
-# never take an app down with it.
+# The @suffix convention is a hint, not proof, so only remove what Homebrew
+# itself reports as conflicting.
 confirmed=$(
   printf '%s\n' "$superseded" | while IFS="$(printf '\t')" read -r old new; do
     [ -n "$old" ] || continue
@@ -78,10 +67,8 @@ confirmed=$(
   done
 ) || exit 1
 
-# Past this point the machine is already being changed, so a failure part way
-# through is worse than one before it started: brew bundle is what installs the
-# replacements, and aborting would strand whatever was already removed. Carry on
-# and let bundle report anything still conflicting.
+# Aborting here would strand whatever was already removed, since brew bundle is
+# what installs the replacements. Carry on and let bundle report any conflict.
 printf '%s\n' "$confirmed" | while IFS="$(printf '\t')" read -r old new; do
   [ -n "$old" ] || continue
   echo "install-cask-variants: uninstalling $old, superseded by $new"

--- a/scripts/lint-expired
+++ b/scripts/lint-expired
@@ -28,12 +28,9 @@ tab=$(printf '\t')
 
 matches=$(git grep -n -- "$marker" || true)
 
-# Emit one tagged record per finding rather than accumulating into variables,
-# which a pipeline's subshell would discard. A here-document would keep the
-# variables, but bash stages one through a temp file whose location it picks
-# itself, and where that path is denied the read fails while the script carries
-# on to exit 0. A clean report for a repo full of expired markers is the one
-# outcome this check must never produce, so it does not depend on that write.
+# Records go out through a pipeline rather than a here-document, which bash
+# stages through a temp file it picks itself. A denied write there would leave
+# this check exiting 0 with a clean report.
 classify_matches() {
   while IFS=: read -r file line rest; do
     [ -n "$file" ] || continue

--- a/scripts/spec/dotfiles_sync_spec.sh
+++ b/scripts/spec/dotfiles_sync_spec.sh
@@ -13,10 +13,8 @@ Describe "dotfiles-sync exit status"
     mkdir -p "$stubdir"
 
     # gum stub: `gum spin … -- cmd` runs cmd; `gum log … msg` echoes msg.
-    # Written with printf rather than a here-document. bash stages a
-    # here-document through a temp file whose location it picks itself, so
-    # under a sandbox that denies that path it fails with "cannot create temp
-    # file for here document" and the stub never gets written.
+    # printf, not a here-document: bash stages those through a temp file it
+    # picks itself, which a sandbox may deny.
     # shellcheck disable=SC2016 # the stub's own $1 and $@, not this shell's
     printf '%s\n' \
       '#!/usr/bin/env bash' \


### PR DESCRIPTION
The comments in these files had grown into a decision log. They recorded what was rejected, how a bug was found, and why an alternative was wrong, which is material for the commit message and the PR, not for the line above the code.

Cuts comment volume in the three files by about half. What stays is the part a reader cannot get from the code: `brew` printing a complete list while exiting nonzero, bash staging a here-document through a temp file of its own choosing, and the ordering constraint that makes the cask confirmation pass run before any removal.

No behavior change. The `scripts` shellspec suite is 42/42 and shellcheck passes.

The same overwriting is in `.github/workflows/test.yml`, where a nine-line comment sits above one env var. That is being trimmed in #583, which already edits that file.
