### PR TITLE
worktrunk: add wt pr to worktree a pull request from any repo

### DIFF
--- a/bin/wt-pr
+++ b/bin/wt-pr
@@ -1,0 +1,99 @@
+#!/usr/bin/env zsh
+# shellcheck shell=bash
+# wt pr: pick one of your open pull requests, or one waiting on your review,
+# from any repo and switch to a worktree for it.
+#
+# `wt switch --prs` already covers the in-repo case. This starts from the pull
+# request instead, so the repo does not have to be the one you are standing in,
+# or cloned at all. clone-repo resolves the checkout and clones it if missing.
+
+set -e
+set -o pipefail
+
+usage() {
+  cat <<'EOF'
+usage: wt pr [--mine|--review] [wt switch options]
+
+Pick from your open pull requests and those waiting on your review, across every
+repo, then switch to a worktree for the one you choose.
+
+  --mine    Only pull requests you authored
+  --review  Only pull requests waiting on your review
+
+Remaining options go to `wt switch`, so `wt pr -x claude` opens the worktree and
+launches Claude in it.
+EOF
+}
+
+want_mine=true
+want_review=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mine)
+      want_review=false
+      shift
+      ;;
+    --review)
+      want_mine=false
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) break ;;
+  esac
+done
+
+for tool in gh jq fzf clone-repo wt; do
+  if ! command -v "$tool" >/dev/null; then
+    gum log --level error "$tool is required"
+    exit 1
+  fi
+done
+
+search() {
+  gh search prs --state=open "$1=@me" --limit 50 \
+    --json number,title,repository,url \
+    --jq ".[] | {url, title, repo: .repository.nameWithOwner, number, bucket: \"$2\"}"
+}
+
+collect() {
+  if [[ "$want_mine" == true ]]; then
+    search --author mine
+  fi
+  if [[ "$want_review" == true ]]; then
+    search --review-requested review
+  fi
+}
+
+# Authored wins over review-requested when a pull request is both, because
+# unique_by keeps the first and collect emits authored first.
+rows=$(collect | jq -rs '
+  unique_by(.url)
+  | sort_by(.bucket, .repo, .number)
+  | .[]
+  | [.bucket, (.repo + "#" + (.number | tostring)), .title, .url]
+  | @tsv
+')
+
+if [[ -z "$rows" ]]; then
+  gum log --level warn "no open pull requests"
+  exit 1
+fi
+
+selection=$(
+  printf '%s\n' "$rows" |
+    fzf --delimiter='\t' --with-nth=1,2,3 \
+      --prompt='pr> ' \
+      --preview='gh pr view {4}' \
+      --preview-window='right,60%,border-left'
+) || exit 1
+
+repo=$(printf '%s' "$selection" | cut -f2)
+repo=${repo%%\#*}
+url=$(printf '%s' "$selection" | cut -f4)
+
+path=$(clone-repo "$repo")
+exec wt -C "$path" switch "$url" "$@"


### PR DESCRIPTION
## What

`wt pr` lists your open pull requests and those waiting on your review across every repo, and switches to a worktree for the one you pick. The local clone is resolved through `clone-repo`, which returns the path when the repo is already at `$PROJECTS/owner/repo` and clones it when it isn't.

```
wt pr                # everything, authored and review-requested
wt pr --mine
wt pr --review
wt pr -x claude      # pick, worktree it, launch Claude there
```

Named `bin/wt-pr`, so worktrunk dispatches it as `wt pr` the same way it already does for `wt-all` and `wt-prune`. Trailing options pass through to `wt switch`, which is where `-x` comes from.

## Why this rather than what already exists

`wt switch --prs` already opens a picker over open PRs, and `wt switch <url>` and `wt switch pr:{N}` already take a pull request directly. Those all require standing in the repo. `wt` refuses to run outside a git repository, so nothing today gets you from "a PR in some repo" to a worktree without first navigating there yourself.

That's the only gap this fills. It composes the existing pieces rather than reimplementing them: `gh search prs` for the list, `clone-repo` for the checkout, `wt -C <path> switch <url>` for the worktree.

## Notes

Authored and review-requested are two `gh search prs` calls merged with `unique_by(.url)`. Authored is emitted first, so a pull request that is both shows as yours.

`clone-repo` rather than zoxide for the path. It derives `$PROJECTS/owner/repo` deterministically and can clone a repo you've never opened, where zoxide only knows directories you've already visited. zoxide would only help for clones kept outside that convention.

## Coverage

Exercised end to end against real data for the authored list, the `--help` output, the `wt pr` dispatch, and the empty-state path. The picker itself and the final `wt switch` handoff need a TTY, so they were checked by inspection rather than run.

The review-requested branch runs the same code path as authored and was exercised only against an empty result, since there are no open review requests on this account right now. Worth a real run before trusting it.

## Follow-up

A `wt mr` companion for GitLab is the obvious pair, and `wt switch` already understands `mr:{N}` and merge request URLs. Not included here: the `glab` OAuth token on this machine is expired, so the cross-project `/merge_requests` query could not be verified. Rather than ship an unverified script, that lands separately once `glab auth login` has been re-run.