### PR TITLE
gitlab: add merge request aliases

### DIFF
--- a/gitlab/aliases.zsh
+++ b/gitlab/aliases.zsh
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+
+# Ordered by measured usage. `mr` rather than `gl` to avoid reading as a
+# variant of `gl` (git log); these operate on merge requests, not glab at large.
+alias mrc='glab mr checkout'
+alias mrl='glab mr list'
+alias mrv='glab mr view'
+alias mrd='glab mr diff'


### PR DESCRIPTION
**Low confidence, and the counter-evidence is stronger than the case for it.** This copies a pattern that has already been measured as unused. Opened as a cheap experiment; closing it is a reasonable outcome.

## The case for

`glab mr` subcommands over the last six months: `checkout` 17, `list` 12, `view` 8, `diff` 5, `co` 4, `approve` 4. Over 50 uses with no aliases at all, while the parallel `gh pr` family has three. The asymmetry is real.

## The case against

The `gh pr` aliases this mirrors were added on 2026-07-13 in ff1fd731, titled "add data-backed aliases from history analysis". In the two and a half weeks since, `ghm`, `ghd`, and `ghv` have been used **zero times**, against 5 further uses of `gh pr merge`. The same commit added `gsw`, `grs`, and `gd`, also zero uses against 33 long-form uses.

So the honest framing is that this extends a 0% adoption rate to a second tool.

## The question worth more than the PR

If short aliases went unused on `gh pr`, aliases may be the wrong shape for these subcommands. `glab mr checkout` is the most-used at 17, and what it really wants is a picker: list open MRs, choose one, check it out. Same for `gh pr checkout`. That would be a function with `fzf` or `gum choose`, not an abbreviation. Raising it rather than building it.

## Naming

Used `mr` rather than `gl`. A `gl` prefix would read as a variant of `gl` (`git log`), and these operate on merge requests specifically. New `gitlab/` topic since none existed; `glab` itself is already in the root Brewfile and ships its own completion from Homebrew, so this is aliases only.