### PR TITLE
docs: note the ZDOTDIR trap when stubbing for zsh scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,18 @@ To add tests to a topic:
 
 Existing examples: `git/spec/`, `neovim/spec/`. Tests run against the installed config (symlinks from `~/.dotfiles`), so they verify the real post-bootstrap state.
 
+#### Stubbing a Command for a zsh Script
+
+A spec that runs a script from `bin/` and replaces one of its dependencies with a stub has to isolate zsh's startup files. Those scripts use a `#!/usr/bin/env zsh` shebang, and zsh sources `~/.zshenv` on every invocation, non-interactive ones included. `zsh/.zshenv` runs `brew shellenv`, which can put `$HOMEBREW_PREFIX/bin` ahead of whatever the spec prepended to `$PATH`, so the real command wins and the stub never runs. Point `ZDOTDIR` at an empty directory for the duration of the call. zsh then finds no `.zshenv` and leaves `$PATH` alone.
+
+```sh
+run_with_stub() {
+  (cd "$dir" && PATH="$stub_bin:$PATH" ZDOTDIR="$empty_dir" "$script" "$@")
+}
+```
+
+The shape of this failure is what makes it worth documenting. It passes on a developer machine, where `HOMEBREW_PREFIX` is already exported and `brew shellenv` emits no `PATH` line, and fails in CI, where it does. Prepending to `$PATH` is enough to stub a command for a bash script, so the habit carries over and breaks silently.
+
 ### Version Updates
 
 Recent patterns show dependency updates via PRs:


### PR DESCRIPTION
## Why

Found while writing a spec for a `bin/` script in #592. Six examples stubbed `gum` by prepending a directory to `$PATH`, the way you would for a bash script. They passed locally and failed on both CI platforms.

The cause is that `bin/` scripts use a `#!/usr/bin/env zsh` shebang, and zsh sources `~/.zshenv` on every invocation including non-interactive ones. `zsh/.zshenv` runs `eval "$(brew shellenv)"`, which puts `$HOMEBREW_PREFIX/bin` ahead of the stub directory. The real command then wins and the stub never runs.

Reproduced directly:

```
$ env -i HOME=$HOME ZDOTDIR=<dotfiles>/zsh PATH=<stub>:/usr/bin:/bin zsh -c 'command -v gum'
/opt/homebrew/bin/gum

$ env -i HOME=$HOME ZDOTDIR=<empty> PATH=<stub>:/usr/bin:/bin zsh -c 'command -v gum'
<stub>/gum
```

## Why it deserves a note rather than a comment in one spec

It passes on a developer machine and fails in CI. `HOMEBREW_PREFIX` is already exported in an interactive shell, so `brew shellenv` emits no `PATH` line and the stub keeps its lead. A fresh CI environment has no such luck.

Prepending to `$PATH` is the ordinary way to stub a command, and it works for a bash script, so the habit carries over and breaks without any obvious reason. This applies to every zsh-shebang script in `bin/`, including `dotfiles-upgrade`, `dotf`, `dotfiles-sync`, and `worktree-prune`.

The spec that found it went away with #592, so without this the finding is lost.

Docs only.