### PR TITLE
neovim: install tree-sitter-cli and cover parsers in CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,14 +10,6 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["neovim/config/init\\.lua$"],
-      "matchStrings": [
-        "\"(?<depName>[^\"]+/[^\"]+)\"[,\\s]*tag\\s*=\\s*\"(?<currentValue>v[^\"]+)\""
-      ],
-      "datasourceTemplate": "github-tags"
-    },
-    {
-      "customType": "regex",
       "fileMatch": ["^github/extensions\\.conf$"],
       "matchStrings": [
         "(?m)^(?<depName>[^\\s#/]+/[^\\s#]+)\\s+(?<currentValue>\\S+)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,14 @@ Topic directories can contain `mise.toml` files for language/tool versions. The 
 
 Always pin mise tool versions to exact values (e.g., `"0.9.6"`, not `"latest"`). Renovate tracks `mise.toml` files and auto-merges non-major updates after a 2-week release age delay. Using `"latest"` prevents Renovate from detecting new versions. For tools not available in the mise registry, use the `github:` backend (e.g., `"github:owner/repo" = "1.2.3"`) to install pre-built release binaries.
 
+#### Neovim Plugins
+
+Plugins are declared in `neovim/config/init.lua` with `vim.pack.add` and no `version`, so each tracks its default branch. The pin lives in `neovim/config/nvim-pack-lock.json`. That lockfile is authoritative when present, and `vim.pack` takes every revision from it while ignoring `version`. This is what lets a fresh machine reproduce an existing one.
+
+Updates are manual. Run `:lua vim.pack.update()`, review the confirmation buffer, `:write` to apply, then commit the lockfile diff. Renovate is not a fallback here, because nvim-treesitter publishes no tags on `main` (its tags sit on the diverged `master` branch) and lualine and vim-tmux-navigator publish no version tags at all.
+
+Treesitter parsers are built against a specific nvim-treesitter revision. They break when the plugin moves ahead of them. A `PackChanged` autocommand in `neovim/config/lua/config/treesitter.lua` re-runs `treesitter.update()` on every plugin change, and `neovim/spec/` asserts that each declared language ends up with a parser that attaches a highlighter.
+
 ### Shell Configuration
 
 - **Aliases**: Add to `<topic>/aliases.zsh`

--- a/neovim/Brewfile
+++ b/neovim/Brewfile
@@ -1,1 +1,2 @@
-brew "neovim"
+brew 'neovim'
+brew 'tree-sitter-cli'

--- a/neovim/config/lua/config/options.lua
+++ b/neovim/config/lua/config/options.lua
@@ -6,3 +6,6 @@ vim.o.scrolloff = 8
 vim.o.termguicolors = true
 vim.o.showmode = false
 vim.o.laststatus = 3
+
+-- Treesitter supplies folds; open files with all of them expanded.
+vim.o.foldlevelstart = 99

--- a/neovim/config/lua/config/treesitter.lua
+++ b/neovim/config/lua/config/treesitter.lua
@@ -1,25 +1,40 @@
-require("nvim-treesitter").install({
-  "bash", "dockerfile", "go", "gomod",
+local treesitter = require("nvim-treesitter")
+
+local languages = {
+  "bash", "diff", "dockerfile",
+  "git_rebase", "gitcommit", "go", "gomod",
   "hcl", "javascript", "json", "lua",
-  "python", "rust", "terraform", "toml",
+  "python", "ruby", "rust", "terraform", "toml",
   "typescript", "tsx", "yaml",
+}
+
+treesitter.install(languages)
+
+-- Parsers are pinned to the plugin revision and break when it moves ahead of them.
+vim.api.nvim_create_autocmd("PackChanged", {
+  callback = function(event)
+    if event.data.spec.name == "nvim-treesitter" and event.data.kind == "update" then
+      treesitter.update()
+    end
+  end,
 })
 
 vim.api.nvim_create_autocmd("FileType", {
-  pattern = {
-    "bash", "sh",
-    "dockerfile",
-    "go", "gomod",
-    "hcl",
-    "javascript", "javascriptreact",
-    "json",
-    "lua",
-    "python",
-    "rust",
-    "terraform",
-    "toml",
-    "typescript", "typescriptreact",
-    "yaml",
-  },
-  callback = function() vim.treesitter.start() end,
+  callback = function(event)
+    local lang = vim.treesitter.language.get_lang(event.match)
+    if not (lang and vim.treesitter.language.add(lang)) then
+      return
+    end
+
+    vim.treesitter.start(event.buf, lang)
+
+    -- foldexpr is window-local, so it would land on whatever the current window
+    -- holds when the filetype is set on a buffer that isn't displayed.
+    if vim.api.nvim_get_current_buf() == event.buf then
+      vim.wo[0][0].foldmethod = "expr"
+      vim.wo[0][0].foldexpr = "v:lua.vim.treesitter.foldexpr()"
+    end
+  end,
 })
+
+return { languages = languages }

--- a/neovim/config/nvim-pack-lock.json
+++ b/neovim/config/nvim-pack-lock.json
@@ -1,0 +1,32 @@
+{
+  "plugins": {
+    "gitsigns.nvim": {
+      "rev": "6d808f99bd63303646794406e270bd553ad7792e",
+      "src": "https://github.com/lewis6991/gitsigns.nvim"
+    },
+    "lualine.nvim": {
+      "rev": "131a558e13f9f28b15cd235557150ccb23f89286",
+      "src": "https://github.com/nvim-lualine/lualine.nvim"
+    },
+    "nvim": {
+      "rev": "426dbebe06b5c69fd846ceb17b42e12f890aedf1",
+      "src": "https://github.com/catppuccin/nvim"
+    },
+    "nvim-treesitter": {
+      "rev": "4916d6592ede8c07973490d9322f187e07dfefac",
+      "src": "https://github.com/nvim-treesitter/nvim-treesitter"
+    },
+    "plenary.nvim": {
+      "rev": "74b06c6c75e4eeb3108ec01852001636d85a932b",
+      "src": "https://github.com/nvim-lua/plenary.nvim"
+    },
+    "telescope.nvim": {
+      "rev": "506338434fec5ad19cb1f8d45bf92d66c4917393",
+      "src": "https://github.com/nvim-telescope/telescope.nvim"
+    },
+    "vim-tmux-navigator": {
+      "rev": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432",
+      "src": "https://github.com/christoomey/vim-tmux-navigator"
+    }
+  }
+}

--- a/neovim/spec/neovim_spec.sh
+++ b/neovim/spec/neovim_spec.sh
@@ -14,4 +14,13 @@ Describe "neovim"
     When call start_nvim
     The status should be success
   End
+
+  It "installs a working parser for every declared treesitter language"
+    check_treesitter() {
+      nvim --headless -c 'luafile spec/support/treesitter_check.lua' 2>&1
+    }
+    When call check_treesitter
+    The status should be success
+    The output should include "tree-sitter CLI"
+  End
 End

--- a/neovim/spec/support/treesitter_check.lua
+++ b/neovim/spec/support/treesitter_check.lua
@@ -1,0 +1,48 @@
+-- Installs every parser declared in config.treesitter and asserts that opening a
+-- buffer of the matching filetype attaches a highlighter. Run headless; writes
+-- one line per language and exits non-zero on the first failure.
+
+local failures = {}
+
+local function fail(fmt, ...)
+  local message = string.format(fmt, ...)
+  table.insert(failures, message)
+  io.stderr:write("FAIL: " .. message .. "\n")
+end
+
+local function ok(fmt, ...)
+  io.stdout:write("OK: " .. string.format(fmt, ...) .. "\n")
+end
+
+if vim.fn.executable("tree-sitter") == 0 then
+  fail("tree-sitter CLI not on $PATH; nvim-treesitter cannot build parsers")
+else
+  ok("tree-sitter CLI %s", vim.fn.system({ "tree-sitter", "--version" }):gsub("%s+$", ""))
+end
+
+local languages = require("config.treesitter").languages
+
+require("nvim-treesitter").install(languages):wait(600000)
+
+for _, lang in ipairs(languages) do
+  local filetype = vim.treesitter.language.get_filetypes(lang)[1]
+  if not filetype then
+    fail("%s: no filetype registered", lang)
+  else
+    local buf = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_set_option_value("filetype", filetype, { buf = buf })
+
+    if vim.treesitter.highlighter.active[buf] then
+      ok("%s: highlighting active for filetype %s", lang, filetype)
+    else
+      fail("%s: no highlighter attached to a %s buffer", lang, filetype)
+    end
+  end
+end
+
+if #failures > 0 then
+  io.stderr:write(string.format("\n%d treesitter check(s) failed\n", #failures))
+  vim.cmd("cquit 1")
+end
+
+vim.cmd("quit")


### PR DESCRIPTION
Treesitter highlighting was silently off everywhere. `~/.local/share/nvim/site/parser/` was empty on my machine, because nvim-treesitter `main` shells out to `tree-sitter build` for every parser and the `tree-sitter` formula is lib-only (it says so in its own caveat). Nothing ever compiled. Adds `tree-sitter-cli` to `neovim/Brewfile`.

## Test Coverage

The existing spec ran `nvim --headless +qa` and grepped for `E[0-9]+:`, which could never catch this. `install()` is async, so nvim quit before any parser work started, and nvim-treesitter routes build failures to `:TSLog` rather than stderr. Zero parsers looked identical to a healthy setup.

The new check asserts the end state instead: for every declared language, open a buffer of that filetype and confirm a highlighter attached. I exercised it both ways locally, against a healthy setup and against a `$PATH` with `tree-sitter` removed, where it fails and names each language that lost its parser.

It also covers a renamed parser, a parser that stops building, and an ABI break after a plugin update. Costs a minute or two in the bootstrap job, which compiles every declared parser with no cache.

## Folds Yes, Indent No

I took treesitter folding and skipped treesitter indentation, even though the README labels the pair together.

`foldexpr` is Neovim core (`runtime/lua/vim/treesitter.lua`), and nvim-treesitter only supplies the `folds.scm` queries. Five open core issues match it, all narrow. Indentation is 346 lines of plugin Lua with 93 open issues against it, an RFC for an alternative algorithm open since 2022, and an "Indent logic migration" issue from May 2025. Python and Ruby both have long-lived correctness bugs, and those are languages I use. The failure modes differ too: a wrong fold is cosmetic and `zR` undoes it, while a wrong `indentexpr` reflows text as you type.

## Plugin Pinning

Commits the `vim.pack` lockfile rather than pinning versions in `init.lua`. The lockfile is authoritative when present, so every revision comes from it and `version` stays unset. I wiped the plugin directory and reinstalled from scratch to confirm the recorded revisions reproduce exactly.

Renovate can't do this job. nvim-treesitter publishes no tags on `main`, and its newest tag `v0.10.0` sits on `master`, which has diverged 468 commits. lualine's only tags are `compat-nvim-0.6`, and vim-tmux-navigator has a single `v1.0`. That's coverage on three of seven plugins, missing the one where pinning actually matters because of the parser ABI coupling.

So this also deletes the Renovate custom manager for `neovim/config/init.lua`. It matched `tag =` where `vim.pack` uses `version`, and had matched nothing since the switch to `vim.pack`.

Updates stay manual via `vim.pack.update()`, which is no worse than before, since `vim.pack` never auto-updated. Documented the flow in CLAUDE.md.

## Notes

Parsers are built against a specific plugin revision, so a `PackChanged` autocommand re-runs `treesitter.update()` when the plugin moves.

The `FileType` autocmd now resolves the parser from the filetype instead of matching a hand-maintained pattern list that duplicated the install list. That picks up Neovim's bundled parsers for free, so markdown and vimdoc highlight without being installed. The fold options sit behind a current-buffer guard because `foldexpr` is window-local and would otherwise land on whatever the current window holds when a filetype is set on a buffer that isn't displayed. Telescope previewers and my own spec both create buffers that way.

I couldn't run the Greptile pre-push pass. It returned `free_reviews_limit_reached`.
