### PR TITLE
mise: pin uv and node to exact versions

### DIFF
--- a/nodejs/mise.toml
+++ b/nodejs/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-node = "lts"
+node = "24.18.0"

--- a/python/mise.toml
+++ b/python/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 python = "3.14.6"
-uv = "latest"
+uv = "0.12.1"


### PR DESCRIPTION
Renovate tracks `mise.toml` files, but it cannot detect an update behind a floating spec. `CLAUDE.md` says so and requires exact pins. `uv = "latest"` and `node = "lts"` were the only two violations left in the repo, so Renovate has never proposed an update for either while it manages the exact pins in `go`, `rust`, `terraform`, and `terminal`. Pinning puts both back on the same 2-week-delay auto-merge flow as everything else.

`uv` goes to 0.12.1, the current latest. It resolved to 0.11.31 on this machine, so this advances it.

`node` pins to 24.18.0, the version `"lts"` resolves to today. Latest is 26.5.1, but pinning there would move the machine off LTS and defeat the point of the original spec. Renovate can now raise the major as a PR to review instead of it landing on its own.
