### PR TITLE
terminal: add zc to jump and launch claude

### DIFF
--- a/terminal/completion.zsh
+++ b/terminal/completion.zsh
@@ -1,3 +1,5 @@
 #!/usr/bin/env zsh
 
 compdef __zoxide_z_complete z
+
+compdef __zoxide_z_complete zc

--- a/terminal/zoxide.zsh
+++ b/terminal/zoxide.zsh
@@ -2,4 +2,13 @@
 
 if (( $+commands[zoxide] )); then
   eval "$(zoxide init zsh)"
+
+  # Jump, then start Claude there. `z` is a shell function, so calling it here
+  # moves the calling shell and Claude inherits the new directory. Passes no
+  # --permission-mode: the mode comes from Claude's own default.
+  if (( $+commands[claude] )); then
+    zc() {
+      z "$@" && claude
+    }
+  fi
 fi


### PR DESCRIPTION
**Speculative. Close it if it doesn't land.** The behavior it targets is well evidenced; whether a new name displaces an existing two-step habit is not.

## The evidence

Consecutive-command analysis over 6,490 history entries from the last six months, counting pairs run within three minutes:

| Pair | Occurrences |
| --- | --- |
| `z` then `claude` | 43 |
| `cd` then `claude` | 21 |
| `z` then `ccw` | 38 |
| `z` then `cwa` | 27 |

So navigate-then-launch happens about 64 times for the plain `claude` case. `z` is the fastest-growing command in the history, going from 0 to 216 uses per month over five months and now well ahead of `cd`.

## The argument against

This repo has measured evidence that new shortcuts don't get adopted. The six aliases added in ff1fd731 on 2026-07-13 have zero uses since. `ca='claude agents'` has zero uses against 71 uses of the long form. `b='bat'` has zero uses against 96 uses of `bat`.

The distinction I'd draw is that every one of those abbreviates a single command, saving keystrokes. `zc` collapses two commands and the round trip between them. That may be a different enough kind of saving to stick. It may not.

## Notes

Lives in `terminal/zoxide.zsh` because `z` is the dependency and that file already guards on zoxide. Nested guard on `claude`.

Passes no `--permission-mode`, deliberately. With `permissions.defaultMode` moving to `auto`, baking a mode flag in would recreate exactly the redundancy that #591 removes from `cwa`.

`compdef __zoxide_z_complete zc` gives it the same directory completion as `z`. Function definition only, no subshell, so no startup cost.

## Why a function and not an upstream feature

zoxide has no way to run a command in the matched directory. Its full command surface is `add`, `edit`, `import`, `init`, `query`, `remove`. `claude` has no `--cwd` flag either; `--add-dir` grants tool access to extra directories rather than setting the working directory.

The one alternative is building on `zoxide query`, which prints the best match:

```zsh
zc() { (cd "$(zoxide query -- "$@")" && claude) }
```

Rejected for two reasons. `zoxide query` does not record the visit, while `z` routes through `__zoxide_cd` and calls `zoxide add`, so the query version would jump to a directory without ever teaching zoxide that you go there. And the subshell returns you to where you started, whereas the observed pattern (`z` then `claude`) leaves you in the project once Claude exits.