### PR TITLE
sync: file a to-do when the nightly sync fails

### DIFF
--- a/bin/dotfiles-upgrade
+++ b/bin/dotfiles-upgrade
@@ -10,12 +10,24 @@ DOTFILES_HOME="${DOTFILES_HOME:-$HOME/.dotfiles}"
 
 source "${0:A:h}/../scripts/lib/report-failure.sh"
 
+SYNC_LOG=$(mktemp)
 INSTALL_LOG=$(mktemp)
-trap 'rm -f "$INSTALL_LOG"' EXIT
+trap 'rm -f "$SYNC_LOG" "$INSTALL_LOG"' EXIT
+
+report_log_failure() {
+  local title="$1" command="$2" log="$3"
+
+  local revision output
+  revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  output=$(tail -n 100 "$log" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')
+  report_failure "dotfiles-upgrade" "$title" "$command" "$output" "$revision"
+}
 
 if ! gum spin --show-output --show-error --title "Syncing dotfiles" -- \
-  "$DOTFILES_HOME/bin/dotfiles-sync"; then
+  "$DOTFILES_HOME/bin/dotfiles-sync" 2>&1 | tee "$SYNC_LOG"; then
   gum log --level error "sync failed"
+
+  report_log_failure "Dotfiles sync failed" "dotfiles-sync" "$SYNC_LOG"
   exit 1
 fi
 
@@ -23,9 +35,7 @@ gum log --level info "Running install"
 if ! "$DOTFILES_HOME/scripts/install" 2>&1 | tee "$INSTALL_LOG"; then
   gum log --level error "install failed"
 
-  revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-  output=$(tail -n 100 "$INSTALL_LOG" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')
-  report_failure "dotfiles-upgrade" "Dotfiles install failed" "brew bundle" "$output" "$revision"
+  report_log_failure "Dotfiles install failed" "brew bundle" "$INSTALL_LOG"
   exit 1
 fi
 

--- a/scripts/spec/dotfiles_upgrade_spec.sh
+++ b/scripts/spec/dotfiles_upgrade_spec.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "dotfiles-upgrade failure reporting"
+  dotfiles_upgrade="$SHELLSPEC_PROJECT_ROOT/../bin/dotfiles-upgrade"
+
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/dotfiles-upgrade"
+    home="$sandbox/dotfiles"
+    stubdir="$sandbox/stub"
+    opened="$sandbox/opened"
+    rm -rf "$sandbox"
+    mkdir -p "$stubdir" "$home/bin" "$sandbox/state"
+
+    # printf, not a here-document: bash stages those through a temp file it
+    # picks itself, which a sandbox may deny.
+    # shellcheck disable=SC2016 # the stub's own $1 and $@, not this shell's
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'case "$1" in' \
+      '  spin)' \
+      '    shift' \
+      '    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done' \
+      '    [ "$1" = "--" ] && shift' \
+      '    exec "$@"' \
+      '    ;;' \
+      '  log)' \
+      '    printf "%s\n" "${@: -1}" >&2' \
+      '    ;;' \
+      'esac' \
+      > "$stubdir/gum"
+    chmod +x "$stubdir/gum"
+
+    # report_failure files the to-do by handing a things:/// URL to `open`.
+    # Record it instead of launching Things.
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      "printf '%s\\n' \"\$1\" >> \"$opened\"" \
+      > "$stubdir/open"
+    chmod +x "$stubdir/open"
+
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$stubdir/osascript"
+    chmod +x "$stubdir/osascript"
+
+    printf '#!/usr/bin/env bash\necho "fatal: could not read from remote" >&2\nexit 1\n' \
+      > "$home/bin/dotfiles-sync"
+    chmod +x "$home/bin/dotfiles-sync"
+  }
+
+  # `zsh -f` so the script's startup skips ~/.zshenv, which exports
+  # DOTFILES_HOME unconditionally and would clobber the sandbox path.
+  run_upgrade() {
+    PATH="$stubdir:$PATH" DOTFILES_HOME="$home" XDG_STATE_HOME="$sandbox/state" \
+      zsh -f "$dotfiles_upgrade"
+  }
+
+  BeforeEach 'setup'
+
+  todo_filed() { grep -c "things:///add" "$opened" 2>/dev/null || echo 0; }
+
+  # Regression: a failing sync used to log and exit 1 with no report_failure
+  # call, so an unattended failure surfaced only as a notification banner that
+  # fires at 3am and is gone before anyone looks.
+  It "files a to-do when the sync fails"
+    When call run_upgrade
+    The status should equal 1
+    The stderr should include "sync failed"
+    The result of function todo_filed should equal 1
+  End
+
+  # The to-do carries the sync's own output, which is the part worth reading
+  # the next morning.
+  It "names the sync and carries its output"
+    When call run_upgrade
+    The status should equal 1
+    The contents of file "$opened" should include "Dotfiles%20sync%20failed"
+    The contents of file "$opened" should include "could%20not%20read%20from%20remote"
+    The stdout should include "could not read from remote"
+    The stderr should be present
+  End
+
+  # The latch in report_failure keeps a job that stays broken from filing a
+  # fresh to-do every night.
+  It "stays quiet while the sync keeps failing"
+    run_upgrade >/dev/null 2>&1 || true
+    When call run_upgrade
+    The status should equal 1
+    The result of function todo_filed should equal 1
+    The stderr should include "to-do already filed"
+  End
+End


### PR DESCRIPTION
A failing `dotfiles-sync` logged `sync failed` and exited 1. Nothing else. The only trace was the notification banner `git_sync_notify` raises, which fires at 3am against a locked Mac and is gone by morning. The install branch three lines below it already filed a Things to-do.

That asymmetry has a cost, and #607 is what surfaced it. The same locked-Mac SSH failure was hitting both nightly jobs, and it was visible for months on the Claude half, where `claude-upgrade` reports through `report_upgrade_failure`, while the dotfiles half failed silently. Nine to-dos told the story for one job. The other left nothing to read.

The sync output is now captured the way the install step already captures its own, and both branches route through one `report_log_failure` helper rather than repeating the revision lookup and the ANSI strip. The per-job latch in `report_failure` is unchanged, so a job that stays broken still files one to-do rather than one a night.

Covered by `scripts/spec/dotfiles_upgrade_spec.sh`, which stubs the sync into failing and asserts the to-do gets filed, carries the sync's own output, and isn't filed twice while the failure persists.

Independent of #607 and safe to merge in either order. Note that running this spec locally needs `--dangerously-skip-permissions` or an equivalent, because macOS `mktemp` ignores `TMPDIR` and writes to the Darwin per-user temp dir, which the agent sandbox denies. It passes normally on the Linux runner.
