### PR TITLE
sync: fetch github over HTTPS so locked-Mac runs work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,9 +162,11 @@ Never add employer-specific tooling to a topic directory. Machines legitimately 
 
 ### GitHub Transport
 
-The nightly jobs run at 3am against a locked Mac, where Secretive refuses to sign and any SSH fetch dies on `agent refused operation`. Every repo these jobs sync is public, so `git_sync` calls `git_https_remote` to move a `github.com` origin to anonymous HTTPS before fetching. The rewrite is persistent and idempotent, so a clone that arrives over SSH heals on its next sync.
+The nightly jobs run at 3am against a locked Mac, where Secretive refuses to sign and any SSH fetch dies on `agent refused operation`. Every repo these jobs sync is public, so `git_sync` calls `git_https_remote` to move a `github.com` origin to anonymous HTTPS before fetching. Only the fetch URL moves, because the SSH URL stays behind as the remote's `pushurl` and pushes keep the credentials they already had. The rewrite is persistent and idempotent. A clone that arrives over SSH heals on its next sync.
 
-`claude-upgrade` also calls `git_https_env`, which exports the same rewrite as an `insteadOf` rule. That covers the marketplace and plugin clones Claude Code makes for itself, which it creates with `git@github.com:` URLs and re-clones on every update.
+`claude-upgrade` also calls `git_https_env`, which exports the same rewrite as an `insteadOf` rule. That covers the marketplace and plugin clones Claude Code makes for itself, which it creates with `git@github.com:` URLs and re-clones on every update. An `insteadOf` rule outranks a `pushurl`, so the exports are scoped to the plugin steps rather than the whole script.
+
+Read the remote with `git config --get remote.<name>.url`, never `git remote get-url`. The latter resolves `insteadOf` rules, so it reports HTTPS while `.git/config` still holds the SSH URL, and a rewrite keyed on it silently never fires.
 
 ### Manual Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,12 @@ Never add employer-specific tooling to a topic directory. Machines legitimately 
 - Syncs dotfiles, runs `scripts/install`, cleans up stale packages
 - Creates a Things task on failure with error output
 
+### GitHub Transport
+
+The nightly jobs run at 3am against a locked Mac, where Secretive refuses to sign and any SSH fetch dies on `agent refused operation`. Every repo these jobs sync is public, so `git_sync` calls `git_https_remote` to move a `github.com` origin to anonymous HTTPS before fetching. The rewrite is persistent and idempotent, so a clone that arrives over SSH heals on its next sync.
+
+`claude-upgrade` also calls `git_https_env`, which exports the same rewrite as an `insteadOf` rule. That covers the marketplace and plugin clones Claude Code makes for itself, which it creates with `git@github.com:` URLs and re-clones on every update.
+
 ### Manual Commands
 
 - `dotfiles sync` — Pull latest from remote

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -121,11 +121,6 @@ report_upgrade_failure() {
 }
 
 main() {
-  # Claude Code clones marketplaces and plugins from `git@github.com:` and
-  # re-clones them on every update, so those remotes are not ours to rewrite.
-  # git_sync moves $CLAUDE_REPO_HOME itself.
-  git_https_env
-
   local output
   output=$(mktemp)
   # shellcheck disable=SC2064
@@ -136,6 +131,11 @@ main() {
       exit 1
     fi
 
+    # Claude Code clones marketplaces and plugins from `git@github.com:` and
+    # re-clones them on every update, so those remotes are not ours to rewrite.
+    # git_sync moves $CLAUDE_REPO_HOME itself, and leaving these exports out of
+    # sync_repo keeps its PR push on the SSH pushurl.
+    git_https_env
     update_marketplaces
     update_plugins
   } 2>&1 | tee "$output"

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -121,13 +121,10 @@ report_upgrade_failure() {
 }
 
 main() {
-  # Force HTTPS for github.com: SSH agents (Secretive, 1Password, etc.)
-  # can't sign while the Mac is locked, breaking unattended runs.
-  export GIT_CONFIG_COUNT=2
-  export GIT_CONFIG_KEY_0='url.https://github.com/.insteadOf'
-  export GIT_CONFIG_VALUE_0='git@github.com:'
-  export GIT_CONFIG_KEY_1='url.https://github.com/.insteadOf'
-  export GIT_CONFIG_VALUE_1='ssh://git@github.com/'
+  # Claude Code clones marketplaces and plugins from `git@github.com:` and
+  # re-clones them on every update, so those remotes are not ours to rewrite.
+  # git_sync moves $CLAUDE_REPO_HOME itself.
+  git_https_env
 
   local output
   output=$(mktemp)

--- a/scripts/.shellspec
+++ b/scripts/.shellspec
@@ -1,1 +1,2 @@
 --shell bash
+--require spec_helper

--- a/scripts/lib/git-sync.sh
+++ b/scripts/lib/git-sync.sh
@@ -5,9 +5,22 @@
 #   Echo the remote default branch, resolving origin/HEAD with a
 #   set-head retry and falling back to "main".
 #
+# git_https_remote <repo_dir> [remote]
+#   Rewrite a github.com SSH remote to its anonymous HTTPS equivalent, in
+#   place. SSH needs a key from the agent, and Secretive refuses to sign while
+#   the Mac is locked, so a 3am launchd fetch dies on "agent refused
+#   operation". The synced repos are public, so HTTPS reads need no
+#   credentials at all. Other hosts and URL forms are left alone.
+#
+# git_https_env
+#   Export the same rewrite as an insteadOf rule, for child processes cloning
+#   github.com remotes this repo does not own. Appends to any GIT_CONFIG_COUNT
+#   already in the environment rather than replacing it, so a machine-local
+#   entry survives.
+#
 # git_sync <repo_dir> [branch]
 #   Guard the target (reject symlinks, non-repos, and dirty working trees),
-#   fetch with retry, and fast-forward only.
+#   move origin to HTTPS, fetch with retry, and fast-forward only.
 #   Returns:
 #     0  updated   (new short rev echoed to stdout)
 #     2  current   (already up to date)
@@ -29,6 +42,34 @@ git_default_branch() {
   fi
 
   echo "${branch:-main}"
+}
+
+git_https_remote() {
+  local repo_dir="$1"
+  local remote="${2:-origin}"
+
+  local url
+  url=$(git -C "$repo_dir" remote get-url "$remote" 2>/dev/null) || return 0
+
+  local repo_path
+  case "$url" in
+    git@github.com:*) repo_path="${url#git@github.com:}" ;;
+    ssh://git@github.com/*) repo_path="${url#ssh://git@github.com/}" ;;
+    *) return 0 ;;
+  esac
+
+  gum log --level info "Moving $remote from SSH to HTTPS"
+  git -C "$repo_dir" remote set-url "$remote" "https://github.com/$repo_path"
+}
+
+git_https_env() {
+  local i="${GIT_CONFIG_COUNT:-0}"
+
+  export "GIT_CONFIG_KEY_$i=url.https://github.com/.insteadOf"
+  export "GIT_CONFIG_VALUE_$i=git@github.com:"
+  export "GIT_CONFIG_KEY_$((i + 1))=url.https://github.com/.insteadOf"
+  export "GIT_CONFIG_VALUE_$((i + 1))=ssh://git@github.com/"
+  export GIT_CONFIG_COUNT=$((i + 2))
 }
 
 git_sync_fetch() {
@@ -64,6 +105,8 @@ git_sync() {
     gum log --level error "$repo_dir is not a git repository"
     return "$GIT_SYNC_FAILED"
   fi
+
+  git_https_remote "$repo_dir"
 
   if ! git -C "$repo_dir" diff --quiet 2>/dev/null ||
      ! git -C "$repo_dir" diff --cached --quiet 2>/dev/null; then

--- a/scripts/lib/git-sync.sh
+++ b/scripts/lib/git-sync.sh
@@ -6,21 +6,23 @@
 #   set-head retry and falling back to "main".
 #
 # git_https_remote <repo_dir> [remote]
-#   Rewrite a github.com SSH remote to its anonymous HTTPS equivalent, in
-#   place. SSH needs a key from the agent, and Secretive refuses to sign while
-#   the Mac is locked, so a 3am launchd fetch dies on "agent refused
-#   operation". The synced repos are public, so HTTPS reads need no
-#   credentials at all. Other hosts and URL forms are left alone.
+#   Point a github.com SSH remote at its anonymous HTTPS equivalent for fetch,
+#   keeping the SSH URL as the pushurl. SSH needs a key from the agent, and
+#   Secretive refuses to sign while the Mac is locked, so a 3am launchd fetch
+#   dies on "agent refused operation". The synced repos are public, so HTTPS
+#   reads need no credentials, while pushes stay on the transport that already
+#   has them. Other hosts and URL forms are left alone.
 #
 # git_https_env
 #   Export the same rewrite as an insteadOf rule, for child processes cloning
 #   github.com remotes this repo does not own. Appends to any GIT_CONFIG_COUNT
 #   already in the environment rather than replacing it, so a machine-local
-#   entry survives.
+#   entry survives. The rule outranks a pushurl, so scope it to the commands
+#   that need it rather than exporting it for a whole script.
 #
 # git_sync <repo_dir> [branch]
 #   Guard the target (reject symlinks, non-repos, and dirty working trees),
-#   move origin to HTTPS, fetch with retry, and fast-forward only.
+#   move origin's fetch URL to HTTPS, fetch with retry, and fast-forward only.
 #   Returns:
 #     0  updated   (new short rev echoed to stdout)
 #     2  current   (already up to date)
@@ -44,32 +46,42 @@ git_default_branch() {
   echo "${branch:-main}"
 }
 
+GIT_HTTPS_SSH_PREFIXES=("git@github.com:" "ssh://git@github.com/")
+
 git_https_remote() {
   local repo_dir="$1"
   local remote="${2:-origin}"
 
+  # `git remote get-url` resolves insteadOf rules, so it reports HTTPS while
+  # .git/config still holds the SSH URL, and the rewrite below never fires.
   local url
-  url=$(git -C "$repo_dir" remote get-url "$remote" 2>/dev/null) || return 0
+  url=$(git -C "$repo_dir" config --get "remote.$remote.url" 2>/dev/null) || return 0
 
-  local repo_path
-  case "$url" in
-    git@github.com:*) repo_path="${url#git@github.com:}" ;;
-    ssh://git@github.com/*) repo_path="${url#ssh://git@github.com/}" ;;
-    *) return 0 ;;
-  esac
+  local prefix repo_path=""
+  for prefix in "${GIT_HTTPS_SSH_PREFIXES[@]}"; do
+    if [[ "$url" == "$prefix"* ]]; then
+      repo_path="${url#"$prefix"}"
+      break
+    fi
+  done
+  [[ -n "$repo_path" ]] || return 0
 
-  gum log --level info "Moving $remote from SSH to HTTPS"
+  gum log --level info "Fetching $remote over HTTPS, pushing over SSH"
+  git -C "$repo_dir" config --get "remote.$remote.pushurl" >/dev/null 2>&1 ||
+    git -C "$repo_dir" remote set-url --push "$remote" "$url"
   git -C "$repo_dir" remote set-url "$remote" "https://github.com/$repo_path"
 }
 
 git_https_env() {
-  local i="${GIT_CONFIG_COUNT:-0}"
+  local i="${GIT_CONFIG_COUNT:-0}" prefix
 
-  export "GIT_CONFIG_KEY_$i=url.https://github.com/.insteadOf"
-  export "GIT_CONFIG_VALUE_$i=git@github.com:"
-  export "GIT_CONFIG_KEY_$((i + 1))=url.https://github.com/.insteadOf"
-  export "GIT_CONFIG_VALUE_$((i + 1))=ssh://git@github.com/"
-  export GIT_CONFIG_COUNT=$((i + 2))
+  for prefix in "${GIT_HTTPS_SSH_PREFIXES[@]}"; do
+    export "GIT_CONFIG_KEY_$i=url.https://github.com/.insteadOf"
+    export "GIT_CONFIG_VALUE_$i=$prefix"
+    i=$((i + 1))
+  done
+
+  export GIT_CONFIG_COUNT=$i
 }
 
 git_sync_fetch() {
@@ -106,13 +118,13 @@ git_sync() {
     return "$GIT_SYNC_FAILED"
   fi
 
-  git_https_remote "$repo_dir"
-
   if ! git -C "$repo_dir" diff --quiet 2>/dev/null ||
      ! git -C "$repo_dir" diff --cached --quiet 2>/dev/null; then
     gum log --level error "$repo_dir has local changes - skipping sync"
     return "$GIT_SYNC_FAILED"
   fi
+
+  git_https_remote "$repo_dir"
 
   [[ -n "$branch" ]] || branch=$(git_default_branch "$repo_dir")
 

--- a/scripts/spec/dotfiles_sync_spec.sh
+++ b/scripts/spec/dotfiles_sync_spec.sh
@@ -12,32 +12,8 @@ Describe "dotfiles-sync exit status"
     rm -rf "$sandbox"
     mkdir -p "$stubdir"
 
-    # gum stub: `gum spin … -- cmd` runs cmd; `gum log … msg` echoes msg.
-    # printf, not a here-document: bash stages those through a temp file it
-    # picks itself, which a sandbox may deny.
-    # shellcheck disable=SC2016 # the stub's own $1 and $@, not this shell's
-    printf '%s\n' \
-      '#!/usr/bin/env bash' \
-      'case "$1" in' \
-      '  spin)' \
-      '    shift' \
-      '    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done' \
-      '    [ "$1" = "--" ] && shift' \
-      '    exec "$@"' \
-      '    ;;' \
-      '  log)' \
-      '    # Real gum log writes to stderr; match that so command substitution' \
-      '    # in callers keeps log lines off the captured stdout rev.' \
-      '    printf "%s\n" "${@: -1}" >&2' \
-      '    ;;' \
-      'esac' \
-      > "$stubdir/gum"
-    chmod +x "$stubdir/gum"
-
-    # notify shells out to osascript on macOS; stub it so the failure path
-    # stays silent and side-effect-free during the test.
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$stubdir/osascript"
-    chmod +x "$stubdir/osascript"
+    stub_gum "$stubdir"
+    stub_osascript "$stubdir"
 
     # Bare origin with one commit on main; clone so HEAD == origin/main.
     git init -q --bare -b main "$origin"

--- a/scripts/spec/git_https_remote_spec.sh
+++ b/scripts/spec/git_https_remote_spec.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "git_https_remote"
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/git-https-remote"
+    repo="$sandbox/repo"
+    stubdir="$sandbox/stub"
+    rm -rf "$sandbox"
+    mkdir -p "$stubdir"
+
+    # The real gum log writes to stderr. Nothing here asserts on it.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$stubdir/gum"
+    chmod +x "$stubdir/gum"
+
+    git init -q -b main "$repo"
+  }
+
+  BeforeEach 'setup'
+
+  # shellcheck source=../lib/git-sync.sh
+  Include "$SHELLSPEC_PROJECT_ROOT/lib/git-sync.sh"
+
+  rewrite() {
+    git -C "$repo" remote add origin "$1"
+    PATH="$stubdir:$PATH" git_https_remote "$repo"
+    git -C "$repo" remote get-url origin
+  }
+
+  It "rewrites an scp-style github remote"
+    When call rewrite "git@github.com:bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+  End
+
+  It "rewrites an ssh:// github remote"
+    When call rewrite "ssh://git@github.com/bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+  End
+
+  It "leaves an https github remote alone"
+    When call rewrite "https://github.com/bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+  End
+
+  # Only github.com is public enough to fetch anonymously. A work host keeps
+  # whatever transport its credentials are set up for.
+  It "leaves a non-github ssh remote alone"
+    When call rewrite "git@gitlab.com:bendrucker/private.git"
+    The output should equal "git@gitlab.com:bendrucker/private.git"
+  End
+
+  It "does nothing when the remote is missing"
+    When call git_https_remote "$repo"
+    The status should be success
+  End
+End
+
+Describe "git_https_env"
+  # shellcheck source=../lib/git-sync.sh
+  Include "$SHELLSPEC_PROJECT_ROOT/lib/git-sync.sh"
+
+  setup() {
+    repo="$SHELLSPEC_TMPBASE/git-https-env"
+    rm -rf "$repo"
+    git init -q -b main "$repo"
+  }
+
+  BeforeEach 'setup'
+
+  resolved_url() {
+    git -C "$repo" remote add origin "$1"
+    git_https_env
+    git -C "$repo" ls-remote --get-url origin
+  }
+
+  It "rewrites github SSH urls for child git processes"
+    When call resolved_url "git@github.com:bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+  End
+
+  # A ~/.zshenv.local can export its own GIT_CONFIG entries. Overwriting index
+  # 0 and pinning the count at 2 would silently drop them.
+  It "appends to inherited GIT_CONFIG entries"
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0=core.pager
+    export GIT_CONFIG_VALUE_0=cat
+    When call resolved_url "git@github.com:bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The variable GIT_CONFIG_COUNT should equal 3
+    The variable GIT_CONFIG_VALUE_0 should equal cat
+  End
+End

--- a/scripts/spec/git_https_remote_spec.sh
+++ b/scripts/spec/git_https_remote_spec.sh
@@ -1,40 +1,41 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2329
 
+# shellcheck source=../lib/git-sync.sh
+Include "$SHELLSPEC_PROJECT_ROOT/lib/git-sync.sh"
+
+setup() {
+  sandbox="$SHELLSPEC_TMPBASE/git-https"
+  repo="$sandbox/repo"
+  stubdir="$sandbox/stub"
+  rm -rf "$sandbox"
+  mkdir -p "$stubdir"
+  stub_gum "$stubdir"
+  git init -q -b main "$repo"
+}
+
+BeforeEach 'setup'
+
+fetch_url() { git -C "$repo" config --get remote.origin.url; }
+push_url() { git -C "$repo" config --get "remote.origin.pushurl"; }
+
 Describe "git_https_remote"
-  setup() {
-    sandbox="$SHELLSPEC_TMPBASE/git-https-remote"
-    repo="$sandbox/repo"
-    stubdir="$sandbox/stub"
-    rm -rf "$sandbox"
-    mkdir -p "$stubdir"
-
-    # The real gum log writes to stderr. Nothing here asserts on it.
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$stubdir/gum"
-    chmod +x "$stubdir/gum"
-
-    git init -q -b main "$repo"
-  }
-
-  BeforeEach 'setup'
-
-  # shellcheck source=../lib/git-sync.sh
-  Include "$SHELLSPEC_PROJECT_ROOT/lib/git-sync.sh"
-
   rewrite() {
     git -C "$repo" remote add origin "$1"
     PATH="$stubdir:$PATH" git_https_remote "$repo"
-    git -C "$repo" remote get-url origin
+    fetch_url
   }
 
   It "rewrites an scp-style github remote"
     When call rewrite "git@github.com:bendrucker/claude.git"
     The output should equal "https://github.com/bendrucker/claude.git"
+    The stderr should include "pushing over SSH"
   End
 
   It "rewrites an ssh:// github remote"
     When call rewrite "ssh://git@github.com/bendrucker/claude.git"
     The output should equal "https://github.com/bendrucker/claude.git"
+    The stderr should include "pushing over SSH"
   End
 
   It "leaves an https github remote alone"
@@ -53,20 +54,34 @@ Describe "git_https_remote"
     When call git_https_remote "$repo"
     The status should be success
   End
+
+  # Only the fetch URL moves. Pushing over anonymous HTTPS would need
+  # credentials the SSH remote already had.
+  It "keeps the SSH url for pushes"
+    When call rewrite "git@github.com:bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The result of function push_url should equal "git@github.com:bendrucker/claude.git"
+  End
+
+  It "does not clobber a pushurl that is already set"
+    git -C "$repo" remote add origin "git@github.com:bendrucker/claude.git"
+    git -C "$repo" remote set-url --push origin "git@github.com:someone/fork.git"
+    When call env PATH="$stubdir:$PATH" git_https_remote "$repo"
+    The result of function push_url should equal "git@github.com:someone/fork.git"
+  End
+
+  # Regression: `git remote get-url` resolves insteadOf rules, so reading the
+  # remote through it reports HTTPS while .git/config still holds SSH, and the
+  # rewrite silently never happens.
+  It "still rewrites when an insteadOf rule already maps the url"
+    git_https_env
+    When call rewrite "git@github.com:bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The stderr should include "pushing over SSH"
+  End
 End
 
 Describe "git_https_env"
-  # shellcheck source=../lib/git-sync.sh
-  Include "$SHELLSPEC_PROJECT_ROOT/lib/git-sync.sh"
-
-  setup() {
-    repo="$SHELLSPEC_TMPBASE/git-https-env"
-    rm -rf "$repo"
-    git init -q -b main "$repo"
-  }
-
-  BeforeEach 'setup'
-
   resolved_url() {
     git -C "$repo" remote add origin "$1"
     git_https_env

--- a/scripts/spec/spec_helper.sh
+++ b/scripts/spec/spec_helper.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Shared fixtures for the scripts specs.
+
+# stub_gum <dir>
+#   Write a gum stub into <dir>. `gum spin … -- cmd` runs cmd; `gum log … msg`
+#   echoes msg to stderr, where the real gum writes it, so command
+#   substitution in callers keeps log lines off the captured stdout.
+stub_gum() {
+  local dir="$1"
+
+  # printf, not a here-document: bash stages those through a temp file it
+  # picks itself, which a sandbox may deny.
+  # shellcheck disable=SC2016 # the stub's own $1 and $@, not this shell's
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'case "$1" in' \
+    '  spin)' \
+    '    shift' \
+    '    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done' \
+    '    [ "$1" = "--" ] && shift' \
+    '    exec "$@"' \
+    '    ;;' \
+    '  log)' \
+    '    printf "%s\n" "${@: -1}" >&2' \
+    '    ;;' \
+    'esac' \
+    > "$dir/gum"
+  chmod +x "$dir/gum"
+}
+
+# stub_osascript <dir>
+#   Write a no-op osascript into <dir>, so notify() stays silent and
+#   side-effect-free during a test.
+stub_osascript() {
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$1/osascript"
+  chmod +x "$1/osascript"
+}


### PR DESCRIPTION
The nightly `claude-upgrade` has been failing on the MacBook Pro since April, always the same way:

```
sign_and_send_pubkey: signing failed for ECDSA
  "GitHub@secretive.Ben-Drucker's-MacBook-Pro.local" from agent: agent refused operation
git@github.com: Permission denied (publickey).
```

`~/.claude-repo` has a `git@github.com:` origin, and Secretive won't sign at 3:30am with the Mac locked. Nine failures on that machine since June 1, all SSH-denied. Studio's failures over the same window are a different thing entirely, a dirty `user/settings.json` tripping the local-changes guard, which is why this only bites the one machine.

#364 already added an `insteadOf` env override to `claude-upgrade` for exactly this. It resolves correctly in isolation, verified through `gum spin`, through a `zsh -l -c` subshell, and against competing `insteadOf` rules in both directions, and it is still not taking effect on the work machine. That machine's `~/.zshenv.local` isn't in this repo and can't be read from here, so rather than keep guessing at it, this moves the remote itself. A URL in `.git/config` doesn't depend on what the environment happens to hold.

`git_sync` now calls `git_https_remote` before fetching, so both `~/.dotfiles` and `~/.claude-repo` heal themselves on the next run with nothing to do by hand. Only the fetch URL moves. The SSH URL stays behind as the remote's `pushurl`, so pushes keep the credentials they already had rather than picking up a new dependency on the gh helper. `git_https_env` keeps the `insteadOf` rule for the marketplace and plugin clones Claude Code makes for itself, which it creates with `git@github.com:` URLs and re-clones on every update, so they aren't ours to rewrite. Those exports are scoped to the plugin steps, because an `insteadOf` rule outranks a `pushurl` and would otherwise undo the split.

One trap worth knowing about, since the first draft of this walked straight into it: `git remote get-url` resolves `insteadOf` rules. Read the remote through it and you get HTTPS back while `.git/config` still holds the SSH URL, so a rewrite keyed on that reading silently never fires. `git config --get remote.<name>.url` gives the raw value. There's a regression test on it.

Verified end to end by pointing a scratch clone at an SSH remote and running the real `bin/dotfiles-sync` with `GIT_SSH_COMMAND=/usr/bin/false`, which fails SSH the same way a locked Mac does: the fetch succeeds over HTTPS and the pushurl comes out SSH.

`bin/dotfiles-upgrade` still files no Things to-do when a sync fails, unlike the install branch three lines below it, so a failure there surfaces only as a 3am notification banner nobody sees. That's why this was visible on the Claude half and invisible on the dotfiles half. Left out as a separate concern.

## Manual step

The MacBook Pro needs one `dotfiles sync` to pick up the new library. After that the next `claude-upgrade` rewrites `~/.claude-repo`'s remote on its own.
