### PR TITLE
zsh: export EDITOR from zshenv

### DIFF
--- a/system/editor.zsh
+++ b/system/editor.zsh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-export EDITOR="nvim"

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -13,6 +13,12 @@ export DOTFILES_TMUX="$ZSH/tmux"
 
 export PROJECTS="$HOME/src"
 
+# Here rather than a topic .zsh file, which only .zshrc sources. A long-lived
+# process started outside an interactive shell (a herdr daemon over mosh, a
+# launchd job) hands its children no EDITOR otherwise, and they fall back to
+# whatever the system ships.
+export EDITOR="nvim"
+
 export XDG_CONFIG_HOME="$HOME/.config"
 export XDG_DATA_HOME="$HOME/.local/share"
 export XDG_STATE_HOME="$HOME/.local/state"


### PR DESCRIPTION
Moves `EDITOR` into `zshenv` and drops `system/editor.zsh`.

Topic `.zsh` files are sourced by `.zshrc`, so `EDITOR` only ever existed in interactive shells. A long-lived process started outside one hands its children nothing. Found this on a herdr daemon started over mosh: PID 8141 under `mosh-server` had no `EDITOR`, a daemon from a local shell had it, and the file viewer plugin's edit key was opening the macOS `vi`. Every process herdr or launchd spawns had the same gap.

`zshenv` runs for every shell, which is where an env var this broad belongs. `PROJECTS` and the XDG vars are already there, so the one-line topic file was the odd one out and is gone.

Checked that nothing else referenced `system/editor.zsh`, and that a non-interactive shell sourcing the new `zshenv` reports `EDITOR=nvim`.
