### PR TITLE
worktrunk: add wt mr to worktree a merge request from any project

### DIFF
--- a/bin/clone-repo
+++ b/bin/clone-repo
@@ -69,7 +69,9 @@ await $`mkdir -p ${projects}/${org}`;
 
 switch (host) {
   case "gitlab.com":
-    await $`glab repo clone ${input} ${target}`;
+    // Not the URL: glab clones an https URL over https, ignoring the git_protocol
+    // it was configured with. A bare path lets it pick the protocol.
+    await $`glab repo clone ${`${org}/${repo}`} ${target}`;
     break;
   default:
     await $`gh repo clone ${host ? input : `${org}/${repo}`} ${target}`;

--- a/bin/wt-mr
+++ b/bin/wt-mr
@@ -1,0 +1,110 @@
+#!/usr/bin/env zsh
+# shellcheck shell=bash
+# wt mr: pick one of your open merge requests, or one waiting on your review,
+# from any project and switch to a worktree for it.
+#
+# The GitLab companion to wt pr. `wt switch --prs` already covers the in-repo
+# case. This starts from the merge request instead, so the project does not have
+# to be the one you are standing in, or cloned at all. clone-repo resolves the
+# checkout and clones it if missing.
+
+set -e
+set -o pipefail
+
+usage() {
+  cat <<'EOF'
+usage: wt mr [--mine|--review] [wt switch options]
+
+Pick from your open merge requests and those waiting on your review, across
+every project, then switch to a worktree for the one you choose.
+
+  --mine    Only merge requests you authored
+  --review  Only merge requests waiting on your review
+
+Remaining options go to `wt switch`, so `wt mr -x claude` opens the worktree and
+launches Claude in it.
+EOF
+}
+
+want_mine=true
+want_review=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mine)
+      want_review=false
+      shift
+      ;;
+    --review)
+      want_mine=false
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) break ;;
+  esac
+done
+
+for tool in glab jq fzf clone-repo wt; do
+  if ! command -v "$tool" >/dev/null; then
+    gum log --level error "$tool is required"
+    exit 1
+  fi
+done
+
+# repo_url drops the /-/merge_requests/N suffix rather than rebuilding the URL
+# from a path, so it stays correct on self-hosted GitLab.
+search() {
+  glab api "/merge_requests?state=opened&per_page=50&$1" --output ndjson |
+    jq -c --arg bucket "$2" '{
+      url: .web_url,
+      title,
+      project: (.references.full | split("!")[0]),
+      iid,
+      bucket: $bucket,
+      repo_url: (.web_url | sub("/-/merge_requests/[0-9]+$"; ""))
+    }'
+}
+
+collect() {
+  if [[ "$want_mine" == true ]]; then
+    search "scope=created_by_me" mine
+  fi
+  if [[ "$want_review" == true ]]; then
+    # GitLab has no @me alias for reviewer, unlike scope=created_by_me.
+    search "scope=all&reviewer_username=$(glab api /user | jq -r .username)" review
+  fi
+}
+
+# Authored wins over review-requested when a merge request is both, because
+# unique_by keeps the first and collect emits authored first.
+rows=$(collect | jq -rs '
+  unique_by(.url)
+  | sort_by(.bucket, .project, .iid)
+  | .[]
+  | [.bucket, (.project + "!" + (.iid | tostring)), .title, .url, .repo_url]
+  | @tsv
+')
+
+if [[ -z "$rows" ]]; then
+  gum log --level warn "no open merge requests"
+  exit 1
+fi
+
+selection=$(
+  printf '%s\n' "$rows" |
+    fzf --delimiter='\t' --with-nth=1,2,3 \
+      --prompt='mr> ' \
+      --preview='glab mr view {4}' \
+      --preview-window='right,60%,border-left'
+) || exit 1
+
+url=$(printf '%s' "$selection" | cut -f4)
+repo_url=$(printf '%s' "$selection" | cut -f5)
+
+# Not `path`: zsh ties that name to $PATH, so assigning to it wipes the PATH
+# this script still needs to find wt.
+checkout=$(clone-repo "$repo_url")
+exec wt -C "$checkout" switch "$url" "$@"

--- a/bin/wt-pr
+++ b/bin/wt-pr
@@ -95,5 +95,7 @@ repo=$(printf '%s' "$selection" | cut -f2)
 repo=${repo%%\#*}
 url=$(printf '%s' "$selection" | cut -f4)
 
-path=$(clone-repo "$repo")
-exec wt -C "$path" switch "$url" "$@"
+# Not `path`: zsh ties that name to $PATH, so assigning to it wipes the PATH
+# this script still needs to find wt.
+checkout=$(clone-repo "$repo")
+exec wt -C "$checkout" switch "$url" "$@"


### PR DESCRIPTION
The GitLab companion to `wt pr` from #603. Merges the merge requests you authored with those awaiting your review, across every project, and hands the one you pick to `clone-repo` and `wt switch`.

```
wt mr                # yours + awaiting your review, every project
wt mr --mine / --review
wt mr -x claude      # pick, worktree it, launch Claude
```

A separate script rather than a forge flag on `wt pr`, because that is the split `wt switch` already draws with `pr:{N}` and `mr:{N}`, and the one `gh` and `glab` draw. The forty lines of shared flag parsing are the price of two commands that each read straight through.

## GitLab Specifics

There is no `@me` alias for reviewers the way there is for `scope=created_by_me`, so the review bucket resolves your username through `/user` first, and only when that bucket is actually wanted.

The project URL comes from stripping `/-/merge_requests/N` off the merge request URL rather than rebuilding it from a namespace path. That keeps it right on self-hosted GitLab, and it sidesteps subgroups, where a path is not two segments.

## Two Bugs on the Same Path

`wt pr` assigned the clone directory to `$path`. zsh ties that name to `$PATH`, so the assignment replaced `$PATH` with a single directory and the `exec wt` handoff on the next line could never resolve. It failed for every selection, which is the step #603 shipped unverified for want of a TTY. Renamed to `checkout` in both scripts.

`clone-repo` passed `glab` the full https URL. `glab` clones an https URL over https and ignores the `git_protocol` it was configured with, so a clone that should have gone over ssh prompted for a password instead. It now gets a bare `owner/repo` and picks the protocol itself.

## Verification

Ran under stub `fzf`, `clone-repo`, and `wt` with an empty `ZDOTDIR`, per the trap documented in #602. Both buckets returned real merge requests, including one that is both authored and review-requested, so `unique_by` dropping the duplicate in favor of the authored row is exercised against real data for the first time. Confirmed `--mine`, `--review`, trailing argument forwarding, `wt mr` dispatch, and that `glab mr view <url>` works as the preview command.

Not exercised: the interactive picker, and the final `wt switch`, both of which need a terminal.
