### PR TITLE
claude: declare moshi-hook

### DIFF
--- a/claude/Brewfile
+++ b/claude/Brewfile
@@ -1,3 +1,4 @@
+tap 'rjyo/moshi'
 tap 'steipete/tap'
 
 cask 'claude'
@@ -6,4 +7,5 @@ cask 'claude-devtools'
 cask 'commander'
 brew 'agent-browser'
 brew 'ast-grep'
+brew 'rjyo/moshi/moshi-hook', start_service: true
 brew 'steipete/tap/peekaboo'


### PR DESCRIPTION
Adds `moshi-hook` from the `rjyo/moshi` tap, which bridges AI coding agents to the Moshi mobile app. It has been running as a launchd service on this machine while being declared in no Brewfile. Shell history shows `brew tap rjyo/moshi && brew install moshi-hook && brew services start moshi-hook` run seven times in the last six months. Each run reinstalled by hand a tool that nothing declared. A fresh machine got nothing.

It goes in `claude/Brewfile` because it is Claude Code tooling.

`start_service: true` matches how it actually runs. The root `Brewfile` strips that option under CI, where runners have no user launchd session. Evaluating the aggregated root Brewfile under Homebrew's vendored Ruby confirms both paths: without `CI` the declaration resolves to `["rjyo/moshi/moshi-hook", {start_service: true}]`, and with `CI=1` to `["rjyo/moshi/moshi-hook", {}]`. That override predates this change and had no user until now, so this is its first exercise. `assert_unique_package` raised nothing, so the formula is declared exactly once across every topic Brewfile.

`brew bundle check` did not run locally because the sandbox blocks Homebrew's cache writes.
