### PR TITLE
terminal: patch Monaspice from nerd-fonts master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,6 +262,9 @@ jobs:
             echo "$bad"
             exit 1
           fi
+      - name: Check private-use glyphs are declared
+        run: bin/glyph-scan
+
       - name: Check for expired migrations
         run: scripts/lint-expired
 

--- a/bin/glyph-scan
+++ b/bin/glyph-scan
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Check that every private-use glyph this repo renders is declared and available.
+
+Two checks, because they fail for different reasons and run in different places:
+
+  declared  every private-use codepoint in a tracked file appears in
+            terminal/glyphs.conf. Runs anywhere, including CI.
+  present   every declared codepoint exists in the installed font. Needs the
+            font, so it is skipped where the cask was not installed.
+"""
+
+import argparse
+import os
+import re
+import struct
+import subprocess
+import sys
+
+# Nerd Fonts places its glyphs in the basic private use area and in plane 15.
+PRIVATE_USE = ((0xE000, 0xF8FF), (0xF0000, 0xFFFFD))
+
+DEFAULT_FONT = "~/Library/Fonts/MonaspiceNeNerdFontMono-Regular.otf"
+
+DECLARATION = re.compile(r"^U\+([0-9A-Fa-f]+)\s+(\S+)")
+
+
+def repo_root():
+    return subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def read_inventory(path):
+    declared = {}
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            match = DECLARATION.match(line.strip())
+            if match:
+                declared[int(match.group(1), 16)] = match.group(2)
+    return declared
+
+
+def is_private_use(code):
+    return any(low <= code <= high for low, high in PRIVATE_USE)
+
+
+def scan_tracked_files(root):
+    listing = subprocess.run(
+        ["git", "-C", root, "ls-files", "-z"],
+        capture_output=True,
+        check=True,
+    ).stdout.split(b"\0")
+
+    used = {}
+    for entry in listing:
+        if not entry:
+            continue
+        relative = entry.decode()
+        path = os.path.join(root, relative)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as handle:
+                text = handle.read()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for char in set(text):
+            if is_private_use(ord(char)):
+                used.setdefault(ord(char), set()).add(relative)
+    return used
+
+
+def font_tables(data):
+    # A TrueType collection puts the real table directory at an offset rather
+    # than at the head of the file.
+    offset = struct.unpack(">I", data[12:16])[0] if data[:4] == b"ttcf" else 0
+    count = struct.unpack(">H", data[offset + 4 : offset + 6])[0]
+    tables = {}
+    for index in range(count):
+        position = offset + 12 + index * 16
+        tag, _, start, length = struct.unpack(">4sIII", data[position : position + 16])
+        tables[tag.decode("latin1")] = (start, length)
+    return tables
+
+
+def font_codepoints(path):
+    with open(path, "rb") as handle:
+        data = handle.read()
+
+    start, _ = font_tables(data)["cmap"]
+    subtables = struct.unpack(">H", data[start + 2 : start + 4])[0]
+
+    codepoints = set()
+    for index in range(subtables):
+        header = start + 4 + index * 8
+        _, _, relative = struct.unpack(">HHI", data[header : header + 8])
+        table = start + relative
+        fmt = struct.unpack(">H", data[table : table + 2])[0]
+
+        if fmt == 4:
+            doubled = struct.unpack(">H", data[table + 6 : table + 8])[0]
+            segments = doubled // 2
+            ends = struct.unpack(
+                ">%dH" % segments, data[table + 14 : table + 14 + doubled]
+            )
+            starts_at = table + 14 + doubled + 2
+            starts = struct.unpack(
+                ">%dH" % segments, data[starts_at : starts_at + doubled]
+            )
+            deltas_at = starts_at + doubled
+            deltas = struct.unpack(
+                ">%dh" % segments, data[deltas_at : deltas_at + doubled]
+            )
+            offsets_at = deltas_at + doubled
+            offsets = struct.unpack(
+                ">%dH" % segments, data[offsets_at : offsets_at + doubled]
+            )
+            for segment, (low, high) in enumerate(zip(starts, ends)):
+                if high == 0xFFFF:
+                    continue
+                for code in range(low, high + 1):
+                    # A segment maps sparsely when it carries an idRangeOffset:
+                    # presence is whatever glyphIdArray holds, and the entries
+                    # that hold 0 are holes rather than glyphs. Taking the
+                    # segment bounds alone would report those holes as covered,
+                    # which is the one answer this script must never give.
+                    if offsets[segment]:
+                        entry = (
+                            offsets_at
+                            + segment * 2
+                            + offsets[segment]
+                            + (code - low) * 2
+                        )
+                        if entry + 2 > len(data):
+                            continue
+                        glyph = struct.unpack(">H", data[entry : entry + 2])[0]
+                        if glyph:
+                            glyph = (glyph + deltas[segment]) & 0xFFFF
+                    else:
+                        glyph = (code + deltas[segment]) & 0xFFFF
+                    if glyph:
+                        codepoints.add(code)
+        elif fmt == 12:
+            groups = struct.unpack(">I", data[table + 12 : table + 16])[0]
+            for group in range(groups):
+                position = table + 16 + group * 12
+                low, high, glyph = struct.unpack(">III", data[position : position + 12])
+                for code in range(low, high + 1):
+                    if glyph + (code - low):
+                        codepoints.add(code)
+
+    return codepoints
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--font",
+        nargs="?",
+        const=DEFAULT_FONT,
+        help="also check the font at this path contains every declared glyph "
+        "(defaults to %s)" % DEFAULT_FONT,
+    )
+    parser.add_argument(
+        "--inventory",
+        default="terminal/glyphs.conf",
+        help="declaration file, relative to the repo root",
+    )
+    arguments = parser.parse_args()
+
+    root = repo_root()
+    declared = read_inventory(os.path.join(root, arguments.inventory))
+    failures = []
+
+    for code, files in sorted(scan_tracked_files(root).items()):
+        if code not in declared:
+            failures.append(
+                "U+%04X %s is used in %s but not declared in %s"
+                % (code, chr(code), ", ".join(sorted(files)), arguments.inventory)
+            )
+
+    if arguments.font:
+        path = os.path.expanduser(arguments.font)
+        if not os.path.exists(path):
+            print("no font at %s, skipping presence check" % path, file=sys.stderr)
+            return 1 if failures else 0
+        available = font_codepoints(path)
+        for code, name in sorted(declared.items()):
+            if code not in available:
+                failures.append(
+                    "U+%04X %s is missing from %s"
+                    % (code, name, os.path.basename(path))
+                )
+
+    for failure in failures:
+        print(failure, file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/README.md
+++ b/claude/README.md
@@ -41,7 +41,7 @@ The agent is dispatched detached and its id is logged. Monitoring and attach hap
 
 ### Tmux Popup and Status Chip
 
-`prefix a` opens the agent view in a popup, near-fullscreen on a narrow client. A 󰚩 pill appears in the status bar while a background agent is waiting on your input, and disappears when none remain.
+`prefix a` opens the agent view in a popup, near-fullscreen on a narrow client. A  pill appears in the status bar while a background agent is waiting on your input, and disappears when none remain.
 
 ### Pruning
 

--- a/terminal/.shellspec
+++ b/terminal/.shellspec
@@ -1,0 +1,1 @@
+--shell bash

--- a/terminal/Brewfile
+++ b/terminal/Brewfile
@@ -6,7 +6,12 @@ cask 'iterm2'
 # predates the Codicon brand marks (see terminal/glyphs.conf) and nerd-fonts has
 # cut no release since. Swap back to font-monaspice-nerd-font once one ships
 # containing U+EC82. The tap opens an issue when that happens.
-cask 'font-monaspice-nerd-font-tip'
+#
+# The @tip suffix is what makes that swap automatic in both directions:
+# install-cask-variants matches variants by stripping at the @, so it retires
+# whichever sibling the Brewfile stopped declaring. A -tip suffix would not
+# match, and bundle would fail on the cask's conflicts_with instead.
+cask 'font-monaspice-nerd-font@tip'
 brew 'glow'
 brew 'shellspec'
 brew 'yazi'

--- a/terminal/Brewfile
+++ b/terminal/Brewfile
@@ -1,5 +1,12 @@
+tap 'bendrucker/fonts'
+
 cask 'iterm2'
-cask 'font-monaspice-nerd-font'
+# Monaspice patched from nerd-fonts master. Same family name as
+# font-monaspice-nerd-font, so nothing downstream of the font changes. 3.4.0
+# predates the Codicon brand marks (see terminal/glyphs.conf) and nerd-fonts has
+# cut no release since. Swap back to font-monaspice-nerd-font once one ships
+# containing U+EC82. The tap opens an issue when that happens.
+cask 'font-monaspice-nerd-font-tip'
 brew 'glow'
 brew 'shellspec'
 brew 'yazi'

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -96,7 +96,7 @@ to `~/.config/ghostty/config` by `install.sh`.
 
 ## Fonts
 
-Ghostty renders `MonaspiceNe NFM`, installed by `font-monaspice-nerd-font-tip`
+Ghostty renders `MonaspiceNe NFM`, installed by `font-monaspice-nerd-font@tip`
 from the [`bendrucker/fonts`](https://github.com/bendrucker/homebrew-fonts) tap.
 That tap patches Monaspace from nerd-fonts `master` instead of a release,
 because 3.4.0 shipped in April 2025, predates the Codicon brand marks for

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -93,3 +93,35 @@ at the end of the config (before TPM runs).
 
 Theme configuration for the Ghostty terminal emulator. The config is symlinked
 to `~/.config/ghostty/config` by `install.sh`.
+
+## Fonts
+
+Ghostty renders `MonaspiceNe NFM`, installed by `font-monaspice-nerd-font-tip`
+from the [`bendrucker/fonts`](https://github.com/bendrucker/homebrew-fonts) tap.
+That tap patches Monaspace from nerd-fonts `master` instead of a release,
+because 3.4.0 shipped in April 2025, predates the Codicon brand marks for
+Claude, OpenAI, and Cursor, and is still the newest release. The family name
+matches upstream's cask, so swapping back to `font-monaspice-nerd-font` when
+3.5.0 lands changes nothing else.
+
+### Client Coverage
+
+tmux and herdr emit bytes. The attached *client* picks the font. One session can
+be attached from Ghostty on the Mac and Rootshell on an iPad at the same time,
+so a glyph cannot be varied per client. The usable set is the intersection of
+every client's coverage. That is why the font goes onto every client, rather
+than holding the glyphs back to what a stock release covers.
+
+Rootshell and Moshi both import a TTF/OTF. Open the tap's latest release on the
+device and import the four `.otf` assets. They are uploaded individually so a
+single file can be tapped from Safari without unzipping. Release notes list the
+codepoints each build gained, so a re-import only matters when one of them turns
+up in `glyphs.conf`.
+
+### `glyphs.conf`
+
+`glyphs.conf` declares every private-use glyph this repo renders, with the Nerd
+Fonts name it comes from. `glyph-scan` fails when a tracked file uses a glyph
+that is not declared, and `glyph-scan --font` fails when the installed font is
+missing one that is. CI runs the first. `spec/glyphs_spec.sh` runs both, skipping
+the second where the cask was not installed.

--- a/terminal/glyphs.conf
+++ b/terminal/glyphs.conf
@@ -1,0 +1,26 @@
+# Every private-use glyph this repo renders to a terminal, and the Nerd Fonts
+# name it comes from. `glyph-scan` fails when a tracked file uses a codepoint
+# that is not listed here, and when the installed font is missing one that is.
+#
+# Adding a glyph to a config means adding it here first. Check its release with
+# `glyph-scan --font` before using it: a glyph that only exists on nerd-fonts
+# master renders as tofu on any surface still running a stock release font.
+#
+# Format: <codepoint> <name> [# note]
+
+U+E0B4  ple-right_half_circle_thick
+U+E0B6  ple-left_half_circle_thick
+U+F0F3  fa-bell
+U+F004C md-arrow_expand_all
+U+F009E md-bell_ring
+U+F0293 md-fullscreen
+U+F0570 md-view_grid
+U+F06A9 md-robot
+
+# Codicon brand marks. Only cod-copilot shipped in Nerd Fonts 3.4.0. The rest
+# landed on master afterwards and reach a release in 3.5.0, which is what
+# font-monaspice-nerd-font-tip exists to bridge (see terminal/Brewfile).
+U+EC1E  cod-copilot
+U+EC5C  cod-cursor
+U+EC81  cod-openai
+U+EC82  cod-claude

--- a/terminal/glyphs.conf
+++ b/terminal/glyphs.conf
@@ -19,7 +19,7 @@ U+F06A9 md-robot
 
 # Codicon brand marks. Only cod-copilot shipped in Nerd Fonts 3.4.0. The rest
 # landed on master afterwards and reach a release in 3.5.0, which is what
-# font-monaspice-nerd-font-tip exists to bridge (see terminal/Brewfile).
+# font-monaspice-nerd-font@tip exists to bridge (see terminal/Brewfile).
 U+EC1E  cod-copilot
 U+EC5C  cod-cursor
 U+EC81  cod-openai

--- a/terminal/spec/glyphs_spec.sh
+++ b/terminal/spec/glyphs_spec.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "terminal glyphs"
+  glyph_scan() { "$SHELLSPEC_PROJECT_ROOT/../bin/glyph-scan" "$@"; }
+
+  font="$HOME/Library/Fonts/MonaspiceNeNerdFontMono-Regular.otf"
+  font_missing() { [ ! -f "$font" ]; }
+
+  It "declares every private-use glyph used in a tracked file"
+    When call glyph_scan
+    The status should be success
+    The stderr should equal ""
+  End
+
+  It "renders every declared glyph in the installed font"
+    Skip if "the font cask is not installed" font_missing
+    When call glyph_scan --font
+    The status should be success
+    The stderr should equal ""
+  End
+End

--- a/tmux/claude/claude.conf
+++ b/tmux/claude/claude.conf
@@ -11,9 +11,9 @@ bind -N "Claude agents" a if -F "#{E:@resp_is_narrow}" \
 
 # Inputs for the agent-attention pill, built into @catppuccin_status_claude by
 # appearance/status.conf (post-TPM) with the same module builder as the bell
-# pill and gated there on a nonzero count. 󰚩 marks a background agent waiting
+# pill and gated there on a nonzero count.  marks a background agent waiting
 # on your input. Absolute path: the running server's PATH froze before this
 # topic existed, so a bare script name resolves to command-not-found.
-set -g @catppuccin_claude_icon "󰚩 "
+set -g @catppuccin_claude_icon " "
 set -g @catppuccin_claude_color "#{@thm_mauve}"
 set -g @catppuccin_claude_text " #(~/.config/tmux/claude/bin/_tmux-claude-agents-count)"

--- a/tmux/responsive/responsive.conf
+++ b/tmux/responsive/responsive.conf
@@ -62,7 +62,7 @@ set -g @resp_sr_narrow '#[fg=#{@thm_yellow}]#[fg=#{@thm_crust},bg=#{@thm_yell
 # waiting on your input). Same chip technique as the bell chip above; status.conf
 # gates it behind a nonzero count. Absolute path because the running server's
 # frozen PATH can predate this topic, leaving a bare script name unresolvable.
-set -g @resp_sr_claude_narrow '#[fg=#{@thm_mauve}]#[fg=#{@thm_crust},bg=#{@thm_mauve}]󰚩 #(~/.config/tmux/claude/bin/_tmux-claude-agents-count)#[fg=#{@thm_mauve},bg=default]#[default]'
+set -g @resp_sr_claude_narrow '#[fg=#{@thm_mauve}]#[fg=#{@thm_crust},bg=#{@thm_mauve}] #(~/.config/tmux/claude/bin/_tmux-claude-agents-count)#[fg=#{@thm_mauve},bg=default]#[default]'
 
 # Current window: rounded pill with index block + name + zoom flag. The name is
 # window_name, the working directory under automatic-rename and the manual name


### PR DESCRIPTION
Nerd Fonts 3.4.0 shipped in April 2025 and is still the newest release. The Codicon brand marks for Claude, OpenAI, and Cursor landed on `master` afterwards, so no released patched font carries them and the agent pill was using `md-robot` as a stand-in.

Adds a [`bendrucker/fonts`](https://github.com/bendrucker/homebrew-fonts) tap that patches Monaspace Neon from nerd-fonts `master` weekly, publishes it as `font-monaspice-nerd-font@tip`, and switches the pill to `cod-claude`.

## Patched Font Over Symbols Fallback

I went after a symbols-only fallback first, since `master` ships a prebuilt `SymbolsNerdFontMono-Regular.ttf` and Ghostty takes a fallback chain through repeated `font-family`. I dropped it for two reasons. Rootshell and Moshi import a single font and I could not confirm either supports a chain. That prebuilt file is also rebuilt on an irregular cadence (2024-11, 2025-04, 2026-08), so it can lag `master`'s own glyph definitions by months.

Patching gives one artifact that works on every client. `patched-fonts/Monaspace/` on `master` holds only a README, but `src/unpatched-fonts/Monaspace/Neon/*.otf` is checked in and `config.cfg` is just `--makegroups 4`, so the build is cheap. It runs four styles, not all ten weights, because Ghostty resolves no others from a `font-family` line and four files is a tolerable manual import on iOS.

## Client Coverage

tmux and herdr emit bytes, and the attached client picks the font. One session can be attached from Ghostty on the Mac and from an iPad at the same time, so a glyph cannot vary per client. The usable set is the intersection of every client's coverage. That is why this puts the font on every client instead of holding glyphs back to what a release covers.

## `@tip` Naming

The cask started out as `font-monaspice-nerd-font-tip`. `scripts/install-cask-variants` matches siblings by stripping at the `@`, so that name never paired: `brew bundle` would have failed on the cask's `conflicts_with` for anyone still holding the released font, then failed again in reverse at retirement. Renamed to match the existing `ghostty@tip`.

## Glyph Inventory

`terminal/glyphs.conf` declares every private-use glyph this repo renders, with the Nerd Fonts name behind it. `bin/glyph-scan` fails when a tracked file uses an undeclared glyph, which CI lint runs, and when the installed font lacks a declared one, which the topic spec runs. Nothing recorded which release each glyph needed before this.

Writing the cmap reader I first took every codepoint between a format 4 segment's `startCode` and `endCode` as covered. That ignores `idRangeOffset`, and every declared BMP glyph in this repo sits in a sparse segment. Measured against the installed font, it claimed 6275 BMP codepoints where only 6101 map to a real glyph, so 174 were phantoms. A tool whose whole job is proving a glyph renders cannot return a false pass, so it now resolves through `glyphIdArray`.

## Verification

`ghostty +show-face --cp=0xEC82` returned "not found" before this change and now resolves to `MonaspiceNe Nerd Font Mono`. All four Codicon marks resolve. `brew bundle check` reports the dependencies satisfied.

The built font's name table carries both `MonaspiceNe NFM` and `MonaspiceNe Nerd Font Mono`, so `ghostty.config` needed no change and will need none at retirement. `glyph-scan --font` passes against the tip build and fails against 3.4.0 with exactly the three missing marks.

Greptile's local pass did not run: `free_reviews_limit_reached`.

## Retirement

When nerd-fonts ships a release containing `U+EC82`, the tap's weekly build opens an issue. Point the Brewfile back at `font-monaspice-nerd-font` and `install-cask-variants` handles the uninstall.
