### PR TITLE
install-trust: stop paying brew startup per tap

### DIFF
--- a/scripts/install-trust
+++ b/scripts/install-trust
@@ -12,22 +12,33 @@
 # `brew bundle` runs, then trust so `brew bundle` can install from it.
 #
 # Every `brew` call pays ~400ms of Ruby startup, so the steady-state run makes
-# two of them rather than two per tap. `brew tap` on an already-tapped repo does
-# nothing but pay that startup, and Homebrew defines a tap as installed by the
-# presence of its directory (Tap#installed? is `path.directory?`), so a `test -d`
-# answers the same question for free. `brew trust` takes every tap at once.
+# two of them rather than two per tap. The conditions under which `brew tap`
+# would do nothing are two file tests Homebrew itself uses: Tap#installed? is
+# `path.directory?` and Tap#shallow? is `.git/shallow`. Meeting both is what
+# makes Tap#install raise TapAlreadyTappedError, which `brew tap` swallows.
+# A shallow tap still needs the call, because that is what unshallows it.
+# `brew trust` takes every tap at once.
 set -e
 
 DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
 : "${XDG_CONFIG_HOME:=$HOME/.config}"
-: "${HOMEBREW_REPOSITORY:=$(brew --repository)}"
+
+# Not a ${:=} default, which would swallow a failing brew and leave the path
+# empty, silently re-tapping everything on every run.
+if [ -z "${HOMEBREW_REPOSITORY-}" ]; then
+  HOMEBREW_REPOSITORY=$(brew --repository)
+fi
 
 taps=$(brew bundle list --file "$DOTFILES_ROOT/Brewfile" --tap)
 
 for tap in $taps; do
   # Tap#path is HOMEBREW_TAP_DIRECTORY/<user>/homebrew-<repo>, downcased
-  path=$(printf '%s/homebrew-%s' "${tap%%/*}" "${tap#*/}" | tr '[:upper:]' '[:lower:]')
-  [ -d "$HOMEBREW_REPOSITORY/Library/Taps/$path" ] || brew tap "$tap"
+  name=$(printf '%s/homebrew-%s' "${tap%%/*}" "${tap#*/}" | tr '[:upper:]' '[:lower:]')
+  path="$HOMEBREW_REPOSITORY/Library/Taps/$name"
+
+  if [ ! -d "$path" ] || [ -f "$path/.git/shallow" ]; then
+    brew tap "$tap"
+  fi
 done
 
 rm -f "$XDG_CONFIG_HOME/homebrew/trust.json"

--- a/scripts/install-trust
+++ b/scripts/install-trust
@@ -10,14 +10,29 @@
 # (Homebrew/brew#22599), so trusting a tap is no longer enough to let `brew
 # bundle` clone it. Tap each one explicitly so the formulae are on disk before
 # `brew bundle` runs, then trust so `brew bundle` can install from it.
+#
+# Every `brew` call pays ~400ms of Ruby startup, so the steady-state run makes
+# two of them rather than two per tap. `brew tap` on an already-tapped repo does
+# nothing but pay that startup, and Homebrew defines a tap as installed by the
+# presence of its directory (Tap#installed? is `path.directory?`), so a `test -d`
+# answers the same question for free. `brew trust` takes every tap at once.
 set -e
 
 DOTFILES_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd -P)}"
 : "${XDG_CONFIG_HOME:=$HOME/.config}"
+: "${HOMEBREW_REPOSITORY:=$(brew --repository)}"
+
+taps=$(brew bundle list --file "$DOTFILES_ROOT/Brewfile" --tap)
+
+for tap in $taps; do
+  # Tap#path is HOMEBREW_TAP_DIRECTORY/<user>/homebrew-<repo>, downcased
+  path=$(printf '%s/homebrew-%s' "${tap%%/*}" "${tap#*/}" | tr '[:upper:]' '[:lower:]')
+  [ -d "$HOMEBREW_REPOSITORY/Library/Taps/$path" ] || brew tap "$tap"
+done
 
 rm -f "$XDG_CONFIG_HOME/homebrew/trust.json"
 
-brew bundle list --file "$DOTFILES_ROOT/Brewfile" --tap | while IFS= read -r tap; do
-  brew tap "$tap"
-  brew trust --tap "$tap"
-done
+[ -n "$taps" ] || exit 0
+
+# shellcheck disable=SC2086 # tap names never contain whitespace
+brew trust --tap $taps

--- a/scripts/spec/install_trust_spec.sh
+++ b/scripts/spec/install_trust_spec.sh
@@ -15,6 +15,10 @@ Describe "install-trust"
     : > "$sandbox/trusted"
     printf '%s\n' "$sandbox/repo" > "$sandbox/repository"
 
+    trust_json="$sandbox/config/homebrew/trust.json"
+    # The fallback spec empties this to exercise the brew --repository path.
+    repository="$sandbox/repo"
+
     # Each invocation appends one line, so the specs can count calls as well
     # as check arguments.
     printf '%s\n' \
@@ -37,19 +41,20 @@ Describe "install-trust"
       mkdir -p "$sandbox/repo/Library/Taps/${tap%%/*}/homebrew-${tap#*/}"
     done
   }
-  trust_file() { echo "$sandbox/config/homebrew/trust.json"; }
+  shallow() { mkdir -p "$sandbox/repo/Library/Taps/${1%%/*}/homebrew-${1#*/}/.git" && : > "$sandbox/repo/Library/Taps/${1%%/*}/homebrew-${1#*/}/.git/shallow"; }
+  stale_trust() { printf '{"trustedtaps":["gone/away"]}\n' > "$trust_json"; }
   tapped() { cat "$sandbox/tapped"; }
   trusted() { cat "$sandbox/trusted"; }
 
   run_script() {
     PATH="$sandbox/bin:$PATH" \
-      HOMEBREW_REPOSITORY="$sandbox/repo" \
+      HOMEBREW_REPOSITORY="$repository" \
       XDG_CONFIG_HOME="$sandbox/config" \
       "$script" "$sandbox"
   }
 
-  # The whole point of the directory check: a warm machine makes no `brew tap`
-  # calls at all, only the bundle list and one batched trust.
+  # The steady-state run: no `brew tap` calls at all, only the bundle list and
+  # one batched trust.
   It "does not tap a repository that is already on disk"
     declared oven-sh/bun schpet/tap
     installed oven-sh/bun schpet/tap
@@ -87,32 +92,45 @@ Describe "install-trust"
   End
 
   It "rebuilds the trust file from scratch so a dropped tap drops out"
-    printf '{"trustedtaps":["gone/away"]}\n' > "$(trust_file)"
+    stale_trust
     declared oven-sh/bun
     installed oven-sh/bun
 
     When call run_script
     The status should be success
-    The path "$sandbox/config/homebrew/trust.json" should not be exist
+    The path "$trust_json" should not be exist
     The result of function trusted should equal "--tap oven-sh/bun"
   End
 
   # `brew trust` with no targets prints the trusted list instead of writing it.
   It "clears the trust file without calling trust when nothing is declared"
-    printf '{"trustedtaps":["gone/away"]}\n' > "$(trust_file)"
+    stale_trust
 
     When call run_script
     The status should be success
-    The path "$sandbox/config/homebrew/trust.json" should not be exist
+    The path "$trust_json" should not be exist
     The result of function trusted should equal ""
   End
 
   It "falls back to asking brew for the repository path"
     declared oven-sh/bun
     installed oven-sh/bun
+    repository=""
 
-    When call env PATH="$sandbox/bin:$PATH" XDG_CONFIG_HOME="$sandbox/config" HOMEBREW_REPOSITORY= "$script" "$sandbox"
+    When call run_script
     The status should be success
     The result of function tapped should equal ""
+  End
+
+  # `brew tap` is only a no-op on a tap that is installed and not shallow. On a
+  # shallow one it is what runs `git fetch --unshallow`.
+  It "taps a repository whose clone on disk is shallow"
+    declared oven-sh/bun
+    installed oven-sh/bun
+    shallow oven-sh/bun
+
+    When call run_script
+    The status should be success
+    The result of function tapped should equal "oven-sh/bun"
   End
 End

--- a/scripts/spec/install_trust_spec.sh
+++ b/scripts/spec/install_trust_spec.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# The stub body below is written out verbatim, so its expansions are the
+# stub's to resolve at run time.
+# shellcheck disable=SC2329,SC2016
+
+Describe "install-trust"
+  script="$SHELLSPEC_PROJECT_ROOT/install-trust"
+
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/install-trust"
+    rm -rf "$sandbox"
+    mkdir -p "$sandbox/bin" "$sandbox/repo/Library/Taps" "$sandbox/config/homebrew"
+    : > "$sandbox/declared"
+    : > "$sandbox/tapped"
+    : > "$sandbox/trusted"
+    printf '%s\n' "$sandbox/repo" > "$sandbox/repository"
+
+    # Each invocation appends one line, so the specs can count calls as well
+    # as check arguments.
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'case "$1" in' \
+      '  bundle) cat "$FIXTURES/declared" ;;' \
+      '  --repository) cat "$FIXTURES/repository" ;;' \
+      '  tap) echo "$2" >> "$FIXTURES/tapped" ;;' \
+      '  trust) shift; echo "$*" >> "$FIXTURES/trusted" ;;' \
+      'esac' > "$sandbox/bin/brew"
+    chmod +x "$sandbox/bin/brew"
+
+    export FIXTURES="$sandbox"
+  }
+  BeforeEach 'setup'
+
+  declared() { printf '%s\n' "$@" > "$sandbox/declared"; }
+  installed() {
+    for tap in "$@"; do
+      mkdir -p "$sandbox/repo/Library/Taps/${tap%%/*}/homebrew-${tap#*/}"
+    done
+  }
+  trust_file() { echo "$sandbox/config/homebrew/trust.json"; }
+  tapped() { cat "$sandbox/tapped"; }
+  trusted() { cat "$sandbox/trusted"; }
+
+  run_script() {
+    PATH="$sandbox/bin:$PATH" \
+      HOMEBREW_REPOSITORY="$sandbox/repo" \
+      XDG_CONFIG_HOME="$sandbox/config" \
+      "$script" "$sandbox"
+  }
+
+  # The whole point of the directory check: a warm machine makes no `brew tap`
+  # calls at all, only the bundle list and one batched trust.
+  It "does not tap a repository that is already on disk"
+    declared oven-sh/bun schpet/tap
+    installed oven-sh/bun schpet/tap
+
+    When call run_script
+    The status should be success
+    The result of function tapped should equal ""
+  End
+
+  It "taps only the repositories missing from disk"
+    declared oven-sh/bun schpet/tap
+    installed oven-sh/bun
+
+    When call run_script
+    The status should be success
+    The result of function tapped should equal "schpet/tap"
+  End
+
+  It "matches the downcased tap directory Homebrew installs into"
+    declared Oven-SH/Bun
+    installed oven-sh/bun
+
+    When call run_script
+    The status should be success
+    The result of function tapped should equal ""
+  End
+
+  It "trusts every declared tap in a single call"
+    declared oven-sh/bun schpet/tap pulumi/tap
+    installed oven-sh/bun schpet/tap pulumi/tap
+
+    When call run_script
+    The status should be success
+    The result of function trusted should equal "--tap oven-sh/bun schpet/tap pulumi/tap"
+  End
+
+  It "rebuilds the trust file from scratch so a dropped tap drops out"
+    printf '{"trustedtaps":["gone/away"]}\n' > "$(trust_file)"
+    declared oven-sh/bun
+    installed oven-sh/bun
+
+    When call run_script
+    The status should be success
+    The path "$sandbox/config/homebrew/trust.json" should not be exist
+    The result of function trusted should equal "--tap oven-sh/bun"
+  End
+
+  # `brew trust` with no targets prints the trusted list instead of writing it.
+  It "clears the trust file without calling trust when nothing is declared"
+    printf '{"trustedtaps":["gone/away"]}\n' > "$(trust_file)"
+
+    When call run_script
+    The status should be success
+    The path "$sandbox/config/homebrew/trust.json" should not be exist
+    The result of function trusted should equal ""
+  End
+
+  It "falls back to asking brew for the repository path"
+    declared oven-sh/bun
+    installed oven-sh/bun
+
+    When call env PATH="$sandbox/bin:$PATH" XDG_CONFIG_HOME="$sandbox/config" HOMEBREW_REPOSITORY= "$script" "$sandbox"
+    The status should be success
+    The result of function tapped should equal ""
+  End
+End


### PR DESCRIPTION
`install-trust` ran two `brew` calls per declared tap. Every `brew` invocation pays about 400ms of Ruby startup whether or not it has work to do, so with 12 taps declared the script took 9.5s on a machine where everything was already tapped and trusted. It runs on every `scripts/install`, which means every `dotf` and every 3am `dotfiles-upgrade`. Now it makes two `brew` calls total and takes 1.05s.

Two changes get there. `brew trust` accepts every target in one call, so the per-tap loop collapses into a single `brew trust --tap a b c`. And `brew tap` on a tap that is already present does nothing but pay the startup, so the call can be skipped outright.

Skipping it correctly is the part worth reviewing. The condition under which `Tap#install` short-circuits is `installed? && !shallow?`, and both halves are file tests Homebrew itself performs: `Tap#installed?` is `path.directory?` and `Tap#shallow?` is `(path/".git/shallow").exist?`. The script tests the same two things, so it skips exactly when brew would have done nothing and still calls `brew tap` on a shallow clone, which is what runs `git fetch --unshallow`. Anything else about a broken tap is unchanged: a half-cloned non-shallow directory made the old unconditional call raise `TapAlreadyTappedError`, which `brew tap` swallows, so that never self-healed either.

This does hardcode Homebrew's tap directory layout (`<user>/homebrew-<repo>`, downcased, under `Library/Taps`). The alternative is matching against `brew tap` with no arguments, which avoids the coupling but adds a third invocation, roughly 40% of the new budget. The layout is documented in `brew tap`'s own help text, and if it ever changed the check would simply always miss and fall back to calling `brew tap` every time, so the failure mode is the old behavior rather than a wrong one.

The `rm -f trust.json` also moved after the tap loop. If a tap fails to clone, the script now aborts with the previous trust file intact rather than having already deleted it, which leaves `brew bundle` able to install from the taps that do work.

Adds `scripts/spec/install_trust_spec.sh`, which stubs `brew` and pins the skip, the shallow exception, the single batched trust call, and the rebuild-from-scratch semantics a removed tap depends on. Verified against the real Homebrew too: same 12 taps, byte-identical `trust.json`, 9.5s to 1.05s.
