### PR TITLE
herdr: declare plugins in a Renovate-managed list

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,17 @@
         "(?m)^(?<depName>[^\\s#/]+/[^\\s#]+)\\s+(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "description": "herdr plugins, pinned to commits so herdr-lazy's own update path stays out of the way. git-refs needs a branch to take digests from, and all seven repos release from main.",
+      "customType": "regex",
+      "fileMatch": ["^herdr/plugins\\.list$"],
+      "matchStrings": [
+        "(?m)^(?<depName>[^\\s#/]+/[^\\s#@]+)@(?<currentDigest>[0-9a-f]{40})\\s*$"
+      ],
+      "datasourceTemplate": "git-refs",
+      "packageNameTemplate": "https://github.com/{{{depName}}}",
+      "currentValueTemplate": "main"
     }
   ],
   "packageRules": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,7 +25,7 @@
       "datasourceTemplate": "github-releases"
     },
     {
-      "description": "herdr plugins, pinned to commits so herdr-lazy's own update path stays out of the way. git-refs needs a branch to take digests from, and all seven repos release from main.",
+      "description": "herdr plugins, pinned to commits so herdr-lazy's own update path stays out of the way. git-refs needs a branch to take digests from, and all seven repos default to main.",
       "customType": "regex",
       "fileMatch": ["^herdr/plugins\\.list$"],
       "matchStrings": [

--- a/herdr/.gitignore
+++ b/herdr/.gitignore
@@ -1,0 +1,6 @@
+# herdr-lazy writes the lock beside plugins.list, which puts it in this repo.
+# Every entry in the list is pinned to a commit, so the list already is the lock.
+# Committing it would only add a file that goes stale on every Renovate bump,
+# since Renovate moves the list and nothing regenerates the lock. `sync`
+# enforces the list's pins either way.
+plugins.lock

--- a/herdr/herdr.zsh
+++ b/herdr/herdr.zsh
@@ -1,0 +1,19 @@
+#!/usr/bin/env zsh
+
+# Keep the plugin declaration in this repo rather than herdr's plugin config
+# dir, where it would sit next to a cache nobody wants to commit. herdr-lazy
+# writes plugins.lock beside the list, which herdr/.gitignore drops.
+export HERDR_LAZY_LIST="$ZSH/herdr/plugins.list"
+
+# herdr-lazy has no binary on PATH: its plugin directory name carries an
+# install-specific hash, so there is nothing stable to symlink.
+herdr-lazy() {
+  local root
+  root=$(herdr plugin list --json |
+    jq -r '.result.plugins[] | select(.plugin_id == "herdr-lazy") | .plugin_root') || return
+  if [[ -z "$root" ]]; then
+    echo "herdr-lazy is not installed" >&2
+    return 1
+  fi
+  "$root/target/release/herdr-lazy" "$@"
+}

--- a/herdr/install.sh
+++ b/herdr/install.sh
@@ -1,43 +1,58 @@
 #!/usr/bin/env zsh
 #
-# Install herdr plugins.
+# Converge herdr's plugins onto plugins.list.
 #
-# herdr has no declarative manifest for installed plugins, so this script
-# installs the relevant set idempotently — anything already present is skipped.
-# Keybindings for these live in config.toml. Each entry is "owner/repo <id>",
-# where <id> is the plugin id from that repo's herdr-plugin.toml.
-#
-#   worktrunk         git worktree management via worktrunk
-#   persiyanov.reviewr  code-review + diff sidebar for agents
-#   herdr-file-viewer   git-aware read-only file viewer
-#   herdr-navigator     fuzzy workspace / agent / session jumper
+# herdr has no declarative manifest of its own, so herdr-lazy supplies one and
+# installs the rest from it. That leaves herdr-lazy the one plugin this script
+# still has to install by hand. Keybindings for all of them live in config.toml.
 
 set -e
+
+cd "${0:A:h}"
 
 if ! command -v herdr >/dev/null 2>&1; then
   echo "herdr not found; skipping plugin install" >&2
   exit 0
 fi
 
-plugins=(
-  "devashish2203/herdr-worktrunk worktrunk"
-  "persiyanov/herdr-reviewr persiyanov.reviewr"
-  "smarzban/herdr-file-viewer herdr-file-viewer"
-  "thanhdat77/herdr-navigator herdr-navigator"
-)
+# Read the list from this repo rather than herdr's plugin config dir, so the
+# declaration is the one under version control. herdr-lazy writes plugins.lock
+# alongside it, which .gitignore drops.
+export HERDR_LAZY_LIST="$PWD/plugins.list"
 
-installed="$(herdr plugin list --json 2>/dev/null || true)"
+lazy_repo=natori-hrj/herdr-lazy
 
-for entry in "${plugins[@]}"; do
-  repo="${entry%% *}"
-  id="${entry##* }"
-  # Match the JSON-quoted id so one id can't substring-match another
-  # (e.g. herdr-file-viewer inside a herdr-file-viewer-extended).
-  if print -r -- "$installed" | grep -qF -- "\"${id}\""; then
-    echo "✓ ${id} already installed"
-    continue
-  fi
-  echo "› herdr plugin install ${repo}"
-  # Keep a flaky third-party install from aborting the rest under `set -e`.
-  herdr plugin install "${repo}" --yes || echo "✗ ${id} install failed (skipping)" >&2
-done
+# Take the bootstrap ref from the list itself. A second copy of the SHA here
+# would disagree with it the first time Renovate bumps one of them.
+lazy_ref=$(sed -n "s|^${lazy_repo}@||p" plugins.list | head -1)
+if [[ -z "$lazy_ref" ]]; then
+  echo "plugins.list: ${lazy_repo} is missing or unpinned; nothing to bootstrap from" >&2
+  exit 1
+fi
+
+lazy_root() {
+  herdr plugin list --json 2>/dev/null |
+    jq -r '.result.plugins[]? | select(.plugin_id == "herdr-lazy") | .plugin_root'
+}
+
+root=$(lazy_root)
+if [[ -z "$root" ]]; then
+  echo "› herdr plugin install ${lazy_repo}@${lazy_ref}"
+  # Keep a flaky third-party build from aborting the rest under `set -e`.
+  herdr plugin install "$lazy_repo" --ref "$lazy_ref" --yes || true
+  root=$(lazy_root)
+fi
+
+# herdr-lazy is not on PATH: its directory name carries an install-specific
+# hash, so the path has to come back from herdr.
+lazy="$root/target/release/herdr-lazy"
+if [[ -z "$root" || ! -x "$lazy" ]]; then
+  echo "✗ ${lazy_repo} is not installed; leaving herdr plugins as they are" >&2
+  exit 0
+fi
+
+"$lazy" sync || echo "✗ herdr-lazy sync did not finish; some plugins may be missing" >&2
+
+# With this on, a plugin added to the list later installs on the next herdr
+# start instead of waiting for someone to re-run this script.
+"$lazy" auto-sync on

--- a/herdr/install.sh
+++ b/herdr/install.sh
@@ -30,9 +30,12 @@ if [[ -z "$lazy_ref" ]]; then
   exit 1
 fi
 
+# Empty rather than failing when herdr has nothing to say, so a bad response
+# reads as "not installed" instead of aborting the whole dotfiles install.
 lazy_root() {
   herdr plugin list --json 2>/dev/null |
-    jq -r '.result.plugins[]? | select(.plugin_id == "herdr-lazy") | .plugin_root'
+    jq -r '.result.plugins[]? | select(.plugin_id == "herdr-lazy") | .plugin_root' 2>/dev/null ||
+    true
 }
 
 root=$(lazy_root)
@@ -55,4 +58,4 @@ fi
 
 # With this on, a plugin added to the list later installs on the next herdr
 # start instead of waiting for someone to re-run this script.
-"$lazy" auto-sync on
+"$lazy" auto-sync on || echo "✗ could not turn on auto-sync" >&2

--- a/herdr/plugins.list
+++ b/herdr/plugins.list
@@ -1,0 +1,9 @@
+# herdr plugins, installed by herdr-lazy. Commits are managed by Renovate
+# (.github/renovate.json customManagers).
+AltanS/collie@0cbf5834f4d9a97d1fb5032bba1b69ca23c77d60
+devashish2203/herdr-worktrunk@e9131c0b576fd68635194c758c9691dbfb778b61
+natori-hrj/herdr-lazy@3e39db61e7d9c4ed985850b6359362854afe8d44
+ogulcancelik/herdr-browser@be6888b71cf4eb5939ee79a746bd1a1c22ade046
+persiyanov/herdr-reviewr@0a6f46bbbec493b340120edd61bb2ec435f123ea
+smarzban/herdr-file-viewer@96fcc0a2bdd2727ec88c38f8c8806f97b7ca0ea0
+thanhdat77/herdr-navigator@68064d53d25c53b6947d50c5ba440e9dc3b47b21

--- a/herdr/spec/herdr_spec.sh
+++ b/herdr/spec/herdr_spec.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2329,SC2016
 
 Describe "herdr"
   config="${XDG_CONFIG_HOME:-$HOME/.config}/herdr/config.toml"
+  list="$SHELLSPEC_PROJECT_ROOT/plugins.list"
 
   It "symlinks the config into place"
     When call test -L "$config"
@@ -11,6 +12,30 @@ Describe "herdr"
 
   It "config is readable and non-empty"
     When call test -s "$config"
+    The status should be success
+  End
+
+  It "declares the plugin set in plugins.list"
+    When call test -s "$list"
+    The status should be success
+  End
+
+  It "points HERDR_LAZY_LIST at plugins.list"
+    # .zshrc sources every $ZSH/**/*.zsh bar path.zsh and completion.zsh, so
+    # sourcing herdr.zsh under a chosen $ZSH is what a login shell does to it.
+    # `zsh -f` keeps ~/.zshenv, and the installed root it exports, out of the
+    # way. -ef rather than a string compare, so this also proves the export
+    # names a file that exists.
+    lazy_list_target() {
+      local root resolved
+      root=$(cd "$SHELLSPEC_PROJECT_ROOT/.." && pwd)
+      resolved=$(zsh -fc 'ZSH=$1; source "$ZSH/herdr/herdr.zsh"; print -r -- $HERDR_LAZY_LIST' _ "$root") || return
+      if [[ ! "$resolved" -ef "$list" ]]; then
+        echo "HERDR_LAZY_LIST=$resolved, expected $list"
+        return 1
+      fi
+    }
+    When call lazy_list_target
     The status should be success
   End
 End


### PR DESCRIPTION
Replaces the imperative plugin install with a declarative list that herdr-lazy converges the machine to. `install.sh` hardcoded four plugins with no version anywhere. Two more (`AltanS/collie`, `ogulcancelik/herdr-browser`) had since been installed by hand and were not in it at all. The list covers all seven.

Every entry is pinned to a commit, which makes Renovate the only update path. herdr-lazy's own `update` skips pinned entries by design, and its pane never marks them, so nothing competes with the bot. I checked all seven repos. Each defaults to `main`, and each pinned commit is an ancestor of it, so one `currentValueTemplate` covers them all. Four are already behind.

`plugins.lock` is gitignored. herdr-lazy writes it beside the list, which puts it in this repo, but with everything pinned the list already records the commits and `sync` enforces them. A committed lock would only go stale on every Renovate bump: Renovate moves the list, and nothing regenerates the lock.

`install.sh` shrinks to a bootstrap rather than going away. It installs herdr-lazy, and herdr-lazy installs the rest, so deleting it would break the new-machine path. The bootstrap ref comes out of `plugins.list` rather than a second copy of the SHA, which would drift on the first bump. It also turns on `auto-sync`. A plugin added to the list later then installs on the next herdr start, and the marker for that lives under herdr's plugin config dir, which keeps it out of this repo.

#### Verification

`herdr-lazy list` against the worktree copy parses all seven entries. I tested the Renovate regex through RE2, the engine Renovate actually runs. It captures `depName` and `currentDigest` from all seven lines and skips the comment header.

One thing to know before validating this config by hand: `renovate-config-validator` rejects both the new manager and the existing `extensions.conf` one unless the optional `re2` native module is installed alongside it. Without `re2` it falls back to JS `RegExp`, which does not accept an inline `(?m)`. The rejection is an artifact of the missing module rather than the pattern, which is why the `extensions.conf` manager has been producing Renovate PRs all along.

The bootstrap got exercised for real on the runners, which start with no herdr at all. `install.sh` parsed the ref out of the list, installed herdr-lazy at it, and handed the rest to `sync`:

```
› herdr plugin install natori-hrj/herdr-lazy@3e39db61e7d9c4ed985850b6359362854afe8d44
+ installing AltanS/collie@0cbf5834f4d9a97d1fb5032bba1b69ca23c77d60 ...
= natori-hrj/herdr-lazy@3e39db61e7d9c4ed985850b6359362854afe8d44 (present as herdr-lazy)
summary: 1 present, 6 installed, 0 failed, 7 desired total
auto-sync on — herdr-lazy will install missing plugins when herdr starts.
```

Two caveats on the run history. The first `bootstrap (linux)` went red on the neovim treesitter spec, which fails the same way on `main` and passed on rerun. And Greptile's pre-push pass never ran, because the account is at its free review limit.

#### Automerge

`automerge: true` at the config root means these digest bumps land without review. That matches every other dependency here. But these are untagged commits from seven third-party repos rather than releases, so a `packageRules` entry can gate them if that is too loose.
