### PR TITLE
git: pull with rebase and autostash

### DIFF
--- a/git/config
+++ b/git/config
@@ -49,7 +49,11 @@
   sort = -version:refname
 
 [pull]
-  ff = only
+  rebase = true
+
+[rebase]
+  autoStash = true
+  updateRefs = true
 
 [apply]
   whitespace = nowarn

--- a/git/spec/git_spec.sh
+++ b/git/spec/git_spec.sh
@@ -8,6 +8,30 @@ Describe "git"
     The output should equal "checkout"
   End
 
+  It "pulls with rebase"
+    When call git config --global --get pull.rebase
+    The status should be success
+    The output should equal "true"
+  End
+
+  It "does not force fast-forward pulls, which would override pull.rebase"
+    When call git config --global --get pull.ff
+    The status should be failure
+    The output should equal ""
+  End
+
+  It "autostashes before rebasing"
+    When call git config --global --get rebase.autoStash
+    The status should be success
+    The output should equal "true"
+  End
+
+  It "moves intermediate branch refs when rebasing a stack"
+    When call git config --global --get rebase.updateRefs
+    The status should be success
+    The output should equal "true"
+  End
+
   It "resolves the ignore file referenced by core.excludesfile"
     excludes=$(git config --global --get core.excludesfile)
     expanded="${excludes/#\~/$HOME}"


### PR DESCRIPTION
Replaces `pull.ff = only` with `pull.rebase` and `rebase.autoStash`.

`g pull` is my most-typed unaliased git command over the last six months at 112 uses. With `ff = only` it works silently when the branch fast-forwards and hard-errors the moment it has diverged. That error is what sent me to `git reset --hard origin/main`, which shell history records as roughly 22 attempts carrying six distinct misspellings of `--hard`. Rebasing with autostash covers behind, diverged, and dirty working tree in one built-in. `push.autoSetupRemote` is already set and covers a missing upstream on push.

#### `pull.ff` precedence

`ff = only` had to go rather than sit alongside `rebase = true`. I checked instead of assuming, and `pull.ff` wins: the pull aborts before any rebase is attempted.

```
$ git -c pull.ff=only -c pull.rebase=true pull
fatal: Not possible to fast-forward, aborting.
```

`git help pull` reads the other way. It describes `--ff-only` as "the default when no method for reconciling divergent histories is provided (via the --rebase flags)", which suggests `--rebase` displaces it. Setting `pull.ff` explicitly does not behave that way.

#### Autostash

`pull.autostash` stays unset, so `git pull --rebase` falls through to `rebase.autoStash`, as documented under `pull.autoStash` in `git help config`. A tracked uncommitted edit that otherwise fails with `cannot pull with rebase: You have unstaged changes` now survives the pull and leaves no stash entry behind.

#### `rebase.updateRefs`

Separable from the rest of this change. It moves intermediate branch refs during a rebase, which is what the stacked-branch workflow in `CLAUDE.md` needs. Take it or leave it independently of the `pull` change.

#### Behavior change

`ff = only` is a deliberate safety setting. Dropping it means `git pull` now rewrites local commits by rebasing them instead of refusing. That tradeoff is the point of this PR and is worth choosing knowingly. `git rebase --abort` restores the branch to its pre-pull state.

#### Config over script

Replaces #592, a 124-line `bin/git-sync` with a 17-example shellspec suite, closed in favor of the built-ins. The review there found a data-loss bug in its hand-rolled stash handling. `git stash push` exits 0 without creating an entry when the only dirtiness lives inside a submodule working tree, and an unconditional `git stash pop` afterwards consumes an unrelated stash. This repo has two submodules (`bat/catppuccin`, `system/btop-catppuccin`), so it was reachable. Git's own autostash has no such failure mode.

#### Tests

`git/spec/git_spec.sh` asserts all four settings, including that `pull.ff` is unset. The four new examples fail against the pre-change config and pass after it.
