### PR TITLE
herdr: configure navigator roots and update checks

### DIFF
--- a/herdr/plugins/config/herdr-file-viewer/config.toml
+++ b/herdr/plugins/config/herdr-file-viewer/config.toml
@@ -1,0 +1,6 @@
+# Settings in herdr's own config.toml never reach a plugin.
+# https://github.com/smarzban/herdr-file-viewer/blob/main/docs/configuration.md
+
+# The installed version is the commit plugins.list pins, which Renovate moves.
+# A daily check can only ever announce a release this machine won't install.
+update_check = false

--- a/herdr/plugins/config/herdr-navigator/config.toml
+++ b/herdr/plugins/config/herdr-navigator/config.toml
@@ -1,0 +1,14 @@
+# Settings in herdr's own config.toml never reach a plugin.
+# https://github.com/thanhdat77/herdr-navigator#configuration
+
+[picker]
+# F5 on the update badge installs a GitHub release through herdr, and the next
+# herdr-lazy sync restores the commit plugins.list pins. Renovate moves that
+# pin, so the badge can only ever advertise a version this machine won't keep.
+check_updates = false
+
+# Repos live at ~/src/<org>/<repo>. max_depth's default of 3 reaches that second
+# level. The shipped roots find nothing here: ~/workspace does not exist, and
+# ~/projects holds ML model checkouts rather than work.
+[[roots]]
+path = "~/src"


### PR DESCRIPTION
Stacked on #608, which makes `herdr/plugins/config/` the live plugin config tree.

herdr-navigator writes a generated default config on first run, and its roots are wrong for this machine. `~/workspace` does not exist. `~/projects` holds ML model checkouts. Every repo here is `~/src/<org>/<repo>`, so one root at `~/src` replaces both, and `max_depth` stays unset because its default of 3 is what reaches that second level. `herdr-navigator list` run against this file finds 120 repos there and nothing under the old roots.

Both plugins also run their own update check. Neither can lead anywhere: the installed version is the commit `plugins.list` pins, Renovate moves that pin, and herdr-lazy's sync restores it if navigator's F5 installs a release. That is the reason `herdr/config.toml` already gives for turning herdr's own `version_check` off. The file viewer's `?` overlay reports the config loading from the repo path with `update_check = off`.

The rest of the installed plugins get no file. worktrunk exposes one option, `open_mode`, whose default already matches how worktrees open here. Collie reads `.env` and herdr-lazy reads `plugins.list` / `plugins.lock`. The tree tracks neither, and Collie's tailnet settings are machine-local anyway. official.browser reads `browser.json` and wants `experimental.kitty_graphics`, which this setup does not turn on. Navigator's two herdr-plus sources stay at their defaults, since both already gate on a config directory that does not exist. Writing `false` would change nothing.
