### PR TITLE
claude: drop redundant --permission-mode=auto from cwa

### DIFF
--- a/claude/aliases.zsh
+++ b/claude/aliases.zsh
@@ -8,7 +8,7 @@ _claude_worktree_prompt='This is a dedicated git worktree that Worktrunk (the wt
 # Aliases (not functions) so zsh defers completion to `wt switch` for branch names.
 alias cw="wt switch --execute=\"claude --name={{ branch }} --append-system-prompt='$_claude_worktree_prompt'\""
 alias ccw='cw --create'
-alias cwa="wt switch --execute=\"claude --name={{ branch }} --permission-mode=auto --append-system-prompt='$_claude_worktree_prompt'\""
+alias cwa='cw'
 
 cwp() {
   wt switch --create --execute="claude --name={{ branch }} --permission-mode=plan --append-system-prompt='$_claude_worktree_prompt'" "$@" -- "$(pbpaste)"


### PR DESCRIPTION
> [!WARNING]
> **Do not merge before the companion change in `bendrucker/claude` sets `permissions.defaultMode` to `"auto"`.**
> Merging this first silently drops auto mode from `cwa`, and from every invocation that relies on it.

Once `defaultMode` is `auto`, the explicit `--permission-mode=auto` on `cwa` is a no-op, leaving `cwa` identical to `cw`. This points it at `cw` rather than repeating the whole `wt switch` invocation, so the two can't drift.

#### Keeping the name

`cwa` has 219 recorded uses in the last six months, which puts it in my top five commands. Deleting it converts a live reflex into `command not found` and buys nothing back, because an alias costs no startup time.

The alternative is retiring the name now that it carries no meaning. That is a one-line change if you prefer it: drop `alias cwa='cw'` and let muscle memory move to `cw`.

#### Branch-name completion survives

The comment above these lines explains that they are aliases rather than functions so zsh defers completion to `wt switch`. Pointing one alias at another preserves that.

When zsh lexes the line for completion it sets `noaliases` from the `COMPLETE_ALIASES` option, and `zsh/completion.zsh` sets `no_complete_aliases`. Aliases are therefore substituted before completion dispatches, and `cwa` resolves through `cw` to `wt switch`, which supplies branch names. `ccw` already depends on this same alias-to-alias chain and completes correctly today.

#### Blast radius beyond this alias

Setting `defaultMode` to auto also gives `cw` and `ccw` auto mode. `ccw` is my single most-used command at 823 uses in six months. `cwp` passes `--permission-mode=plan` explicitly and is unaffected. I have already weighed this and accepted it. Noted here so the change reads as self-contained later.

#### Follow-up

The permission-mode table in `claude/README.md` goes stale when the companion lands: `cw`, `ccw`, and `cwa` all become auto, and `cwa` stops being distinct. I left the file alone to avoid colliding with other branches in flight, so it needs a separate pass.
