### PR TITLE
worktrunk: stop the drift audit reporting deferrals

### DIFF
--- a/bin/worktree-prune
+++ b/bin/worktree-prune
@@ -33,14 +33,89 @@ gum log --level info "Worktree prune completed successfully"
 # when clean, so any output means the pruner missed something. Latched under
 # its own job name, so drift files a separate to-do from a prune failure and
 # a green prune with silent drift still surfaces.
+#
+# Raw mode keeps the "<repo>\t<branch>\t<reason>\t<path>" fields intact, so the
+# to-do can name each worktree and build a command that jumps straight to it.
 gum log --level info "Auditing for prune drift"
-"$DOTFILES_HOME/bin/wt-all" prune-audit 2>/dev/null \
+WT_ALL_RAW=1 "$DOTFILES_HOME/bin/wt-all" prune-audit 2>/dev/null \
   | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' \
   | grep -v '^[[:space:]]*$' >"$AUDIT_LOG" || true
 
 if [[ -s "$AUDIT_LOG" ]]; then
   gum log --level warn "prune drift detected"
-  report_failure "wt-prune-drift" "Worktree prune drift detected" "wt all prune-audit" "$(cat "$AUDIT_LOG")" "$revision"
+
+  # `wt all` reports each repo relative to the discovery root, so rebuild the
+  # absolute path the investigation commands need to cd into.
+  base="${PROJECTS:-$HOME/src}"
+
+  findings=""
+  investigate=""
+  integer leaked=0
+  while IFS=$'\t' read -r repo branch reason wtpath; do
+    [[ -n "$branch" ]] || continue
+    # Assignment rather than (( leaked++ )), whose result is the pre-increment
+    # value: on the first row that is 0, which this script's set -e reads as a
+    # failed command.
+    leaked=$(( leaked + 1 ))
+    repo_path="$repo"
+    [[ "$repo_path" == /* ]] || repo_path="$base/$repo"
+
+    findings+="$repo	$branch	$reason
+"
+    investigate+="# $repo — $branch ($reason)
+cd '$wtpath' && wt list && git log --oneline -5 && git status -sb
+cd '$repo_path'
+wt step prune --dry-run          # does the integration pass still see it?
+wt prune --dry-run --before      # what did wt-prune decide for it, and why?
+gh pr view '$branch' --json state,number,url   # what does the forge say?
+
+"
+  done <"$AUDIT_LOG"
+
+  # The leading blank line separates this from the host/time/revision list the
+  # reporter emits above it, so the first heading renders as one.
+  # Single-quoted on purpose: the backticks are markdown code spans in the
+  # to-do, and nothing here should expand.
+  # shellcheck disable=SC2016
+  explanation='
+## What this means
+
+The prune ran green and then failed its own audit. Every worktree below is
+integrated into its default branch or belongs to a merged PR, and the pruner
+left it in place. No later run picks these up on its own, so the backlog grows
+each night this fires.
+
+The pruner declines to touch a worktree for its first day, and the audit allows
+for that plus one more nightly run before reporting anything. Everything listed
+is past that window, so these are worktrees the pruner should have removed and
+did not.
+
+## What to do
+
+Fix the pruner. Removing these worktrees by hand clears the to-do and leaves
+the regression in place, and it fires again the next time a worktree lands in
+the same shape.
+
+Run the commands below. They open each leaked worktree, then re-run the two
+passes from its repo so you can see which one stopped matching. Common causes
+are `wt step prune` no longer detecting the integration and the forge lookup in
+`bin/wt-prune` returning nothing for the branch.'
+
+  noun="worktrees"
+  (( leaked == 1 )) && noun="worktree"
+
+  # Align the findings into columns. Command substitution strips the trailing
+  # blank line each accumulator picks up from its last append.
+  findings=$(print -r -- "$findings" | grep -v '^[[:space:]]*$' | column -t -s $'\t')
+  investigate=$(print -r -- "$investigate")
+
+  report_failure "wt-prune-drift" \
+    "Worktree prune leaked $leaked $noun" \
+    "$investigate" \
+    "$findings" \
+    "$revision" \
+    "$explanation" \
+    "Leaked worktrees"
 else
   report_success "wt-prune-drift"
   gum log --level info "No prune drift"

--- a/bin/worktree-prune
+++ b/bin/worktree-prune
@@ -12,7 +12,9 @@ source "${0:A:h}/../scripts/lib/report-failure.sh"
 
 PRUNE_LOG=$(mktemp)
 AUDIT_LOG=$(mktemp)
-trap 'rm -f "$PRUNE_LOG" "$AUDIT_LOG"' EXIT
+AUDIT_ERR=$(mktemp)
+AUDIT_RAW=$(mktemp)
+trap 'rm -f "$PRUNE_LOG" "$AUDIT_LOG" "$AUDIT_ERR" "$AUDIT_RAW"' EXIT
 
 revision=$(git -C "$DOTFILES_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
@@ -37,9 +39,30 @@ gum log --level info "Worktree prune completed successfully"
 # Raw mode keeps the "<repo>\t<branch>\t<reason>\t<path>" fields intact, so the
 # to-do can name each worktree and build a command that jumps straight to it.
 gum log --level info "Auditing for prune drift"
-WT_ALL_RAW=1 "$DOTFILES_HOME/bin/wt-all" prune-audit 2>/dev/null \
-  | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' \
+# Captured in two steps rather than one pipeline: `|| true` resets $pipestatus,
+# so the audit's own exit status has to be taken before anything else runs.
+audit_rc=0
+WT_ALL_RAW=1 "$DOTFILES_HOME/bin/wt-all" prune-audit \
+  >"$AUDIT_RAW" 2>"$AUDIT_ERR" || audit_rc=$?
+sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' <"$AUDIT_RAW" \
   | grep -v '^[[:space:]]*$' >"$AUDIT_LOG" || true
+
+# A nonzero status means repos failed the audit outright, so their worktrees
+# were never examined. Reported on its own, because "the oracle could not look"
+# reads identically to "the oracle found nothing" once it reaches the latch.
+if (( audit_rc != 0 )); then
+  gum log --level error "prune audit failed"
+  report_failure "wt-prune-audit-failed" \
+    "Worktree prune audit could not run" \
+    "wt all prune-audit" \
+    "$(tail -n 100 "$AUDIT_ERR" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')" \
+    "$revision" \
+    '
+The drift tripwire itself failed in one or more repos. Until it runs clean it
+cannot report a leak, so a silent prune regression would go unnoticed.'
+else
+  report_success "wt-prune-audit-failed"
+fi
 
 if [[ -s "$AUDIT_LOG" ]]; then
   gum log --level warn "prune drift detected"
@@ -48,26 +71,30 @@ if [[ -s "$AUDIT_LOG" ]]; then
   # absolute path the investigation commands need to cd into.
   base="${PROJECTS:-$HOME/src}"
 
-  findings=""
+  # The guard the nightly run applies, so the commands in the to-do reproduce
+  # what actually happened rather than worktrunk's default.
+  min_age="${WT_PRUNE_MIN_AGE:-1d}"
+
+  finding_rows=()
   investigate=""
-  integer leaked=0
   while IFS=$'\t' read -r repo branch reason wtpath; do
     [[ -n "$branch" ]] || continue
-    # Assignment rather than (( leaked++ )), whose result is the pre-increment
-    # value: on the first row that is 0, which this script's set -e reads as a
-    # failed command.
-    leaked=$(( leaked + 1 ))
     repo_path="$repo"
     [[ "$repo_path" == /* ]] || repo_path="$base/$repo"
 
-    findings+="$repo	$branch	$reason
-"
-    investigate+="# $repo — $branch ($reason)
+    finding_rows+=("$repo"$'\t'"$branch"$'\t'"$reason")
+    investigate+="## $repo: $branch ($reason)
 cd '$wtpath' && wt list && git log --oneline -5 && git status -sb
+
 cd '$repo_path'
-wt step prune --dry-run          # does the integration pass still see it?
-wt prune --dry-run --before      # what did wt-prune decide for it, and why?
-gh pr view '$branch' --json state,number,url   # what does the forge say?
+# Does the integration pass still see it?
+wt step prune --dry-run --min-age '$min_age'
+# What did wt-prune decide for it, and why?
+wt prune --dry-run --before
+# What does the forge say?
+gh pr view '$branch' --json state,number,url
+# Does the oracle still flag it?
+wt prune-audit
 
 "
   done <"$AUDIT_LOG"
@@ -101,21 +128,37 @@ passes from its repo so you can see which one stopped matching. Common causes
 are `wt step prune` no longer detecting the integration and the forge lookup in
 `bin/wt-prune` returning nothing for the branch.'
 
-  noun="worktrees"
-  (( leaked == 1 )) && noun="worktree"
+  leaked=${#finding_rows}
+  if (( leaked == 0 )); then
+    # The audit wrote something no field parser recognized. Filing a "leaked 0"
+    # to-do would latch the job and suppress the next real drift, so surface the
+    # unparsed text itself and leave the drift latch alone.
+    gum log --level error "prune audit output could not be parsed"
+    report_failure "wt-prune-audit-failed" \
+      "Worktree prune audit output could not be parsed" \
+      "WT_ALL_RAW=1 wt all prune-audit" \
+      "$(cat "$AUDIT_LOG")" \
+      "$revision" \
+      '
+The audit produced output, but no line of it parsed as a finding. The tripwire
+cannot report a leak until the format matches what the nightly job reads.'
+  else
+    noun="worktrees"
+    (( leaked == 1 )) && noun="worktree"
 
-  # Align the findings into columns. Command substitution strips the trailing
-  # blank line each accumulator picks up from its last append.
-  findings=$(print -r -- "$findings" | grep -v '^[[:space:]]*$' | column -t -s $'\t')
-  investigate=$(print -r -- "$investigate")
+    # Command substitution strips the trailing blank line the block accumulator
+    # picks up from its last append.
+    findings=$(print -rl -- "${finding_rows[@]}" | column -t -s $'\t')
+    investigate=$(print -r -- "$investigate")
 
-  report_failure "wt-prune-drift" \
-    "Worktree prune leaked $leaked $noun" \
-    "$investigate" \
-    "$findings" \
-    "$revision" \
-    "$explanation" \
-    "Leaked worktrees"
+    report_failure "wt-prune-drift" \
+      "Worktree prune leaked $leaked $noun" \
+      "$investigate" \
+      "$findings" \
+      "$revision" \
+      "$explanation" \
+      "Leaked worktrees"
+  fi
 else
   report_success "wt-prune-drift"
   gum log --level info "No prune drift"

--- a/bin/wt-all
+++ b/bin/wt-all
@@ -13,6 +13,9 @@
 # Repos whose command produces no output are skipped in the report, so
 # `wt all prune` shows only repos with something to remove, one line each, then
 # a totals trailer. A wrapped command can opt into a terse summary via $WT_ALL.
+#
+# Output is an aligned table by default. Set $WT_ALL_RAW to get the underlying
+# "<repo>\t<line>" rows instead, for a caller that parses the fields.
 
 set -uo pipefail
 
@@ -82,7 +85,9 @@ main () {
   local base="${PROJECTS:-$HOME/src}/"
   integer active=0 worktrees=0 branches=0
   local -a rows failed failed_errs
-  local repo key disp out
+  # outline is declared here rather than in the loop: re-declaring a parameter
+  # that already holds a value makes zsh echo it, which would land in the table.
+  local repo key disp out outline
   for repo in "${repos[@]}"; do
     key="${repo//\%/%25}"; key="${key//\//%2F}"
     disp="${repo#$base}"
@@ -95,10 +100,15 @@ main () {
     out="$(<"$dir/$key")"
     [[ -z "$out" ]] && continue
     (( active++ ))
-    # Each repo's output becomes a row keyed by repo. A wrapped command can emit
-    # tab-separated fields to land in their own columns; `wt prune` emits
-    # "<worktrees>\t<branches>", which we also total below.
-    rows+=("$disp"$'\t'"$out")
+    # Each line of a repo's output becomes a row keyed by that repo. A wrapped
+    # command can emit tab-separated fields to land in their own columns; `wt
+    # prune` emits "<worktrees>\t<branches>", which we also total below.
+    # Keying every line matters for commands like prune-audit that report one
+    # line per finding: prefixing only the first leaves the rest looking like
+    # they belong to whatever repo `column` happens to align them under.
+    for outline in "${(@f)out}"; do
+      rows+=("$disp"$'\t'"$outline")
+    done
     if [[ "$out" == <->$'\t'<-> ]]; then
       (( worktrees += ${out%%$'\t'*} ))
       (( branches  += ${out##*$'\t'} ))
@@ -106,7 +116,12 @@ main () {
   done
 
   if (( ${#rows} )); then
-    if [[ "${wtcmd[1]}" == prune ]]; then
+    if [[ -n "${WT_ALL_RAW:-}" ]]; then
+      # Tab-separated rows, no header and no alignment padding, for callers that
+      # parse the fields rather than read them. `column -t` collapses the tabs,
+      # so the aligned table cannot be split back into fields.
+      print -rl -- "${rows[@]}"
+    elif [[ "${wtcmd[1]}" == prune ]]; then
       # Prune emits "<worktrees>\t<branches>"; head it and sort by worktree
       # count (then branches) so the biggest cleanups sort to the top.
       {
@@ -122,7 +137,9 @@ main () {
   (( ${#failed} )) && summary+=("${#failed} failed")
   (( worktrees || branches )) && summary+=("$worktrees worktrees, $branches branches")
 
-  print
+  # The spacer separates the table from the summary for a reader. Raw output is
+  # parsed field by field, so it gets rows and nothing else.
+  [[ -n "${WT_ALL_RAW:-}" ]] || print
   gum log --level info "${(j: · :)summary}"
   if (( ${#failed} )); then
     gum log --level warn "failed: ${(j:, :)failed}"

--- a/bin/wt-all
+++ b/bin/wt-all
@@ -107,6 +107,9 @@ main () {
     # line per finding: prefixing only the first leaves the rest looking like
     # they belong to whatever repo `column` happens to align them under.
     for outline in "${(@f)out}"; do
+      # A blank line inside a command's output separates records. Keyed to the
+      # repo it would become a row with no fields.
+      [[ -n "$outline" ]] || continue
       rows+=("$disp"$'\t'"$outline")
     done
     if [[ "$out" == <->$'\t'<-> ]]; then
@@ -143,7 +146,10 @@ main () {
   gum log --level info "${(j: · :)summary}"
   if (( ${#failed} )); then
     gum log --level warn "failed: ${(j:, :)failed}"
-    (( ${#failed_errs} )) && print -rl -- "${failed_errs[@]}"
+    # Diagnostics go to stderr, alongside the gum summary they belong to. On
+    # stdout this free-form text would land in a raw consumer's field parser as
+    # rows that are not rows.
+    (( ${#failed_errs} )) && print -rl -- "${failed_errs[@]}" >&2
   fi
 
   (( ${#failed} == 0 ))

--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -30,6 +30,9 @@ set -uo pipefail
 # Suppress zsh's default of echoing a parameter when `local`/`typeset` re-declares
 # one that already holds a value (e.g. `branch`, reused across both read loops).
 setopt typeset_silent
+# $EPOCHSECONDS, so the age helper reads the clock without forking `date` once
+# per candidate worktree across the fleet sweep.
+zmodload zsh/datetime
 
 # `wt step prune` refuses to remove a worktree younger than this, because a
 # worktree just branched off main points at main's commit and so reads as
@@ -53,11 +56,16 @@ parse_duration () {
   esac
 }
 
-# Seconds since a worktree was created, on the same clock worktrunk's
-# --min-age guard uses: the birth time of the per-worktree git dir. Returns
-# nonzero when the path is gone or the filesystem reports no birth time, and
-# callers read that as "old enough", matching how worktrunk treats an age it
-# cannot resolve.
+# Seconds since a worktree was created, on the same clock worktrunk's --min-age
+# guard uses: the birth time of the per-worktree git dir, falling back to the
+# mtime of the commondir file inside it. Both steps mirror worktrunk's own
+# worktree_age (src/commands/step/prune.rs), so the two agree about which
+# worktrees are too young to touch. Filesystems that record no birth time
+# report 0, which is why the commondir fallback carries them.
+#
+# Returns nonzero only when the path is gone or neither clock reads, and
+# callers treat that as "old enough", matching worktrunk's handling of an age
+# it cannot resolve.
 #
 # `wt list` carries only the tip commit's timestamp, which is main's tip for a
 # worktree that has no commits of its own. Age derived from it says nothing
@@ -65,13 +73,21 @@ parse_duration () {
 worktree_age_secs () {
   # Not `path`: zsh ties that name to $PATH, so a local declaration of it would
   # empty the command search path for the whole function and lose `git`.
-  local wt_path=$1 gitdir birth
+  local wt_path=$1 gitdir created
   gitdir=$(git -C "$wt_path" rev-parse --absolute-git-dir 2>/dev/null) || return 1
-  # %B is the BSD/macOS birth time; %W is the GNU coreutils spelling, which
-  # reports 0 on filesystems that do not record one.
-  birth=$(stat -f %B "$gitdir" 2>/dev/null) || birth=$(stat -c %W "$gitdir" 2>/dev/null) || return 1
-  [[ "$birth" == <-> ]] && (( birth > 0 )) || return 1
-  print -r -- $(( $(date +%s) - birth ))
+
+  # BSD stat takes the format as an argument to -f. GNU stat spells the same
+  # field %W under -c and reads a -f argument as a filename, so it exits
+  # nonzero and hands off to the next call.
+  created=$(stat -f %B "$gitdir" 2>/dev/null) || created=$(stat -c %W "$gitdir" 2>/dev/null) || created=
+  if [[ "$created" != <-> ]] || (( created == 0 )); then
+    created=$(stat -f %m "$gitdir/commondir" 2>/dev/null) \
+      || created=$(stat -c %Y "$gitdir/commondir" 2>/dev/null) \
+      || return 1
+  fi
+
+  [[ "$created" == <-> ]] && (( created > 0 )) || return 1
+  print -r -- $(( EPOCHSECONDS - created ))
 }
 
 # Resolve the exact PR/MR state for a branch on the forge. Prints
@@ -162,6 +178,18 @@ main () {
       -i|--interactive)
         interactive=1
         ;;
+      # Consumed rather than forwarded: main appends --min-age itself, and
+      # `wt step prune` rejects the flag given twice.
+      --min-age)
+        local mn="${argv[i+1]:-}"
+        if [[ -n "$mn" && "$mn" != -* ]]; then
+          WT_PRUNE_MIN_AGE="$mn"
+          (( i++ ))
+        fi
+        ;;
+      --min-age=*)
+        WT_PRUNE_MIN_AGE="${a#*=}"
+        ;;
       --before)
         before_enabled=1
         local nxt="${argv[i+1]:-}"
@@ -237,8 +265,6 @@ main () {
     local remote_host
     remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
 
-    integer now=0
-    (( before_enabled )) && now=$(date +%s)
     local branch is_main ts clean onremote is_current wtpath pr_out pr_st pr_num
     while IFS=$'\t' read -r branch is_main ts clean onremote is_current wtpath; do
       [[ "$is_main" == true ]] && continue
@@ -253,8 +279,14 @@ main () {
 
       # The age pass is consulted only under --before. Interactive ignores it
       # and defers aged candidates to the checklist, so mask before there.
+      #
+      # FIXME: ts is the tip commit's timestamp, not the worktree's. A worktree
+      # branched off an old main inherits that tip, so a checkout created
+      # minutes ago can read as older than the threshold and age out the same
+      # night. worktree_age_secs is the right clock here; switching to it
+      # changes what this pass removes, so it is left for its own change.
       integer age_exceeded=0
-      (( before_enabled && now - ts >= before_secs )) && age_exceeded=1
+      (( before_enabled && EPOCHSECONDS - ts >= before_secs )) && age_exceeded=1
       integer classify_before=before_enabled
       (( interactive )) && classify_before=0
 

--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -8,6 +8,11 @@
 # tree. Resolving per survivor (not a capped bulk list) catches PRs that merged
 # outside the recent window.
 #
+# The integration pass leaves worktrees younger than $WT_PRUNE_MIN_AGE alone,
+# since a worktree branched off main reads as integrated before any work lands
+# in it. The forge pass has no such guard and does not need one: a MERGED PR is
+# proof the work is done however new the checkout is.
+#
 # Age pass (--before [DURATION], default 1mo): removes old, clean worktree
 # directories that aren't integrated anywhere, to clear out stale checkouts. It
 # keeps the branch (so committed work is recoverable) and skips worktrees with
@@ -26,6 +31,14 @@ set -uo pipefail
 # one that already holds a value (e.g. `branch`, reused across both read loops).
 setopt typeset_silent
 
+# `wt step prune` refuses to remove a worktree younger than this, because a
+# worktree just branched off main points at main's commit and so reads as
+# integrated before any work happens in it. Set explicitly rather than left to
+# worktrunk's default: wt-prune-audit sources this file to honor the same
+# deferral, and an oracle that does not model the guard reports every worktree
+# created since the last run as drift.
+: ${WT_PRUNE_MIN_AGE:=1d}
+
 # Convert a duration like 2w / 30d / 1mo into seconds. Returns nonzero on a
 # spec it doesn't understand so callers can fall back to a default.
 parse_duration () {
@@ -38,6 +51,27 @@ parse_duration () {
     mo) print -r -- $(( n * 2592000 ));;
     y)  print -r -- $(( n * 31536000 ));;
   esac
+}
+
+# Seconds since a worktree was created, on the same clock worktrunk's
+# --min-age guard uses: the birth time of the per-worktree git dir. Returns
+# nonzero when the path is gone or the filesystem reports no birth time, and
+# callers read that as "old enough", matching how worktrunk treats an age it
+# cannot resolve.
+#
+# `wt list` carries only the tip commit's timestamp, which is main's tip for a
+# worktree that has no commits of its own. Age derived from it says nothing
+# about when the worktree appeared.
+worktree_age_secs () {
+  # Not `path`: zsh ties that name to $PATH, so a local declaration of it would
+  # empty the command search path for the whole function and lose `git`.
+  local wt_path=$1 gitdir birth
+  gitdir=$(git -C "$wt_path" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+  # %B is the BSD/macOS birth time; %W is the GNU coreutils spelling, which
+  # reports 0 on filesystems that do not record one.
+  birth=$(stat -f %B "$gitdir" 2>/dev/null) || birth=$(stat -c %W "$gitdir" 2>/dev/null) || return 1
+  [[ "$birth" == <-> ]] && (( birth > 0 )) || return 1
+  print -r -- $(( $(date +%s) - birth ))
 }
 
 # Resolve the exact PR/MR state for a branch on the forge. Prints
@@ -161,7 +195,7 @@ main () {
   # background cleanup, so counting from it under-counts.
   local -a probe_args=("${passthrough[@]:#--dry-run}")
   local probe_json
-  probe_json=$(wt step prune "${probe_args[@]}" --dry-run --format=json 2>/dev/null)
+  probe_json=$(wt step prune "${probe_args[@]}" --min-age "$WT_PRUNE_MIN_AGE" --dry-run --format=json 2>/dev/null)
 
   local -A seen
   local worktrees=0 branches=0
@@ -176,7 +210,7 @@ main () {
   # Real run: actually remove. --yes skips approval prompts and --foreground
   # blocks until removal completes, both required under the non-interactive
   # parallel fan-out and the nightly job.
-  (( dry_run )) || wt step prune "${probe_args[@]}" --yes --foreground </dev/null >/dev/null 2>&1
+  (( dry_run )) || wt step prune "${probe_args[@]}" --min-age "$WT_PRUNE_MIN_AGE" --yes --foreground </dev/null >/dev/null 2>&1
 
   # Linked-worktree pass over a single `wt list`: exact forge-state removals,
   # plus the age pass (non-interactive) or candidate collection for the

--- a/bin/wt-prune-audit
+++ b/bin/wt-prune-audit
@@ -33,10 +33,32 @@ set -uo pipefail
 # is this script's path even when invoked by `wt`.
 source "${0:A:h}/wt-prune"
 
-# One nightly run interval on top of the pruner's own guard.
-: ${WT_PRUNE_DRIFT_GRACE:=$(( $(parse_duration "$WT_PRUNE_MIN_AGE") + 86400 ))}
+# Grace, in seconds. $WT_PRUNE_DRIFT_GRACE overrides it and takes the same
+# duration grammar as $WT_PRUNE_MIN_AGE (2h, 1d, 1w, 1mo, 1y); the default is
+# the pruner's guard plus one nightly run interval. Prints nothing and returns
+# nonzero on a spec parse_duration does not understand, because a silently
+# wrong grace either buries real drift or restores the false positives the
+# grace period exists to stop.
+grace_secs () {
+  local secs
+  if [[ -n "${WT_PRUNE_DRIFT_GRACE:-}" ]]; then
+    parse_duration "$WT_PRUNE_DRIFT_GRACE"
+    return
+  fi
+  secs=$(parse_duration "$WT_PRUNE_MIN_AGE") || return 1
+  print -r -- $(( secs + 86400 ))
+}
 
 main () {
+  local grace
+  # A misconfigured duration returns nonzero, which flags the repo as failed
+  # under `wt all` and puts the reason in front of someone. Every other exit
+  # from this script is 0 so that findings, not status, signal drift.
+  if ! grace=$(grace_secs); then
+    print -u2 -- "wt prune-audit: cannot parse WT_PRUNE_MIN_AGE=${WT_PRUNE_MIN_AGE} WT_PRUNE_DRIFT_GRACE=${WT_PRUNE_DRIFT_GRACE:-}"
+    return 1
+  fi
+
   local list_json
   list_json=$(wt list --format=json 2>/dev/null)
   [[ -n "$list_json" && "$list_json" != "[]" ]] || return 0
@@ -60,14 +82,18 @@ main () {
     # filesystem cannot report counts as old enough, so an unreadable clock
     # never hides drift.
     if [[ "$main_state" == empty || "$main_state" == integrated ]]; then
-      age=$(worktree_age_secs "$wtpath") || age=$WT_PRUNE_DRIFT_GRACE
-      (( age >= WT_PRUNE_DRIFT_GRACE )) \
-        && print -r -- "$branch"$'\t'"integrated ($main_state)"$'\t'"$wtpath"
-      continue
+      age=$(worktree_age_secs "$wtpath") || age=$grace
+      if (( age >= grace )); then
+        print -r -- "$branch"$'\t'"integrated ($main_state)"$'\t'"$wtpath"
+        continue
+      fi
+      # Still inside grace on the integration rule. Fall through to the forge:
+      # a merged PR is removed at any age, so grace does not apply to it and a
+      # young merged worktree that survived the prune is still a real miss.
     fi
 
-    # Otherwise pay for one forge lookup: a MERGED PR that still has a worktree
-    # is exactly the historical backlog this tripwire guards against.
+    # One forge lookup: a MERGED PR that still has a worktree is exactly the
+    # historical backlog this tripwire guards against.
     pr_out=$(pr_state "$branch" "$remote_host")
     IFS=$'\t' read -r pr_st _ <<<"$pr_out"
     [[ "$pr_st" == MERGED ]] \

--- a/bin/wt-prune-audit
+++ b/bin/wt-prune-audit
@@ -6,19 +6,35 @@
 # skipped pass). It is deliberately simpler than the pruner and does not share
 # its decision code: it reuses only pr_state, sourced from bin/wt-prune.
 #
-# Prints "<branch>\t<reason>" for each linked, non-current worktree that a
-# healthy prune should already have removed:
-#   - main_state is empty/integrated: `wt list` already knows the work landed
-#     into the default branch, so no forge call is needed.
+# Prints "<branch>\t<reason>\t<path>" for each linked, non-current worktree that
+# a healthy prune should already have removed:
+#   - main_state is empty/integrated and the worktree has outlived the grace
+#     period: `wt list` already knows the work landed into the default branch,
+#     so no forge call is needed.
 #   - otherwise the branch has a MERGED PR that outlived the prune.
 # Prints nothing when there is no drift. Dispatched fleet-wide via
 # `wt all prune-audit`, so a clean repo emits nothing and is skipped.
+#
+# The grace period is what keeps the oracle honest about the pruner's own
+# rules. `wt step prune` declines to touch a worktree younger than
+# $WT_PRUNE_MIN_AGE, so anything created since the last nightly run is a
+# deliberate deferral. Grace covers that guard plus one run interval, so a
+# worktree only counts as drift once a run that could have removed it has come
+# and gone. Without it every same-day worktree files a to-do that resolves
+# itself overnight, and the signal stops meaning anything.
+#
+# The MERGED rule needs no grace: the pruner's forge pass removes a merged
+# worktree at any age, so one that survives is a genuine miss.
 
 set -uo pipefail
 
-# Sourcing defines pr_state without running the prune (guarded on
-# ZSH_EVAL_CONTEXT). $0 is this script's path even when invoked by `wt`.
+# Sourcing defines pr_state, worktree_age_secs, parse_duration, and
+# WT_PRUNE_MIN_AGE without running the prune (guarded on ZSH_EVAL_CONTEXT). $0
+# is this script's path even when invoked by `wt`.
 source "${0:A:h}/wt-prune"
+
+# One nightly run interval on top of the pruner's own guard.
+: ${WT_PRUNE_DRIFT_GRACE:=$(( $(parse_duration "$WT_PRUNE_MIN_AGE") + 86400 ))}
 
 main () {
   local list_json
@@ -36,12 +52,17 @@ main () {
   local remote_host
   remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
 
-  local branch main_state pr_out pr_st
-  while IFS=$'\t' read -r branch main_state; do
+  local branch main_state wtpath age pr_out pr_st
+  while IFS=$'\t' read -r branch main_state wtpath; do
     # Free signal: `wt list` already resolved this as integrated into the
-    # default branch, so a healthy prune would have removed it.
+    # default branch, so a healthy prune would have removed it, once the
+    # worktree is old enough for the pruner to consider it at all. An age the
+    # filesystem cannot report counts as old enough, so an unreadable clock
+    # never hides drift.
     if [[ "$main_state" == empty || "$main_state" == integrated ]]; then
-      print -r -- "$branch"$'\t'"integrated ($main_state)"
+      age=$(worktree_age_secs "$wtpath") || age=$WT_PRUNE_DRIFT_GRACE
+      (( age >= WT_PRUNE_DRIFT_GRACE )) \
+        && print -r -- "$branch"$'\t'"integrated ($main_state)"$'\t'"$wtpath"
       continue
     fi
 
@@ -49,11 +70,12 @@ main () {
     # is exactly the historical backlog this tripwire guards against.
     pr_out=$(pr_state "$branch" "$remote_host")
     IFS=$'\t' read -r pr_st _ <<<"$pr_out"
-    [[ "$pr_st" == MERGED ]] && print -r -- "$branch"$'\t'"merged PR survived"
+    [[ "$pr_st" == MERGED ]] \
+      && print -r -- "$branch"$'\t'"merged PR survived"$'\t'"$wtpath"
   done < <(jq -r '
     .[]
     | select(.kind == "worktree" and (.is_main | not) and (.is_current | not) and ((.branch // "") != ""))
-    | [ .branch, (.main_state // "") ] | @tsv' <<<"$list_json")
+    | [ .branch, (.main_state // ""), .path ] | @tsv' <<<"$list_json")
 
   # Drift is signalled by the printed violator lines, not by exit status: under
   # `wt all`, a nonzero return would flag the repo as failed rather than as

--- a/scripts/lib/report-failure.sh
+++ b/scripts/lib/report-failure.sh
@@ -4,7 +4,7 @@
 # notify <title> <message> [sound]
 #   Darwin-guarded osascript notification (default sound: Basso).
 #
-# report_failure <job> <title> <command> <output> <revision> [extra_meta]
+# report_failure <job> <title> <command> <output> <revision> [extra_meta] [output_heading]
 #   File a Things to-do describing the failure and notify, but only on the
 #   transition into a failed state. A per-job latch under
 #   ${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/<job>.status records ok
@@ -12,7 +12,9 @@
 #   to-dos. report_success resets it so the next break files a fresh one.
 #   <command> is the shell snippet shown in the to-do for reproduction;
 #   <output> is the captured log; <extra_meta> is optional extra metadata
-#   markdown appended to the host/time/revision header.
+#   markdown appended to the host/time/revision header; <output_heading> names
+#   the section holding <output>, for a job whose output is a finding list
+#   rather than an error (default: "Error Output").
 #
 # report_success <job>
 #   Clear the latch.
@@ -45,6 +47,7 @@ report_failure() {
   local output="$4"
   local revision="$5"
   local extra_meta="$6"
+  local output_heading="${7:-Error Output}"
 
   local status_file prior
   status_file=$(report_status_file "$job")
@@ -75,7 +78,7 @@ report_failure() {
 '"$command"'
 ```
 
-## Error Output
+## '"$output_heading"'
 ```
 '"$output"'
 ```'

--- a/worktrunk/spec/wt_prune_spec.sh
+++ b/worktrunk/spec/wt_prune_spec.sh
@@ -79,10 +79,12 @@ Describe "wt-prune --dry-run and wt-prune-audit (black-box)"
     stubdir="$sandbox/stub"
     export WT_LIST_JSON="$sandbox/list.json"
     export WT_REMOVE_LOG="$sandbox/removed.log"
+    export WT_STEP_LOG="$sandbox/step.log"
     export PR_STATE_FILE="$sandbox/pr_state"
     rm -rf "$sandbox"
     mkdir -p "$stubdir"
     : >"$WT_REMOVE_LOG"
+    : >"$WT_STEP_LOG"
 
     # wt stub: `step prune` probe reports nothing integrated (so the survivor
     # reaches the forge pass); `list` emits the canned fixture; `remove` only
@@ -90,7 +92,7 @@ Describe "wt-prune --dry-run and wt-prune-audit (black-box)"
     cat >"$stubdir/wt" <<'WT'
 #!/usr/bin/env bash
 case "$1" in
-  step)   echo "[]" ;;
+  step)   printf 'step %s\n' "$*" >>"$WT_STEP_LOG"; echo "[]" ;;
   list)   cat "$WT_LIST_JSON" ;;
   remove) printf 'remove %s\n' "$*" >>"$WT_REMOVE_LOG" ;;
 esac
@@ -122,6 +124,13 @@ GH
     git -C "$repo" -c user.email=test@example.com -c user.name=test \
       commit -q --allow-empty -m init
     git -C "$repo" remote add origin "https://github.com/test/repo.git"
+
+    # A real linked worktree, so the age helper resolves a per-worktree git dir
+    # (a .git *file* pointing at .git/worktrees/<name>) rather than the repo's
+    # own .git. Reading the repo's dir instead would date every worktree to the
+    # clone, which the fixture must be able to tell apart.
+    linked="$sandbox/linked"
+    git -C "$repo" worktree add -q -b fresh "$linked" 2>/dev/null
 
     printf 'MERGED' >"$PR_STATE_FILE"
   }
@@ -222,16 +231,16 @@ JSON
       "$(printf 'agent-x\tintegrated (integrated)\t/repo/.worktrees/agent-x')"
   End
 
-  # The regression the grace period exists for. `wt step prune` skips a worktree
-  # for its first day, because one branched off main reads as integrated before
-  # any work lands in it. An oracle blind to that guard reports every worktree
-  # created since the previous run, and the nightly to-do stops carrying signal.
+  # wt step prune skips a worktree for its first day, because one branched off
+  # main reads as integrated before any work lands in it. Without the grace
+  # period the audit reports every worktree created since the previous run.
   # $repo is created fresh in setup, so its git dir dates from moments ago.
   It "audit ignores an integrated worktree still inside the grace period"
+    : >"$PR_STATE_FILE"
     cat >"$WT_LIST_JSON" <<JSON
 [
   {"kind":"worktree","branch":"fresh","is_main":false,"is_current":false,
-   "path":"$repo","main_state":"empty","commit":{"timestamp":0},
+   "path":"$linked","main_state":"empty","commit":{"timestamp":0},
    "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
    "remote":null}
 ]
@@ -241,20 +250,71 @@ JSON
     The output should equal ""
   End
 
-  # Shrinking grace to zero must bring the same worktree back, pinning the skip
-  # above to the age check rather than to the fixture being filtered elsewhere.
+  # Shrinking grace to zero must bring the same worktree back, confirming the
+  # skip above came from the age check.
   It "audit flags that same worktree once the grace period is zero"
     cat >"$WT_LIST_JSON" <<JSON
 [
   {"kind":"worktree","branch":"fresh","is_main":false,"is_current":false,
-   "path":"$repo","main_state":"empty","commit":{"timestamp":0},
+   "path":"$linked","main_state":"empty","commit":{"timestamp":0},
    "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
    "remote":null}
 ]
 JSON
-    When call run_audit_grace 0
+    When call run_audit_grace 0h
     The status should be success
-    The line 1 of output should equal "$(printf 'fresh\tintegrated (empty)\t%s' "$repo")"
+    The line 1 of output should equal "$(printf 'fresh\tintegrated (empty)\t%s' "$linked")"
+  End
+
+  # The coupling the whole design rests on: the audit models a guard the pruner
+  # must actually be applying. Drop the flag and the two disagree silently.
+  It "passes the configured min-age through to wt step prune"
+    fixture_merged_survivor
+    When call run_prune --dry-run
+    The status should be success
+    The output should include "feature-x"
+    The contents of file "$WT_STEP_LOG" should include "--min-age 1d"
+  End
+
+  # An override has to reach the binary too, or the audit's grace is derived
+  # from a value the pruner never saw.
+  It "forwards an overridden min-age exactly once"
+    fixture_merged_survivor
+    When call run_prune --dry-run --min-age 3d
+    The status should be success
+    The output should include "feature-x"
+    The contents of file "$WT_STEP_LOG" should include "--min-age 3d"
+    The contents of file "$WT_STEP_LOG" should not include "--min-age 1d"
+  End
+
+  # Grace defers the integration rule only. A merged PR is removed at any age,
+  # so a young worktree whose PR merged is still a real miss and the forge check
+  # has to run even while the integration rule is inside its grace window.
+  It "still reports a merged PR on a worktree inside the grace period"
+    printf 'MERGED' >"$PR_STATE_FILE"
+    cat >"$WT_LIST_JSON" <<JSON
+[
+  {"kind":"worktree","branch":"fresh","is_main":false,"is_current":false,
+   "path":"$linked","main_state":"integrated","commit":{"timestamp":0},
+   "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
+   "remote":null}
+]
+JSON
+    When call run_audit
+    The status should be success
+    The line 1 of output should equal \
+      "$(printf 'fresh\tmerged PR survived\t%s' "$linked")"
+  End
+
+  # A grace spelling parse_duration cannot read must stop the audit rather than
+  # silently fall back, which would either bury drift or restore the false
+  # positives the grace period exists to remove.
+  It "fails loudly on an unparseable grace duration"
+    fixture_merged_survivor
+    When call run_audit_grace 30min
+    The status should equal 1
+    The stderr should include "cannot parse"
+    The output should equal ""
   End
 
   It "audit stays silent when the survivor's PR is still open"

--- a/worktrunk/spec/wt_prune_spec.sh
+++ b/worktrunk/spec/wt_prune_spec.sh
@@ -148,6 +148,9 @@ JSON
   # reorders PATH, pushing $stubdir below a real wt/gh and shadowing the stubs.
   run_prune() { ( cd "$repo" && PATH="$stubdir:$PATH" zsh -f "$wtprune" "$@" ); }
   run_audit() { ( cd "$repo" && PATH="$stubdir:$PATH" zsh -f "$wtaudit" ); }
+  run_audit_grace() {
+    ( cd "$repo" && PATH="$stubdir:$PATH" WT_PRUNE_DRIFT_GRACE="$1" zsh -f "$wtaudit" )
+  }
 
   It "dry-run prints a reasons table and removes nothing"
     fixture_merged_survivor
@@ -191,14 +194,19 @@ JSON
     The contents of file "$WT_REMOVE_LOG" should not include "force-delete"
   End
 
+  # A merged PR proves the work landed however new the checkout is, so the forge
+  # rule reports it without consulting the grace period.
   It "audit flags a merged survivor the prune left behind"
     fixture_merged_survivor
     printf 'MERGED' >"$PR_STATE_FILE"
     When call run_audit
     The status should be success
-    The line 1 of output should equal "$(printf 'feature-x\tmerged PR survived')"
+    The line 1 of output should equal \
+      "$(printf 'feature-x\tmerged PR survived\t/repo/.worktrees/feature-x')"
   End
 
+  # This fixture path does not exist, so the age is unresolvable. An unknown age
+  # counts as old enough, keeping a missing clock from masking real drift.
   It "audit flags an integrated survivor without a forge call"
     cat >"$WT_LIST_JSON" <<'JSON'
 [
@@ -210,7 +218,43 @@ JSON
 JSON
     When call run_audit
     The status should be success
-    The line 1 of output should equal "$(printf 'agent-x\tintegrated (integrated)')"
+    The line 1 of output should equal \
+      "$(printf 'agent-x\tintegrated (integrated)\t/repo/.worktrees/agent-x')"
+  End
+
+  # The regression the grace period exists for. `wt step prune` skips a worktree
+  # for its first day, because one branched off main reads as integrated before
+  # any work lands in it. An oracle blind to that guard reports every worktree
+  # created since the previous run, and the nightly to-do stops carrying signal.
+  # $repo is created fresh in setup, so its git dir dates from moments ago.
+  It "audit ignores an integrated worktree still inside the grace period"
+    cat >"$WT_LIST_JSON" <<JSON
+[
+  {"kind":"worktree","branch":"fresh","is_main":false,"is_current":false,
+   "path":"$repo","main_state":"empty","commit":{"timestamp":0},
+   "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
+   "remote":null}
+]
+JSON
+    When call run_audit
+    The status should be success
+    The output should equal ""
+  End
+
+  # Shrinking grace to zero must bring the same worktree back, pinning the skip
+  # above to the age check rather than to the fixture being filtered elsewhere.
+  It "audit flags that same worktree once the grace period is zero"
+    cat >"$WT_LIST_JSON" <<JSON
+[
+  {"kind":"worktree","branch":"fresh","is_main":false,"is_current":false,
+   "path":"$repo","main_state":"empty","commit":{"timestamp":0},
+   "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
+   "remote":null}
+]
+JSON
+    When call run_audit_grace 0
+    The status should be success
+    The line 1 of output should equal "$(printf 'fresh\tintegrated (empty)\t%s' "$repo")"
   End
 
   It "audit stays silent when the survivor's PR is still open"


### PR DESCRIPTION
The nightly drift tripwire has been filing to-dos for worktrees nothing was wrong with. `wt step prune` refuses to touch a worktree younger than its `--min-age` (default `1d`), because one branched off main points at main's commit and reads as integrated before any work lands in it. `bin/wt-prune-audit` modelled no such guard, so every worktree created since the previous 04:00 run tripped the oracle, filed a to-do, and was pruned quietly the next night once it aged past the guard.

Every drift to-do on this machine came from that mismatch. A sweep of all 103 repos, comparing `main_state` against the birth time of each worktree's git dir, found no worktree older than the guard in an integrated state. The oracle has been reporting deliberate deferrals and has never yet caught a real miss.

## The Guard

`$WT_PRUNE_MIN_AGE` is now set explicitly and passed to both `wt step prune` calls rather than left to worktrunk's default, so the value the audit models is the value the pruner applies. The audit honors it plus one run interval before calling a survivor drift, which is when a run that could have removed the worktree has come and gone.

`wt list --format=json` carries no worktree creation time, only the tip commit's timestamp, which for a worktree with no commits of its own is main's tip. `worktree_age_secs` reads the birth time of the per-worktree git dir instead, falling back to `commondir` mtime exactly as worktrunk's own `worktree_age` does, so the two agree on filesystems that record no birth time. An age neither clock resolves counts as old enough, so a missing clock cannot hide drift.

Grace covers the integration rule alone. A merged PR is removed at any age, so a young worktree whose PR merged still falls through to the forge check.

Asking `wt step prune --dry-run` what it would remove would be simpler and would need none of this. It also routes detection through the code the oracle exists to check, so a pruner that silently stopped detecting integration would take its own tripwire down with it. The duplication is the point.

## The To-Do

The old to-do carried a title, a bare `wt all prune-audit`, and a list of branch names under an "Error Output" heading. It never said that drift means the pruner is broken and leaking, that the leak grows until someone fixes it, or that clearing the worktrees by hand hides the regression rather than resolving it. It now says all three, names the count, and carries a runnable block per leaked worktree that opens the worktree and re-runs both prune passes and the forge lookup from its repo, with the run's actual `--min-age`.

`bin/wt-all` was keying only the first line of a repo's output to that repo, so `prune-audit`, which emits one line per finding, produced to-dos with branch names floating under whichever repo `column` aligned them beneath. Every line is keyed now, and `$WT_ALL_RAW` emits the underlying tab-separated rows for a caller that parses fields.

## Failure Modes Found in Review

Three states used to be indistinguishable from a clean run: the audit failing in some repos, the audit emitting text no field parses, and genuine silence. The first two now file their own to-do and leave the drift latch alone, so a broken oracle cannot read as "no drift" or suppress the next real report by latching itself. Building the findings table through `grep -v` was also killing the job outright, since grep exits 1 when it filters everything and `set -e` took the script down before anything was filed.

Smaller ones: `wt step prune` rejects a repeated `--min-age`, so appending it unconditionally broke `wt prune --min-age 0s`; an unparseable grace duration silently became 86400 through `$(( + 86400 ))`; and per-repo failure text went to stdout, the one stream raw mode promises is nothing but rows.

## Verification

`shellspec` covers the guard in both directions, the `--min-age` passthrough and an override reaching the binary once, the unparseable-grace exit, and the merged-inside-grace path. The grace fixtures use a real linked worktree, so a helper reading the repo's git dir rather than the worktree's no longer passes.

Beyond the suite: the fleet audit is silent across all 103 repos and reproduces the previous findings with `WT_PRUNE_DRIFT_GRACE=0h`; `wt prune --dry-run` decisions are unchanged; and the nightly job was driven end to end against stubs for the drift, unparseable-output, audit-failure, and clean paths, checking the generated to-do and the latch transitions in each.

## Left Alone

The `--before` age pass still measures age from `.commit.timestamp`, so a worktree created today off a repo whose main tip is older than a month can classify as aged out and be removed the same night. It keeps the branch, so committed work survives, but the checkout and any gitignored state do not. `worktree_age_secs` is the right clock and the swap is two lines. It changes what that pass removes, so it belongs in its own change with its own test, and the code carries a `FIXME` pointing at it.
