### PR TITLE
github: add copilot-cli

### DIFF
--- a/github/Brewfile
+++ b/github/Brewfile
@@ -1,1 +1,3 @@
 brew 'gh'
+
+cask 'copilot-cli'


### PR DESCRIPTION
Adds the GitHub Copilot CLI so it comes along with `gh` on a fresh machine. It lands in `github/Brewfile` rather than alongside the other agent CLIs in `claude/Brewfile`, since it is GitHub tooling with `github-mcp-server` built in and has its own `copilot login`.

No topic config comes with it, deliberately. The cask generates its own zsh completions into `$HOMEBREW_PREFIX/share/zsh/site-functions`, so there is nothing for a `completion.zsh` to register. Everything else the CLI exposes is a per-invocation flag: model, reasoning effort, tool and path permissions. None has an obvious global default worth pinning. The one real settings file, `~/.copilot/settings.json`, is already written by the vibe-island installer, which rewrites all thirteen hook entries whenever it updates. Symlinking a dotfiles copy over it would break that and turn every vibe-island upgrade into a manual sync.

The cask declares `auto_updates`, so `brew bundle` installs it once and the binary self-updates from there. Nothing for Renovate to track.
