### PR TITLE
herdr: configure reviewr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Treesitter parsers are built against a specific nvim-treesitter revision. They b
 Most tool configs live under `~/.config/<tool>/` (XDG Base Directory). Symlinks are declared in per-topic `symlinks.conf` files and installed by `scripts/install-symlinks`. Topics with non-symlink setup logic (plugin managers, system config) use `install.sh`.
 
 - Symlinks point to `~/.dotfiles` (the installed copy), **not** the development working tree. Edits in a dev checkout won't take effect until synced unless dev mode is enabled.
+- A `source` may be a directory, linking the whole tree in one entry. This is what to use when a tool owns a directory of same-shaped files and you want a new file to go live without another install run. The catch is a tool that writes its own state in there, which lands in the repo too. A `.gitignore` inside the tree narrows what gets tracked. `herdr/plugins/config` mirrors `$XDG_CONFIG_HOME/herdr/plugins/config`, tracks each plugin's `config.toml`, and ignores the rest.
+- A real directory sitting at a link target aborts the install with the path named. Move its contents into the repo, remove it, re-run.
 
 ### Dev Mode
 

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -60,3 +60,11 @@ key = "prefix+shift+f"
 type = "shell"
 command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"
 description = "file viewer (tab)"
+
+# reviewr's auto-open is off (reviewr.toml), so this is the only way in.
+# herdr's resize mode already holds prefix+r.
+[[keys.command]]
+key = "prefix+d"
+type = "shell"
+command = "herdr plugin action invoke toggle --plugin persiyanov.reviewr"
+description = "reviewr diff (toggle)"

--- a/herdr/plugins/config/.gitignore
+++ b/herdr/plugins/config/.gitignore
@@ -1,0 +1,8 @@
+# $XDG_CONFIG_HOME/herdr/plugins/config links to this whole tree, so a plugin
+# writing beside its config writes here. Track the config file herdr looks for
+# and leave every plugin's own state (update checks, pinned entries, caches)
+# untracked.
+*
+!*/
+!*/config.toml
+!.gitignore

--- a/herdr/plugins/config/persiyanov.reviewr/config.toml
+++ b/herdr/plugins/config/persiyanov.reviewr/config.toml
@@ -1,4 +1,4 @@
-# reviewr's own config. herdr's config.toml never reaches it.
+# Settings in herdr's own config.toml never reach a plugin.
 # https://github.com/persiyanov/herdr-reviewr#configuration
 
 # A vertical split leaves both panes unreadable on a phone. prefix+d opens it

--- a/herdr/reviewr.toml
+++ b/herdr/reviewr.toml
@@ -1,0 +1,14 @@
+# reviewr's own config. herdr's config.toml never reaches it.
+# https://github.com/persiyanov/herdr-reviewr#configuration
+
+# A vertical split leaves both panes unreadable on a phone. prefix+d opens it
+# on demand instead.
+auto_open = false
+
+# Reviewing is a branch-at-a-time activity here, not a working-tree one.
+default_scope = "branch"
+
+# Beside the diff, the file list costs 32% of the width. Under it, 25% of the
+# height. Width is what a phone has none of, and a desktop split can spare the
+# rows. `p` cycles it for the session.
+navigator_position = "bottom"

--- a/herdr/spec/herdr_spec.sh
+++ b/herdr/spec/herdr_spec.sh
@@ -4,6 +4,7 @@
 Describe "herdr"
   config="${XDG_CONFIG_HOME:-$HOME/.config}/herdr/config.toml"
   list="$SHELLSPEC_PROJECT_ROOT/plugins.list"
+  plugin_config="${XDG_CONFIG_HOME:-$HOME/.config}/herdr/plugins/config"
 
   It "symlinks the config into place"
     When call test -L "$config"
@@ -12,6 +13,18 @@ Describe "herdr"
 
   It "config is readable and non-empty"
     When call test -s "$config"
+    The status should be success
+  End
+
+  It "symlinks the whole plugin config tree"
+    # A directory link, so a new plugin's config goes live by existing in the
+    # repo rather than by another install run.
+    When call test -L "$plugin_config"
+    The status should be success
+  End
+
+  It "reaches a plugin's config through that link"
+    When call test -s "$plugin_config/persiyanov.reviewr/config.toml"
     The status should be success
   End
 

--- a/herdr/symlinks.conf
+++ b/herdr/symlinks.conf
@@ -1,2 +1,2 @@
 config.toml:$XDG_CONFIG_HOME/herdr/config.toml
-reviewr.toml:$XDG_CONFIG_HOME/herdr/plugins/config/persiyanov.reviewr/config.toml
+plugins/config:$XDG_CONFIG_HOME/herdr/plugins/config

--- a/herdr/symlinks.conf
+++ b/herdr/symlinks.conf
@@ -1,1 +1,2 @@
 config.toml:$XDG_CONFIG_HOME/herdr/config.toml
+reviewr.toml:$XDG_CONFIG_HOME/herdr/plugins/config/persiyanov.reviewr/config.toml

--- a/scripts/install
+++ b/scripts/install
@@ -25,6 +25,20 @@ eval "$(brew shellenv)"
 
 source mise/install.sh
 
+# herdr's plugin config directory became a link into this repo, and
+# install-symlinks refuses to replace a real directory with one. This has to run
+# ahead of that rather than from herdr/install.sh, which runs after. It moves the
+# old directory aside rather than into the repo, so a config that was never
+# committed can't land as an untracked file that a later sync refuses to
+# overwrite.
+# EXPIRES: 2027-02-02 every machine has the linked herdr plugin config tree
+herdr_plugin_config="${XDG_CONFIG_HOME:-$HOME/.config}/herdr/plugins/config"
+if [[ -d $herdr_plugin_config && ! -L $herdr_plugin_config ]]; then
+  rm -rf $herdr_plugin_config.pre-link
+  mv $herdr_plugin_config $herdr_plugin_config.pre-link
+  gum log --level warn "moved $herdr_plugin_config to .pre-link; anything you configured by hand is in there"
+fi
+
 ./scripts/install-symlinks
 
 # Build exclusions for mise and any git submodules

--- a/scripts/lib/symlinks.sh
+++ b/scripts/lib/symlinks.sh
@@ -6,7 +6,14 @@
 # symlink_create <src> <dst>
 #   Create dst as a symlink to src, making parent directories as needed.
 #   Silent and idempotent. Source-existence validation belongs in the caller.
+#   A real directory at dst is fatal: `ln -sfn` would put the link inside it
+#   rather than replace it, and the caller's contents are worth a look before
+#   anything removes them.
 symlink_create() {
+  if [ -d "$2" ] && [ ! -L "$2" ]; then
+    echo "symlink_create: $2 is a directory; move its contents into $1 and remove it" >&2
+    return 1
+  fi
   mkdir -p "$(dirname "$2")"
   ln -sfn "$1" "$2"
 }


### PR DESCRIPTION
Configures reviewr, and changes how this repo tracks plugin config so the next plugin costs nothing.

## Plugin config tree

`$XDG_CONFIG_HOME/herdr/plugins/config` is now a directory symlink into the repo. A plugin's config goes live by existing at `herdr/plugins/config/<plugin-id>/config.toml`, with no `symlinks.conf` entry and no install run. That was the point: one line per plugin plus a re-run is friction that compounds.

Plugins write state next to their config. herdr-navigator keeps `update-check` and `pinned-entries.json` in its directory, so a link at this level puts plugin writes inside the repo. A `.gitignore` in the tree tracks `*/config.toml` and ignores the rest. A plugin rewriting a config this repo tracks then shows up as a git diff, which is where you want to notice it.

Per-plugin directory links were the other option, and the same state files rule them out.

`symlink_create` now aborts on a real directory at the link target. `ln -sfn` puts the link *inside* such a directory rather than replacing it, leaving a layout that looks installed and resolves nowhere. Existing machines hit this once on the `plugins/config` swap. The error names both paths.

## reviewr settings

reviewr auto-opened a split in every new worktree. That reads well on a desktop display, which is why it was on, but on a phone the vertical split leaves both panes too narrow to use. `prefix+d` toggles it on demand now. `prefix+r` was the obvious key. herdr's resize mode already has it.

`default_scope = "branch"` starts on the merge-base diff rather than the working tree. `navigator_position = "bottom"` moves the file list under the diff, where it costs 25% of the height instead of 32% of the width, and width is the axis a phone has none of.

Making that position depend on terminal size would beat picking one. reviewr can't. `split_body` in its `ui.rs` divides the pane by a percentage of whichever axis the configured position names, and nothing consults width. herdr's `mobile_width_threshold` governs herdr's own chrome and exposes no signal a plugin can read.

`toggle_placement` stays on `split`, the only placement that keeps reviewr beside the agent. herdr's `prefix+z` zooms the focused pane, covering the phone case per-invocation without giving up the desktop layout.

`theme` is deliberately absent. reviewr has no light/dark detection and keeps the terminal's background, so it clashes in whichever mode you don't pick. A script could rewrite one line on the appearance signal that ghostty and herdr already follow, except the config is symlinked into this repo, so every flip would dirty the working tree.

## Verification

Ran `scripts/install-symlinks` against a clean `XDG_CONFIG_HOME`: the link lands and all six herdr specs pass, including two new ones covering the directory link and reachability through it. Re-ran with a real directory planted at the target and confirmed the install exits 1 with the path named. Settings themselves checked with `herdr-reviewr --resolve-plugin-config`, worth knowing about since one bad key silently invalidates the whole file.

## Migration

Every machine that ran an install before this has a real `~/.config/herdr/plugins/config`, which `install-symlinks` now refuses to overwrite. `scripts/install` clears that itself, tagged `EXPIRES: 2027-02-02` so CI prompts its removal once every machine has run it. Nightly `dotfiles-upgrade` runs `scripts/install`, so machines migrate themselves within a day.

It moves the old directory to `config.pre-link` rather than into the repo. Carrying files in was the first attempt, and it leaves an untracked `config.toml` that a later sync refuses to overwrite once a tracked copy of the same path lands. Anything configured by hand and never committed is still in `.pre-link` to be recovered or deleted.
