### PR TITLE
git: replace Graphite with GitHub native stacked PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,13 +146,19 @@ Based on recent history:
 
 ## Stacked PRs
 
-I use worktrunk for worktree creation. Graphite (`gt`) is the preferred stacking tool where the platform supports it (GitHub). On GitLab and anywhere else Graphite isn't available, `wt sync` handles stack rebases:
+Each branch in a stack lives in its own worktrunk worktree. `wt sync` owns the local side and rebases each branch onto its parent in dependency order.
 
 1. Create base branch: `wt switch --create feature/base`
 2. Work, commit, then stack next branch: `wt switch --create child-name --base=@`
-3. Sync entire stack: `wt sync` (add `--push` to update remotes)
+3. Sync entire stack: `wt sync --push`
 
-Ship branches oldest-first. After a stack branch merges, `wt sync` rebases remaining branches.
+Publishing to GitHub runs in three steps. Start with `wt sync --push`, because `gh stack link` pushes without force and would be rejected on a freshly rebased branch. Then open each layer's PR with `/ship` or `pull-request:create`. That gets it a real body and the review passes. Then `gh stack link <bottom> ... <top>` chains the bases and registers the stack on GitHub. `link` opens a PR for any branch still missing one, with an auto-generated title and body, so let it fill gaps rather than lead. It writes no local tracking state, which is why it fits the one-worktree-per-branch layout.
+
+`gh stack merge` lands the stack. With no argument it merges everything atomically. Pass a PR number to stop partway, and GitHub retargets and rebases the layers left open. `gh pr merge` does not work on a stacked PR. The `ghm` alias is off limits once a stack exists. Follow a merge with `wt sync --prune` to drop integrated worktrees.
+
+`link` and `merge` are the only two `gh stack` commands to use here. Everything else (`init`, `add`, `submit`, `push`, `checkout`, `sync`, `rebase`, `modify`, `unstack`, `view`, and the `up`/`down`/`top`/`bottom`/`switch`/`trunk` navigation) reads or writes local tracking state that assumes every layer is checked out in one working tree. `submit` is the trap, since it is the command the tool's own help steers you toward. `gh stack rebase` reports success for a branch checked out in another worktree without doing anything ([gh-stack#35](https://github.com/github/gh-stack/issues/35)).
+
+On GitLab, `glab stack` fills the same role. See the `gitlab:merge-request` skill.
 
 ## ZSH Startup Performance
 

--- a/git/Brewfile
+++ b/git/Brewfile
@@ -1,5 +1,3 @@
-tap 'withgraphite/tap'
-
 brew 'act'
 brew 'actionlint'
 brew 'git'
@@ -7,5 +5,4 @@ brew 'git-delta'
 brew 'glab'
 brew 'lazygit'
 brew 'prek'
-brew 'withgraphite/tap/graphite'
 brew 'worktrunk'

--- a/git/completion.zsh
+++ b/git/completion.zsh
@@ -1,5 +1,0 @@
-#!/usr/bin/env zsh
-
-if (( $+commands[gt] )); then
-  eval "$(gt completion)"
-fi

--- a/git/config
+++ b/git/config
@@ -61,6 +61,11 @@
 [mergetool]
   keepBackup = false
 
+# Stack rebases replay the same conflicts on every restack. Record the
+# resolutions so only genuinely new ones need attention.
+[rerere]
+  enabled = true
+
 [difftool]
   prompt = false
 

--- a/github/aliases.zsh
+++ b/github/aliases.zsh
@@ -1,5 +1,6 @@
 #!/usr/bin/env zsh
 
+# gh pr merge cannot merge a stacked PR. Use `gh stack merge` there.
 alias ghm='gh pr merge'
 alias ghd='gh pr diff'
 alias ghv='gh pr view'

--- a/github/extensions.conf
+++ b/github/extensions.conf
@@ -3,3 +3,4 @@
 dlvhdr/gh-dash v4.25.2
 einride/gh-dependabot v0.14.1
 chmouel/gh-news v0.18.0
+github/gh-stack v0.1.0


### PR DESCRIPTION
Retires Graphite now that [GitHub ships stacked pull requests natively](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/) (public preview, 2026-07-30). Graphite was last invoked on 2026-02-22 and has zero uses in the past 90 days, so this mostly ratifies what already happened.

Adds `github/gh-stack v0.1.0` to the pinned extension set and drops the `withgraphite` tap, formula, and `gt` completion.

## Only `link` and `merge`

The interesting decision is which half of `gh stack` to adopt. The extension's local-tracking commands (`init`, `add`, `submit`, `checkout`, `sync`, `rebase`, and the navigation verbs) assume every layer of a stack is checked out in one working tree. Each stack branch here lives in its own worktree, and `gh stack rebase` prints a success line and does nothing when the branch it is rebasing is checked out elsewhere ([github/gh-stack#35](https://github.com/github/gh-stack/issues/35), still open). v0.1.0 fixed the analogous trunk-in-another-worktree case but not this one.

`gh stack link` is the fit. Its help text names external branch managers as the intended audience, it writes no local state, and it chains the PR bases and registers the stack through the API. So `wt sync` keeps owning the rebases and `link` publishes the result. `gh stack merge` lands it, which is also mandatory rather than optional: `gh pr merge` does not work on a stacked PR, hence the warning comment now sitting on the `ghm` alias.

Also enables `rerere`. It is gh-stack's documented prerequisite, and repeated stack rebases replay the same conflicts regardless of which tool drives them.

## Local uninstall

Removing the Brewfile lines uninstalls nothing. Nothing in this repo runs `brew bundle cleanup`, `bin/dotfiles-upgrade` runs plain `brew cleanup` which never removes undeclared formulae, and `graphite` was marked installed-on-request so `brew autoremove` skips it too. Left alone, `gt` would have stayed on `$PATH` untracked and unupgraded while a fresh machine got nothing, which is the worst of both. Ran `brew uninstall graphite && brew untap withgraphite/tap` to close that gap.

## Dropped from this branch

I had also reworked `github/install.sh` so one failing extension stops aborting the whole run. `einride/gh-dependabot` fails its pinned install on this machine, and because the loop iterates an unordered zsh associative array, that failure can prevent `gh-stack` itself from ever installing. Reverted it. The justification I wrote (assetless releases fail the pinned install) does not reproduce: against an isolated `XDG_DATA_HOME` that same command exits 0 on a fresh directory and exits 0 again on repeat, silently upgrading past the pin. Whatever breaks that extension on this machine is something else, the guard would have been unreachable on a fresh machine anyway, and `scripts/install` still aborts on any non-zero topic installer, so the run-level blast radius was unchanged. It deserves a real diagnosis rather than a tolerance keyed on the wrong property.

Worth following up separately: that `gh-dependabot` failure, and the fact that Renovate's `minimumReleaseAge` covers only the `mise` and `pep621` managers, so a breaking `0.2.0` of gh-stack would auto-merge the day it lands.

Untested here: whether the preview is live on this repo yet. `gh stack link` exits 9 where stacks are not enabled.
