### PR TITLE
ssh: complete tssh hosts

### DIFF
--- a/ssh/completion.zsh
+++ b/ssh/completion.zsh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+
+# tssh is a drop-in ssh client, so ssh's completion covers it, including hosts
+# from ~/.ssh/config. trzsz-ssh ships no completion of its own.
+if (( $+commands[tssh] )); then
+  compdef _ssh tssh
+fi


### PR DESCRIPTION
## Why

`tssh` has 32 uses in the last six months and no completion from any source. I checked the full `$fpath` and there is no `_tssh`, and no topic registers one. `trzsz-ssh` ships none.

`tssh` is a drop-in ssh client, so `_ssh` completes it correctly and brings host completion from `~/.ssh/config` along with it. `_ssh` is present at `/usr/share/zsh/5.9/functions/_ssh`.

## Notes

Filename is `completion.zsh`, singular. `CLAUDE.md` warns that the zshrc filter matches the singular form and that a `completions.zsh` would be sourced eagerly during startup instead of deferred. `lint-completion-names` enforces this in CI.

Guarded on `$+commands[tssh]`, matching `git/completion.zsh` and `herdr/completion.zsh`. No subshell, so no startup cost.

## Out of scope

The same audit found `tssh ben-druckers-macbook-pro` typed verbatim 32 times, which wants a short `Host` alias. That is a personal machine hostname, so it belongs in the untracked `~/.ssh/config.local` rather than this public repo. Handled separately.