### PR TITLE
claude: cover every plugin on upgrade and audit the result

### DIFF
--- a/bin/claude-plugin-audit
+++ b/bin/claude-plugin-audit
@@ -123,7 +123,15 @@ audit_external_plugin () {
   local source=$1 payload=$2
   local url ref expected actual
 
-  url=$(print -r -- "$source" | jq -r '.url // ("https://github.com/" + .repo) // empty')
+  if [[ -z "$payload" || ! -d "$payload" ]]; then
+    print -r -- "stale"$'\t'"no payload installed"
+    return
+  fi
+
+  # `.repo // empty` inside the concatenation, because jq treats null as the
+  # identity for +: a source carrying neither field would otherwise build the
+  # string "https://github.com/" and send the audit off to fetch it.
+  url=$(print -r -- "$source" | jq -r '.url // ("https://github.com/" + (.repo // empty)) // empty')
   [[ -n "$url" ]] || { print -r -- "unknown"$'\t'"source names no repository"; return }
 
   ref=$(print -r -- "$source" | jq -r '.sha // .ref // "HEAD"')
@@ -147,6 +155,7 @@ audit_marketplace () {
   local location=$1 url=$2 ref=$3
   local head expected
 
+  [[ -n "$url" ]] || { print -r -- "unknown"$'\t'"source names no repository"; return }
   [[ -d "$location/.git" ]] || {
     print -r -- "unknown"$'\t'"not a git clone, so freshness is unverifiable"
     return
@@ -170,7 +179,7 @@ marketplace_inventory () {
     to_entries[]
     | [ .key,
         (.value.installLocation // ""),
-        (.value.source.url // ("https://github.com/" + (.value.source.repo // ""))),
+        (.value.source.url // ("https://github.com/" + (.value.source.repo // empty)) // ""),
         (.value.source.ref // "HEAD") ]
     | @tsv
   ' "$(claude_plugins_dir)/known_marketplaces.json" 2>/dev/null
@@ -190,19 +199,37 @@ main () {
   (( $# )) && { print -u2 -- "claude-plugin-audit: unknown option $1"; return 1 }
 
   local -a drifted unverified
+  local -A vouched
   local name location url ref id payload verdict detail current=0
+  local marketplaces inventory
 
+  marketplaces=$(marketplace_inventory)
   while IFS=$'\t' read -r name location url ref; do
     [[ -n "$name" ]] || continue
     IFS=$'\t' read -r verdict detail <<< "$(audit_marketplace "$location" "$url" "$ref")"
+    [[ "$verdict" == current ]] && vouched[$name]=1
     record_verdict "marketplace/$name" "$verdict" "$detail"
-  done < <(marketplace_inventory)
+  done <<< "$marketplaces"
+
+  # An inventory that could not be read is not an empty one, and reporting
+  # "everything current" over it would be the silence this tool exists to break.
+  if ! inventory=$(plugin_inventory); then
+    print -u2 -- "claude-plugin-audit: could not enumerate installed plugins"
+    return 2
+  fi
 
   while IFS=$'\t' read -r id payload; do
     [[ -n "$id" ]] || continue
     IFS=$'\t' read -r verdict detail <<< "$(audit_plugin "$id" "$payload")"
+    # A payload is only as current as the tree it was compared against. A match
+    # with a marketplace the audit could not vouch for proves nothing, and
+    # calling it current is how a stale clone hides every stale install under it.
+    if [[ "$verdict" == current && -z "${vouched[${id##*@}]:-}" ]]; then
+      verdict=unknown
+      detail="matches marketplace ${id##*@}, which is itself unverified"
+    fi
     record_verdict "$id" "$verdict" "$detail"
-  done < <(plugin_inventory)
+  done <<< "$inventory"
 
   (( ${#unverified} )) && {
     print -rl -- $unverified | sort | column -t -s $'\t'

--- a/bin/claude-plugin-audit
+++ b/bin/claude-plugin-audit
@@ -32,6 +32,12 @@ typeset -g script_path=${0:A}
 # the plugin.
 typeset -gra payload_noise=(.in_use .orphaned_at node_modules .git)
 
+# Where compare_payload leaves what diff could not read. Named off the pid
+# rather than mktemp, which ignores TMPDIR on macOS and so fails under a sandbox
+# that only grants it.
+typeset -g diff_errors=${TMPDIR:-/tmp}/claude-plugin-audit.$$.err
+trap 'rm -f "$diff_errors"' EXIT
+
 compare_payload () {
   local payload=$1 source_dir=$2
   local -a excludes
@@ -46,7 +52,11 @@ compare_payload () {
   # drift. A plugin that does ship one stays covered.
   [[ -d "$source_dir/.claude-plugin" ]] || excludes+=(--exclude=.claude-plugin)
 
-  diff -rq $excludes "$payload" "$source_dir" 2>&1
+  # stderr is kept off stdout because a path diff could not read is not a
+  # difference. Folding the two together made an unreadable file report as
+  # drift, which no update can clear.
+  : >"$diff_errors"
+  diff -rq $excludes "$payload" "$source_dir" 2>"$diff_errors"
 }
 
 resolve_ref () {
@@ -88,8 +98,14 @@ audit_plugin () {
 
   source=$(plugin_source "$id") || source_rc=$?
   case $source_rc in
-    3) print -r -- "unknown"$'\t'"marketplace $marketplace has no readable manifest"; return ;;
-    4) print -r -- "orphaned"$'\t'"marketplace $marketplace no longer offers $name"; return ;;
+    "$PLUGIN_SOURCE_UNREADABLE")
+      print -r -- "unknown"$'\t'"marketplace $marketplace does not say where $name comes from"
+      return
+      ;;
+    "$PLUGIN_SOURCE_ABSENT")
+      print -r -- "orphaned"$'\t'"marketplace $marketplace no longer offers $name"
+      return
+      ;;
   esac
 
   if [[ $(print -r -- "$source" | jq -r 'type') == string ]]; then
@@ -102,7 +118,7 @@ audit_plugin () {
 audit_relative_plugin () {
   local marketplace=$1 relative=$2 payload=$3
   local source_dir="$(claude_plugins_dir)/marketplaces/$marketplace/${relative#./}"
-  local differences
+  local differences diff_rc=0
 
   [[ -d "$source_dir" ]] || {
     print -r -- "unknown"$'\t'"marketplace source $relative is missing"
@@ -113,8 +129,16 @@ audit_relative_plugin () {
     return
   fi
 
-  differences=$(compare_payload "$payload" "$source_dir")
-  [[ -z "$differences" ]] && { print -r -- "current"$'\t'; return }
+  differences=$(compare_payload "$payload" "$source_dir") || diff_rc=$?
+
+  # Both signals are needed. diff exits 2 on a path it could not read, but on
+  # macOS a dangling symlink gets it an error on stderr and exit 0, so a status
+  # check alone would call the payload current over a file nothing compared.
+  if (( diff_rc > 1 )) || [[ -s "$diff_errors" ]]; then
+    print -r -- "unknown"$'\t'"could not compare against $relative: $(head -1 "$diff_errors")"
+    return
+  fi
+  (( diff_rc == 0 )) && { print -r -- "current"$'\t'; return }
 
   print -r -- "stale"$'\t'"differs from $relative at $(plural $(print -r -- "$differences" | wc -l | tr -d ' ') path)"
 }
@@ -203,7 +227,14 @@ main () {
   local name location url ref id payload verdict detail current=0
   local marketplaces inventory
 
-  marketplaces=$(marketplace_inventory)
+  # Same reasoning as the plugin inventory below: an unreadable marketplace list
+  # vouches for nothing, and every plugin check downstream reads `vouched` as
+  # proof its tree was fresh.
+  if ! marketplaces=$(marketplace_inventory); then
+    print -u2 -- "claude-plugin-audit: could not enumerate marketplaces"
+    return 2
+  fi
+
   while IFS=$'\t' read -r name location url ref; do
     [[ -n "$name" ]] || continue
     IFS=$'\t' read -r verdict detail <<< "$(audit_marketplace "$location" "$url" "$ref")"

--- a/bin/claude-plugin-audit
+++ b/bin/claude-plugin-audit
@@ -1,0 +1,178 @@
+#!/usr/bin/env zsh
+#/ Usage: claude-plugin-audit
+#/ Report installed Claude Code plugins whose payload no longer matches what
+#/ their marketplace offers. Exits non-zero when anything is stale.
+#
+# `claude plugin update` reports success in cases where it changed nothing: a
+# plugin that declares a fixed `version` string is "already at the latest
+# version" however far its source has moved, and an id the updater never
+# enumerated is never attempted at all. Neither case is distinguishable from a
+# real update by its exit status, so the updater's own success is not evidence
+# that an install is current. This checks the outcome instead.
+#
+# The check is a content comparison rather than a reading of the recorded
+# gitCommitSha, because a forced refresh (rm -rf the payload, reinstall)
+# restores current content while leaving that field at its old value.
+
+set -uo pipefail
+setopt typeset_silent
+
+source "${0:A:h}/../scripts/lib/claude-plugins.sh"
+
+# Captured at file scope: inside a function $0 is the function name, so --help
+# could not find the usage header to print.
+typeset -g script_path=${0:A}
+
+# Neither side of the comparison owns these. .in_use and .orphaned_at are
+# runtime markers Claude Code writes into a payload, node_modules is an
+# install-time artifact, and .git belongs to a marketplace whose whole repo is
+# the plugin.
+typeset -gra payload_noise=(.in_use .orphaned_at node_modules .git)
+
+compare_payload () {
+  local payload=$1 source_dir=$2
+  local -a excludes
+  local marker
+
+  for marker in $payload_noise; do
+    excludes+=(--exclude="$marker")
+  done
+
+  # Claude Code synthesizes .claude-plugin/plugin.json for a plugin that ships
+  # none, so on those the directory exists only on the payload side and is not
+  # drift. A plugin that does ship one stays covered.
+  [[ -d "$source_dir/.claude-plugin" ]] || excludes+=(--exclude=.claude-plugin)
+
+  diff -rq $excludes "$payload" "$source_dir" 2>&1
+}
+
+resolve_ref () {
+  local url=$1 ref=$2 refs peeled
+
+  [[ "$ref" =~ '^[0-9a-f]{40}$' ]] && { print -r -- "$ref"; return }
+
+  refs=$(git ls-remote "$url" "$ref" 2>/dev/null) || return 1
+  [[ -n "$refs" ]] || return 1
+
+  # An annotated tag resolves to a tag object; its peeled ^{} line carries the
+  # commit the install would actually hold.
+  peeled=$(print -r -- "$refs" | awk '$2 ~ /\^\{\}$/ { print $1; exit }')
+  [[ -n "$peeled" ]] && { print -r -- "$peeled"; return }
+
+  print -r -- "$refs" | awk 'NR == 1 { print $1 }'
+}
+
+recorded_commit () {
+  local payload=$1
+  jq -r --arg payload "$payload" '
+    (if type == "array" then (.[] | select(.key == "plugins") | .value) else .plugins end)
+    | to_entries[] | .value[]
+    | select(.installPath == $payload) | .gitCommitSha // empty
+  ' "$(claude_plugins_dir)/installed_plugins.json" 2>/dev/null | head -1
+}
+
+# Compare a plugin's installed payload against the source its marketplace
+# currently offers. Prints "<verdict>\t<detail>", where verdict is one of:
+#   current   the payload matches
+#   stale     the payload differs, or was never installed
+#   orphaned  the marketplace no longer offers the plugin, so nothing can update
+#             it and the fix is to uninstall
+#   unknown   the comparison could not be made
+audit_plugin () {
+  local id=$1 payload=$2
+  local marketplace=${id##*@} name=${id%@*}
+  local source source_rc=0
+
+  source=$(plugin_source "$id") || source_rc=$?
+  case $source_rc in
+    3) print -r -- "unknown"$'\t'"marketplace $marketplace has no readable manifest"; return ;;
+    4) print -r -- "orphaned"$'\t'"marketplace $marketplace no longer offers $name"; return ;;
+  esac
+
+  if [[ $(print -r -- "$source" | jq -r 'type') == string ]]; then
+    audit_relative_plugin "$marketplace" "$(print -r -- "$source" | jq -r '.')" "$payload"
+  else
+    audit_external_plugin "$source" "$payload"
+  fi
+}
+
+audit_relative_plugin () {
+  local marketplace=$1 relative=$2 payload=$3
+  local source_dir="$(claude_plugins_dir)/marketplaces/$marketplace/${relative#./}"
+  local differences
+
+  [[ -d "$source_dir" ]] || {
+    print -r -- "unknown"$'\t'"marketplace source $relative is missing"
+    return
+  }
+  if [[ -z "$payload" || ! -d "$payload" ]]; then
+    print -r -- "stale"$'\t'"no payload installed"
+    return
+  fi
+
+  differences=$(compare_payload "$payload" "$source_dir")
+  [[ -z "$differences" ]] && { print -r -- "current"$'\t'; return }
+
+  print -r -- "stale"$'\t'"differs from $relative at $(plural $(print -r -- "$differences" | wc -l | tr -d ' ') path)"
+}
+
+audit_external_plugin () {
+  local source=$1 payload=$2
+  local url ref expected actual
+
+  url=$(print -r -- "$source" | jq -r '.url // ("https://github.com/" + .repo) // empty')
+  [[ -n "$url" ]] || { print -r -- "unknown"$'\t'"source names no repository"; return }
+
+  ref=$(print -r -- "$source" | jq -r '.sha // .ref // "HEAD"')
+  expected=$(resolve_ref "$url" "$ref") || {
+    print -r -- "unknown"$'\t'"$url has no $ref"
+    return
+  }
+
+  actual=$(recorded_commit "$payload")
+  [[ -n "$actual" ]] || { print -r -- "stale"$'\t'"no commit recorded for the install"; return }
+  [[ "$actual" == "$expected" ]] && { print -r -- "current"$'\t'; return }
+
+  print -r -- "stale"$'\t'"installed ${actual[1,12]}, $url $ref is ${expected[1,12]}"
+}
+
+plural () {
+  local n=$1 noun=$2
+  (( n == 1 )) && { print -r -- "$n $noun"; return }
+  print -r -- "$n ${noun}s"
+}
+
+main () {
+  [[ "${1:-}" == -h || "${1:-}" == --help ]] && {
+    grep '^#/' "$script_path" | cut -c4-
+    return 0
+  }
+  (( $# )) && { print -u2 -- "claude-plugin-audit: unknown option $1"; return 1 }
+
+  local -a findings
+  local id payload verdict detail current=0
+
+  while IFS=$'\t' read -r id payload; do
+    [[ -n "$id" ]] || continue
+    IFS=$'\t' read -r verdict detail <<< "$(audit_plugin "$id" "$payload")"
+    if [[ "$verdict" == current ]]; then
+      (( ++current ))
+      continue
+    fi
+    findings+=("$id"$'\t'"$verdict"$'\t'"$detail")
+  done < <(plugin_inventory)
+
+  (( ${#findings} )) || {
+    print -r -- "$(plural $current plugin) current"
+    return 0
+  }
+
+  print -rl -- $findings | sort | column -t -s $'\t'
+  print -r -- ""
+  print -r -- "$(plural ${#findings} plugin) need attention ($current current)"
+  return 1
+}
+
+# Run only when executed directly. When sourced (tests), ZSH_EVAL_CONTEXT gains
+# a ":file" suffix, so the functions are defined without running the audit.
+[[ "$ZSH_EVAL_CONTEXT" == toplevel ]] && main "$@"

--- a/bin/claude-plugin-audit
+++ b/bin/claude-plugin-audit
@@ -10,9 +10,12 @@
 # real update by its exit status, so the updater's own success is not evidence
 # that an install is current. This checks the outcome instead.
 #
-# The check is a content comparison rather than a reading of the recorded
-# gitCommitSha, because a forced refresh (rm -rf the payload, reinstall)
-# restores current content while leaving that field at its old value.
+# Where the marketplace carries the plugin in its own tree, the check compares
+# content rather than reading the recorded gitCommitSha, because a forced
+# refresh (rm -rf the payload, reinstall) restores current content while leaving
+# that field at its old value. A plugin sourced from its own repo has no local
+# copy of that repo to compare against, so it falls back to the recorded commit
+# and inherits that field's inaccuracy.
 
 set -uo pipefail
 setopt typeset_silent
@@ -136,6 +139,43 @@ audit_external_plugin () {
   print -r -- "stale"$'\t'"installed ${actual[1,12]}, $url $ref is ${expected[1,12]}"
 }
 
+# Compare a marketplace clone against the ref its source pins. Every other
+# check reads these clones as ground truth, and `claude plugin marketplace
+# update` warns rather than fails, so a clone that quietly stopped advancing
+# would match a stale install and hide the drift from both sides.
+audit_marketplace () {
+  local location=$1 url=$2 ref=$3
+  local head expected
+
+  [[ -d "$location/.git" ]] || {
+    print -r -- "unknown"$'\t'"not a git clone, so freshness is unverifiable"
+    return
+  }
+
+  head=$(git -C "$location" rev-parse HEAD 2>/dev/null) || {
+    print -r -- "unknown"$'\t'"clone has no HEAD"
+    return
+  }
+  expected=$(resolve_ref "$url" "$ref") || {
+    print -r -- "unknown"$'\t'"$url has no $ref"
+    return
+  }
+
+  [[ "$head" == "$expected" ]] && { print -r -- "current"$'\t'; return }
+  print -r -- "stale"$'\t'"cloned at ${head[1,12]}, $url $ref is ${expected[1,12]}"
+}
+
+marketplace_inventory () {
+  jq -r '
+    to_entries[]
+    | [ .key,
+        (.value.installLocation // ""),
+        (.value.source.url // ("https://github.com/" + (.value.source.repo // ""))),
+        (.value.source.ref // "HEAD") ]
+    | @tsv
+  ' "$(claude_plugins_dir)/known_marketplaces.json" 2>/dev/null
+}
+
 plural () {
   local n=$1 noun=$2
   (( n == 1 )) && { print -r -- "$n $noun"; return }
@@ -149,28 +189,48 @@ main () {
   }
   (( $# )) && { print -u2 -- "claude-plugin-audit: unknown option $1"; return 1 }
 
-  local -a findings
-  local id payload verdict detail current=0
+  local -a drifted unverified
+  local name location url ref id payload verdict detail current=0
+
+  while IFS=$'\t' read -r name location url ref; do
+    [[ -n "$name" ]] || continue
+    IFS=$'\t' read -r verdict detail <<< "$(audit_marketplace "$location" "$url" "$ref")"
+    record_verdict "marketplace/$name" "$verdict" "$detail"
+  done < <(marketplace_inventory)
 
   while IFS=$'\t' read -r id payload; do
     [[ -n "$id" ]] || continue
     IFS=$'\t' read -r verdict detail <<< "$(audit_plugin "$id" "$payload")"
-    if [[ "$verdict" == current ]]; then
-      (( ++current ))
-      continue
-    fi
-    findings+=("$id"$'\t'"$verdict"$'\t'"$detail")
+    record_verdict "$id" "$verdict" "$detail"
   done < <(plugin_inventory)
 
-  (( ${#findings} )) || {
-    print -r -- "$(plural $current plugin) current"
+  (( ${#unverified} )) && {
+    print -rl -- $unverified | sort | column -t -s $'\t'
+    print -r -- ""
+  }
+
+  (( ${#drifted} )) || {
+    print -r -- "$(plural $current check) current"
     return 0
   }
 
-  print -rl -- $findings | sort | column -t -s $'\t'
+  print -rl -- $drifted | sort | column -t -s $'\t'
   print -r -- ""
-  print -r -- "$(plural ${#findings} plugin) need attention ($current current)"
+  print -r -- "$(plural ${#drifted} finding) to act on ($current current)"
   return 1
+}
+
+# Sort a verdict into the two piles main reports on. A comparison that could not
+# be made is not evidence of drift: at 3am an ls-remote loses to a flaky network
+# far more often than to a real change, and failing on one would file a to-do
+# that the next run clears. It still prints, so a standing one is visible.
+record_verdict () {
+  local subject=$1 verdict=$2 detail=$3
+  case $verdict in
+    current)  (( ++current )) ;;
+    unknown)  unverified+=("$subject"$'\t'"unverified"$'\t'"$detail") ;;
+    *)        drifted+=("$subject"$'\t'"$verdict"$'\t'"$detail") ;;
+  esac
 }
 
 # Run only when executed directly. When sourced (tests), ZSH_EVAL_CONTEXT gains

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -142,8 +142,15 @@ report_drift() {
   local revision meta
   IFS=$'\t' read -r revision meta <<< "$(upgrade_metadata)"
 
+  # The subject and verdict of each finding, without the detail, so drift that
+  # deepens on a plugin already named stays quiet while a newly affected plugin
+  # reopens the latch.
+  local fingerprint
+  fingerprint=$(print -r -- "$output" |
+    awk '$2 ~ /^(stale|orphaned|unverified)$/ { print $1, $2 }' | sort | shasum | cut -c1-12)
+
   report_failure "claude-plugin-drift" "Claude plugins are stale" "claude-plugin-audit" \
-    "$output" "$revision" "$meta" "Stale Plugins"
+    "$output" "$revision" "$meta" "Stale Plugins" "$fingerprint"
 }
 
 main() {

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -68,6 +68,15 @@ update_marketplaces() {
 update_plugins() {
   gum log --level info "Updating plugins..."
 
+  local inventory
+  # An inventory that could not be read is not an empty one. Treating it as
+  # empty would update nothing and report success, which is the failure this
+  # job exists to make loud.
+  if ! inventory=$(plugin_inventory); then
+    gum log --level warn "Could not enumerate installed plugins"
+    return 1
+  fi
+
   local failed=0 plugin payload source_rc
   while IFS=$'\t' read -r plugin payload; do
     [[ -n "$plugin" ]] || continue
@@ -77,11 +86,15 @@ update_plugins() {
     # A marketplace that no longer offers the plugin has nothing to update it
     # to, so `claude plugin update` can only ever fail. claude-plugin-audit
     # reports these. Counting them here would make every run fail.
-    (( source_rc == 4 )) && continue
+    (( source_rc == PLUGIN_SOURCE_ABSENT )) && continue
 
     if [[ -z "$payload" || ! -d "$payload" ]]; then
+      # Installing an id the marketplace cannot vouch for is a guess that fails
+      # every night. The audit names it instead.
+      (( source_rc != 0 )) && continue
+
       gum log --level info "Installing $plugin (not yet installed)..."
-      if ! claude plugin install "$plugin"; then
+      if ! claude plugin install "$plugin" </dev/null; then
         gum log --level warn "Failed to install $plugin"
         (( ++failed ))
       fi
@@ -89,11 +102,14 @@ update_plugins() {
     fi
 
     gum log --level info "Updating $plugin..."
-    if ! claude plugin update "$plugin"; then
+    # </dev/null keeps the CLI from reading the loop's stdin, which is the
+    # inventory: one prompt-happy invocation would swallow the rest of it and
+    # leave every plugin after this one silently unattempted.
+    if ! claude plugin update "$plugin" </dev/null; then
       gum log --level warn "Failed to update $plugin"
       (( ++failed ))
     fi
-  done < <(plugin_inventory)
+  done <<< "$inventory"
 
   if ((failed > 0)); then
     gum log --level warn "$failed plugin(s) failed to update"
@@ -109,48 +125,62 @@ audit_plugins() {
   gum log --level info "Auditing plugin payloads..."
 
   local output rc=0
-  output=$("$bin_dir/claude-plugin-audit" 2>&1) || rc=$?
+  output=$("$bin_dir/claude-plugin-audit" </dev/null 2>&1) || rc=$?
   print -r -- "$output"
 
-  if ((rc != 0)); then
-    report_drift "$output"
-  else
-    report_success "claude-plugin-drift"
-  fi
+  case $rc in
+    0) report_success "claude-plugin-drift" ;;
+    1) report_drift "$output" ;;
+    # The audit could not run at all: missing, not executable, or unable to read
+    # the inventory. Filing that as drift would name plugins it never checked
+    # and would leave the upgrade reporting success over a check that never ran.
+    *)
+      gum log --level warn "Plugin audit did not run"
+      return 1
+      ;;
+  esac
 }
 
-upgrade_metadata() {
-  local revision version
-  revision=$(git -C "$CLAUDE_REPO_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-  version=$(claude --version 2>/dev/null || echo "unknown")
-  print -r -- "$revision"$'\t'"- **Claude:** $version"
+upgrade_revision() {
+  git -C "$CLAUDE_REPO_HOME" rev-parse --short HEAD 2>/dev/null || print -r -- "unknown"
+}
+
+upgrade_meta() {
+  print -r -- "- **Claude:** $(claude --version </dev/null 2>/dev/null || print -r -- unknown)"
+}
+
+# Reduce a job's output to what is wrong with it, so the latch reopens when that
+# changes. Everything after the first two fields is detail that moves on its own.
+failure_fingerprint() {
+  awk "$1" | sort | shasum | cut -c1-12
 }
 
 report_upgrade_failure() {
   local output="$1"
 
-  local revision meta
-  IFS=$'\t' read -r revision meta <<< "$(upgrade_metadata)"
+  # Keyed on which steps warned, so a sync that keeps failing stays quiet while
+  # a plugin failing on top of it reopens the latch.
+  local fingerprint
+  fingerprint=$(print -r -- "$output" |
+    failure_fingerprint '/^(WARN|ERRO)/ { print $2, $3, $4 }')
 
   report_failure "claude-upgrade" "Claude upgrade failed" "claude-upgrade" "$output" \
-    "$revision" "$meta"
+    "$(upgrade_revision)" "$(upgrade_meta)" "Error Output" "$fingerprint"
 }
 
 report_drift() {
   local output="$1"
 
-  local revision meta
-  IFS=$'\t' read -r revision meta <<< "$(upgrade_metadata)"
-
   # The subject and verdict of each finding, without the detail, so drift that
   # deepens on a plugin already named stays quiet while a newly affected plugin
-  # reopens the latch.
+  # reopens the latch. Unverified rows are left out: they are the flaky-network
+  # bucket, and hashing them would reopen the latch on any 3am blip.
   local fingerprint
   fingerprint=$(print -r -- "$output" |
-    awk '$2 ~ /^(stale|orphaned|unverified)$/ { print $1, $2 }' | sort | shasum | cut -c1-12)
+    failure_fingerprint '$2 ~ /^(stale|orphaned)$/ { print $1, $2 }')
 
   report_failure "claude-plugin-drift" "Claude plugins are stale" "claude-plugin-audit" \
-    "$output" "$revision" "$meta" "Stale Plugins" "$fingerprint"
+    "$output" "$(upgrade_revision)" "$(upgrade_meta)" "Stale Plugins" "$fingerprint"
 }
 
 main() {
@@ -172,8 +202,11 @@ main() {
     update_marketplaces
 
     local plugins_rc=0
-    update_plugins || plugins_rc=$?
-    audit_plugins
+    update_plugins || plugins_rc=1
+    # The audit runs whatever the update pass did, since a failed update is the
+    # case most likely to have left something stale. Its own findings go to a
+    # separate latch, so only a broken audit reaches this status.
+    audit_plugins || plugins_rc=1
     exit $plugins_rc
   } 2>&1 | tee "$output"
 

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -4,6 +4,11 @@
 
 CLAUDE_REPO_HOME="${CLAUDE_REPO_HOME:-$HOME/.claude-repo}"
 
+# Captured at file scope: inside a function $0 is the function name, so the
+# audit could not be found from there.
+typeset -g bin_dir=${0:A:h}
+
+source "${0:A:h}/../scripts/lib/claude-plugins.sh"
 source "${0:A:h}/../scripts/lib/git-sync.sh"
 source "${0:A:h}/../scripts/lib/report-failure.sh"
 source "${0:A:h}/../scripts/lib/sync-notify.sh"
@@ -57,67 +62,88 @@ update_marketplaces() {
   claude plugin marketplace update || gum log --level warn "marketplace update had issues, continuing"
 }
 
+# Update every plugin installed at user scope, enabled or not. `claude plugin
+# enable` does not update, so a disabled plugin skipped here comes back stale
+# whenever it is re-enabled.
 update_plugins() {
   gum log --level info "Updating plugins..."
 
-  local marketplace_file="$CLAUDE_REPO_HOME/.claude-plugin/marketplace.json"
-  local marketplace_name
-  marketplace_name=$(jq -r '.name' "$marketplace_file")
+  local failed=0 plugin payload source_rc
+  while IFS=$'\t' read -r plugin payload; do
+    [[ -n "$plugin" ]] || continue
 
-  local settings_file="$HOME/.claude/settings.json"
-  if [[ ! -f "$settings_file" ]]; then
-    gum log --level warn "settings.json not found at $settings_file"
-    return 0
-  fi
+    source_rc=0
+    plugin_source "$plugin" >/dev/null || source_rc=$?
+    # A marketplace that no longer offers the plugin has nothing to update it
+    # to, so `claude plugin update` can only ever fail. claude-plugin-audit
+    # reports these. Counting them here would make every run fail.
+    (( source_rc == 4 )) && continue
 
-  local plugins
-  plugins=$(jq -r --arg m "$marketplace_name" \
-    '.enabledPlugins // {} | keys[] | select(endswith("@" + $m))' \
-    "$settings_file" 2>/dev/null)
-
-  if [[ -z "$plugins" ]]; then
-    gum log --level info "No first-party plugins found"
-    return 0
-  fi
-
-  local installed_json
-  installed_json=$(claude plugin list --json 2>/dev/null || echo '[]')
-
-  local failed=0
-  while IFS= read -r plugin; do
-    local is_installed
-    is_installed=$(echo "$installed_json" | jq -r --arg p "$plugin" 'any(.id == $p)')
-    if [[ "$is_installed" != "true" ]]; then
+    if [[ -z "$payload" || ! -d "$payload" ]]; then
       gum log --level info "Installing $plugin (not yet installed)..."
-      if claude plugin install "$plugin"; then
-        continue
-      else
+      if ! claude plugin install "$plugin"; then
         gum log --level warn "Failed to install $plugin"
-        ((failed++))
-        continue
+        (( ++failed ))
       fi
+      continue
     fi
+
     gum log --level info "Updating $plugin..."
     if ! claude plugin update "$plugin"; then
       gum log --level warn "Failed to update $plugin"
-      ((failed++))
+      (( ++failed ))
     fi
-  done <<< "$plugins"
+  done < <(plugin_inventory)
 
   if ((failed > 0)); then
     gum log --level warn "$failed plugin(s) failed to update"
+    return 1
   fi
+}
+
+# Check what the update pass actually produced, and report drift on a latch of
+# its own. Drift outlives the run that should have fixed it, so sharing the
+# claude-upgrade latch would let one persistent stale plugin suppress the to-do
+# for a later upgrade failure.
+audit_plugins() {
+  gum log --level info "Auditing plugin payloads..."
+
+  local output rc=0
+  output=$("$bin_dir/claude-plugin-audit" 2>&1) || rc=$?
+  print -r -- "$output"
+
+  if ((rc != 0)); then
+    report_drift "$output"
+  else
+    report_success "claude-plugin-drift"
+  fi
+}
+
+upgrade_metadata() {
+  local revision version
+  revision=$(git -C "$CLAUDE_REPO_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  version=$(claude --version 2>/dev/null || echo "unknown")
+  print -r -- "$revision"$'\t'"- **Claude:** $version"
 }
 
 report_upgrade_failure() {
   local output="$1"
 
-  local revision version
-  revision=$(git -C "$CLAUDE_REPO_HOME" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-  version=$(claude --version 2>/dev/null || echo "unknown")
+  local revision meta
+  IFS=$'\t' read -r revision meta <<< "$(upgrade_metadata)"
 
   report_failure "claude-upgrade" "Claude upgrade failed" "claude-upgrade" "$output" \
-    "$revision" "- **Claude:** $version"
+    "$revision" "$meta"
+}
+
+report_drift() {
+  local output="$1"
+
+  local revision meta
+  IFS=$'\t' read -r revision meta <<< "$(upgrade_metadata)"
+
+  report_failure "claude-plugin-drift" "Claude plugins are stale" "claude-plugin-audit" \
+    "$output" "$revision" "$meta" "Stale Plugins"
 }
 
 main() {
@@ -137,7 +163,11 @@ main() {
     # sync_repo keeps its PR push on the SSH pushurl.
     git_https_env
     update_marketplaces
-    update_plugins
+
+    local plugins_rc=0
+    update_plugins || plugins_rc=$?
+    audit_plugins
+    exit $plugins_rc
   } 2>&1 | tee "$output"
 
   if [[ ${pipestatus[1]} -ne 0 ]]; then
@@ -149,4 +179,6 @@ main() {
   gum log --level info "All Claude upgrades completed successfully"
 }
 
-main
+# Run only when executed directly. When sourced (tests), ZSH_EVAL_CONTEXT gains
+# a ":file" suffix, so the functions are defined without running the upgrade.
+[[ "$ZSH_EVAL_CONTEXT" == toplevel ]] && main "$@"

--- a/claude/README.md
+++ b/claude/README.md
@@ -60,36 +60,23 @@ without removing, `--force` skips the prompt.
 
 ## Plugins
 
-`claude-upgrade` runs nightly. It syncs the Claude config repo, refreshes every
-marketplace, then updates every plugin installed at user scope, disabled ones
-included. `claude plugin enable` does not update, so a plugin skipped while
-disabled would come back stale months later.
+`claude-upgrade` runs nightly. It syncs the Claude config repo, refreshes every marketplace, then updates every plugin installed at user scope, disabled ones included. `claude plugin enable` does not update, so a plugin skipped while disabled would come back stale months later.
 
-An installed plugin its marketplace no longer offers is left alone. Nothing can
-update it, so the fix is to uninstall it, and the audit says so.
+A plugin no longer offered by its marketplace is left alone. Nothing can update it, so the fix is to uninstall it, and the audit says so.
 
 ### Auditing
 
-`claude plugin update` exiting 0 is not evidence that anything changed. A plugin
-declaring a fixed `version` string reports "already at the latest version"
-however far its source has moved, and an id the updater never enumerated is
-never attempted at all. Both leave a stale install behind a successful run.
+`claude plugin update` exiting 0 is not evidence that anything changed. A plugin that declares a fixed `version` string reports "already at the latest version" however far its source has moved, and an id the updater never enumerated is never attempted at all. Both leave a stale install behind a successful run.
 
-`claude-plugin-audit` checks the result instead. For a plugin the marketplace
-carries in its own tree, it compares the installed payload against that tree,
-ignoring the runtime markers and installed dependencies that only ever exist on
-the payload side. For a plugin living in its own repo, it compares the recorded
-commit against what the remote points at. It exits non-zero listing what needs
-attention, and is worth running by hand for an on-demand answer.
+`claude-plugin-audit` checks the result instead. For a plugin that the marketplace carries in its own tree, it compares the installed payload against that tree, ignoring the runtime markers and installed dependencies that only ever exist on the payload side. For a plugin living in its own repo, it compares the recorded commit against the sha the marketplace pins, or against what the remote points at when the marketplace pins nothing. It exits non-zero, listing what needs attention, and is worth running by hand for an on-demand answer.
 
-The comparison is on content rather than the recorded `gitCommitSha`, because a
-forced refresh (`rm -rf` the payload, then update) restores current content
-while leaving that field at its old value.
+The marketplace clones are checked too. Every other comparison reads them as ground truth, and `claude plugin marketplace update` warns rather than fails, so a clone that quietly stopped advancing would match a stale install and hide the drift from both sides. A marketplace served as a tarball has no clone to check and is reported as unverified.
 
-`claude-upgrade` runs the audit after updating and files its findings as a
-Things to-do on a latch separate from the upgrade's own. Drift outlives the run
-that should have fixed it, so one stale plugin sharing the upgrade latch would
-suppress the to-do for a later upgrade failure.
+A comparison that could not be made is not a finding. At 3am an unreachable remote is a flaky network far more often than a real change, so unverified results print but do not fail the audit.
+
+The tree comparison is on content rather than the recorded `gitCommitSha`, because a forced refresh (`rm -rf` the payload, then update) restores current content while leaving that field at its old value. A plugin sourced from its own repo has no local copy of that repo to compare against, so it falls back to the recorded commit and inherits the same inaccuracy. Repair one of those with `claude plugin uninstall` and `install` rather than a forced refresh, which would leave it permanently flagged.
+
+`claude-upgrade` runs the audit after updating and files its findings as a Things to-do on a latch separate from the upgrade's own. Drift outlives the run that should have fixed it, so one stale plugin sharing the upgrade latch would suppress the to-do for a later upgrade failure. The latch also holds a fingerprint of which plugins are flagged, so a plugin that goes stale months later reopens it instead of hiding behind one that has been stale all along.
 
 ## Computer Use
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -58,6 +58,39 @@ without removing, `--force` skips the prompt.
 
 `CLAUDE_AGENTS_ADD_DIR` (colon-separated) passes tool-access directories as repeated `--add-dir` to both the launcher's dispatch and the popup.
 
+## Plugins
+
+`claude-upgrade` runs nightly. It syncs the Claude config repo, refreshes every
+marketplace, then updates every plugin installed at user scope, disabled ones
+included. `claude plugin enable` does not update, so a plugin skipped while
+disabled would come back stale months later.
+
+An installed plugin its marketplace no longer offers is left alone. Nothing can
+update it, so the fix is to uninstall it, and the audit says so.
+
+### Auditing
+
+`claude plugin update` exiting 0 is not evidence that anything changed. A plugin
+declaring a fixed `version` string reports "already at the latest version"
+however far its source has moved, and an id the updater never enumerated is
+never attempted at all. Both leave a stale install behind a successful run.
+
+`claude-plugin-audit` checks the result instead. For a plugin the marketplace
+carries in its own tree, it compares the installed payload against that tree,
+ignoring the runtime markers and installed dependencies that only ever exist on
+the payload side. For a plugin living in its own repo, it compares the recorded
+commit against what the remote points at. It exits non-zero listing what needs
+attention, and is worth running by hand for an on-demand answer.
+
+The comparison is on content rather than the recorded `gitCommitSha`, because a
+forced refresh (`rm -rf` the payload, then update) restores current content
+while leaving that field at its old value.
+
+`claude-upgrade` runs the audit after updating and files its findings as a
+Things to-do on a latch separate from the upgrade's own. Drift outlives the run
+that should have fixed it, so one stale plugin sharing the upgrade latch would
+suppress the to-do for a later upgrade failure.
+
 ## Computer Use
 
 Claude Code's built-in `computer-use` MCP drives the macOS GUI with screenshots and mouse/keyboard input. [Peekaboo](https://github.com/steipete/peekaboo) is the accessibility-tree fallback for cases where screenshot perception is brittle or too costly: `peekaboo see` snapshots the AX tree with element IDs, then `peekaboo click`/`type` target those IDs. Call it from any agent via the CLI.

--- a/claude/README.md
+++ b/claude/README.md
@@ -76,7 +76,13 @@ A payload is only as current as the tree it was compared against, so a plugin th
 
 A comparison that could not be made is not a finding. At 3am an unreachable remote is a flaky network far more often than a real change, so unverified results print but do not fail the audit. An inventory the audit could not read is different: it exits 2 and reports nothing, because calling zero plugins current is the silence the tool exists to break.
 
-The tree comparison is on content rather than the recorded `gitCommitSha`, because a forced refresh (`rm -rf` the payload, then update) restores current content while leaving that field at its old value. A plugin sourced from its own repo has no local copy of that repo to compare against, so it falls back to the recorded commit and inherits the same inaccuracy. Repair one of those with `claude plugin uninstall` and `install` rather than a forced refresh, which would leave it permanently flagged.
+The tree comparison is on content rather than the recorded `gitCommitSha`, because a forced refresh restores current content while leaving that field at its old value. A plugin sourced from its own repo has no local copy of that repo to compare against, so it falls back to the recorded commit and inherits the same inaccuracy.
+
+### Repairing a Flagged Plugin
+
+`claude plugin uninstall <id>` then `claude plugin install <id>`. Deleting the payload and running `claude plugin update` does not work on the plugins most likely to be flagged: a version-keyed plugin reports `already at the latest version` whether or not the payload is even there, so the delete stands and the plugin ends up uninstalled behind a successful-looking update. Reinstalling also rewrites `gitCommitSha`, which a forced refresh leaves stale and permanently flagged for a plugin sourced from its own repo.
+
+Payload directories carry an `.in_use` directory holding one file per session PID. Check those with `kill -0` before removing anything by hand. Deleting a payload out from under a live session breaks its skill loads until restart, which is why the audit only ever reports.
 
 `claude-upgrade` runs the audit after updating and files its findings as a Things to-do on a latch separate from the upgrade's own. Drift outlives the run that should have fixed it, so one stale plugin sharing the upgrade latch would suppress the to-do for a later upgrade failure. The latch also holds a fingerprint of which plugins are flagged, so a plugin that goes stale months later reopens it instead of hiding behind one that has been stale all along.
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -72,7 +72,9 @@ A plugin no longer offered by its marketplace is left alone. Nothing can update 
 
 The marketplace clones are checked too. Every other comparison reads them as ground truth, and `claude plugin marketplace update` warns rather than fails, so a clone that quietly stopped advancing would match a stale install and hide the drift from both sides. A marketplace served as a tarball has no clone to check and is reported as unverified.
 
-A comparison that could not be made is not a finding. At 3am an unreachable remote is a flaky network far more often than a real change, so unverified results print but do not fail the audit.
+A payload is only as current as the tree it was compared against, so a plugin that matches a marketplace the audit could not vouch for is reported as unverified rather than current. Without that, one unchecked marketplace would hide every install it serves.
+
+A comparison that could not be made is not a finding. At 3am an unreachable remote is a flaky network far more often than a real change, so unverified results print but do not fail the audit. An inventory the audit could not read is different: it exits 2 and reports nothing, because calling zero plugins current is the silence the tool exists to break.
 
 The tree comparison is on content rather than the recorded `gitCommitSha`, because a forced refresh (`rm -rf` the payload, then update) restores current content while leaving that field at its old value. A plugin sourced from its own repo has no local copy of that repo to compare against, so it falls back to the recorded commit and inherits the same inaccuracy. Repair one of those with `claude plugin uninstall` and `install` rather than a forced refresh, which would leave it permanently flagged.
 

--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -175,6 +175,16 @@ add_orphan() {
   write_plugin_list
 }
 
+# A plugin the marketplace still carries but no longer says where to get. The
+# marketplace has not dropped it, so uninstalling is the wrong answer.
+drop_source() {
+  local name="$1" marketplace="$2"
+  local manifest="$plugins/marketplaces/$marketplace/.claude-plugin/marketplace.json"
+  jq --arg name "$name" \
+    '.plugins |= map(if .name == $name then del(.source) else . end)' \
+    "$manifest" >"$manifest.next" && mv "$manifest.next" "$manifest"
+}
+
 BeforeEach 'setup'
 
 # `zsh -f` skips ~/.zshenv, which after bootstrap re-runs `brew shellenv` and
@@ -236,6 +246,16 @@ Describe "update_plugins"
     When call call_upgrade update_plugins
     The status should be success
     The contents of file "$CLAUDE_PLUGIN_LOG" should not include "ghost@first"
+  End
+
+  # Only a marketplace that stopped listing the plugin is beyond updating. One
+  # that lists it without saying where it comes from still carries it, and
+  # skipping those is how a plugin stops being updated for good.
+  It "keeps updating a plugin listed without a source"
+    drop_source alpha first
+    When call call_upgrade update_plugins
+    The status should be success
+    The contents of file "$CLAUDE_PLUGIN_LOG" should include "update alpha@first"
   End
 
   # The loop's stdin is the inventory. One CLI invocation that reads stdin would
@@ -342,5 +362,35 @@ Describe "claude-plugin-audit"
     The status should be failure
     The output should include "ghost@first"
     The output should include "orphaned"
+  End
+
+  It "does not call a plugin orphaned while its marketplace still lists it"
+    drop_source alpha first
+    When call run_audit
+    The status should be success
+    The output should include "alpha@first"
+    The output should include "unverified"
+    The output should not include "orphaned"
+  End
+
+  # A file the audit cannot read is not a file that changed. Reporting it as
+  # drift files a to-do that no plugin update can ever clear.
+  It "reports an unreadable payload as unverified rather than stale"
+    Skip if "root reads a file whatever its mode says" [ "$(id -u)" = 0 ]
+    chmod 000 "$plugins/cache/third/beta/abc123/README.md"
+    When call run_audit
+    The status should be success
+    The output should include "beta@third"
+    The output should include "could not compare"
+  End
+
+  # macOS diff exits 0 here, having written only to stderr, so a payload with a
+  # path nothing could compare would otherwise be reported as current.
+  It "reports a payload it could not fully read as unverified"
+    ln -sf nowhere "$plugins/cache/third/beta/abc123/README.md"
+    When call run_audit
+    The status should be success
+    The output should include "beta@third"
+    The output should include "could not compare"
   End
 End

--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+#
+# Locks the two invariants a silent plugin upgrade failure broke: every
+# installed plugin is enumerated for update, and a plugin that did not end up
+# matching its marketplace is reported. Both regressions were invisible from the
+# outside, because the upgrade kept exiting 0 while installs sat months behind.
+#
+# The functions are exercised by sourcing bin/claude-upgrade and
+# bin/claude-plugin-audit under their ZSH_EVAL_CONTEXT guard, which defines them
+# without running the upgrade. PATH-shim stubs for claude/gum/git feed canned
+# plugin metadata to the real code, following claude_prune_agents_spec.sh.
+
+upgrade="$SHELLSPEC_PROJECT_ROOT/../bin/claude-upgrade"
+audit="$SHELLSPEC_PROJECT_ROOT/../bin/claude-plugin-audit"
+
+# The commit every fixture install records, and by default the one the stubbed
+# remote reports, so a repo-backed plugin starts out current.
+recorded_sha="1111111111111111111111111111111111111111"
+
+setup() {
+  sandbox="$SHELLSPEC_TMPBASE/claude-upgrade"
+  stubdir="$sandbox/stub"
+  plugins="$sandbox/.claude/plugins"
+  rm -rf "$sandbox"
+  mkdir -p "$stubdir" "$plugins"
+
+  export HOME="$sandbox"
+  export CLAUDE_PLUGIN_LOG="$sandbox/plugin.log"
+  export CLAUDE_UPDATE_FAILS=""
+  : >"$CLAUDE_PLUGIN_LOG"
+
+  # alpha ships its own .claude-plugin and matches its marketplace, down to the
+  # .in_use marker Claude Code writes into the payload at runtime.
+  write_plugin alpha first "$plugins/cache/first/alpha/1.0.0"
+  mkdir -p "$plugins/marketplaces/first/plugins/alpha/.claude-plugin"
+  printf '{"name":"alpha"}\n' >"$plugins/marketplaces/first/plugins/alpha/.claude-plugin/plugin.json"
+  cp -R "$plugins/marketplaces/first/plugins/alpha/." "$plugins/cache/first/alpha/1.0.0/"
+  : >"$plugins/cache/first/alpha/1.0.0/.in_use"
+
+  # beta ships no .claude-plugin, so Claude Code synthesizes one into the
+  # payload, and its dependencies land there as node_modules. Neither comes from
+  # the marketplace, and neither is drift.
+  write_plugin beta third "$plugins/cache/third/beta/abc123"
+  mkdir -p "$plugins/marketplaces/third/plugins/beta"
+  printf 'beta\n' >"$plugins/marketplaces/third/plugins/beta/README.md"
+  cp -R "$plugins/marketplaces/third/plugins/beta/." "$plugins/cache/third/beta/abc123/"
+  mkdir -p "$plugins/cache/third/beta/abc123/.claude-plugin" \
+    "$plugins/cache/third/beta/abc123/node_modules/dep"
+  printf '{"name":"beta"}\n' >"$plugins/cache/third/beta/abc123/.claude-plugin/plugin.json"
+
+  # gamma carries a second record left behind by an uninstall, pointing at a
+  # payload directory that was never created.
+  write_plugin gamma first "$plugins/cache/first/gamma/1.0.0" "$plugins/cache/first/gamma/unknown"
+  mkdir -p "$plugins/marketplaces/first/plugins/gamma"
+  printf 'gamma\n' >"$plugins/marketplaces/first/plugins/gamma/README.md"
+  cp -R "$plugins/marketplaces/first/plugins/gamma/." "$plugins/cache/first/gamma/1.0.0/"
+
+  # delta lives in its own repo rather than in the marketplace tree, so it is
+  # checked against the commit that repo currently points at.
+  write_plugin delta third "$plugins/cache/third/delta/1.0.0" \
+    '{"source":"github","repo":"example/delta"}'
+
+  write_marketplace first alpha gamma
+  write_marketplace third beta delta
+  write_settings alpha@first beta@third gamma@first delta@third
+  write_plugin_list
+
+  cat >"$stubdir/claude" <<'CLAUDE'
+#!/usr/bin/env bash
+case "$2" in
+  list)   cat "$HOME/plugin-list.json" ;;
+  update)
+    printf 'update %s\n' "$3" >>"$CLAUDE_PLUGIN_LOG"
+    case " $CLAUDE_UPDATE_FAILS " in *" $3 "*) exit 1 ;; esac
+    ;;
+  install) printf 'install %s\n' "$3" >>"$CLAUDE_PLUGIN_LOG" ;;
+esac
+exit 0
+CLAUDE
+  chmod +x "$stubdir/claude"
+
+  # Only ls-remote is stubbed; the audit uses git for nothing else.
+  cat >"$stubdir/git" <<'GIT'
+#!/usr/bin/env bash
+[ "$1" = "ls-remote" ] && printf '%s\trefs/heads/main\n' "$REMOTE_SHA"
+exit 0
+GIT
+  chmod +x "$stubdir/git"
+  export REMOTE_SHA="$recorded_sha"
+
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$stubdir/gum"
+  chmod +x "$stubdir/gum"
+}
+
+# Record a plugin's install metadata. Extra arguments are either further
+# installPaths (duplicate records) or, when JSON, the plugin's marketplace
+# source; a source implies the install is tracked by commit rather than content.
+write_plugin() {
+  local name="$1" marketplace="$2" path="$3"
+  shift 3
+  printf '%s\t%s\t%s\n' "$name" "$marketplace" "$path" >>"$sandbox/plugins.tsv"
+  mkdir -p "$path"
+  local extra
+  for extra in "$@"; do
+    case "$extra" in
+      '{'*) printf '%s\t%s\n' "$path" "$extra" >>"$sandbox/sources.tsv" ;;
+      *)    printf '%s\t%s\t%s\n' "$name" "$marketplace" "$extra" >>"$sandbox/plugins.tsv" ;;
+    esac
+  done
+}
+
+write_marketplace() {
+  local marketplace="$1" name entries=""
+  shift
+  for name in "$@"; do
+    local source="\"./plugins/$name\""
+    grep -q "/$marketplace/$name/" "$sandbox/sources.tsv" 2>/dev/null &&
+      source=$(grep "/$marketplace/$name/" "$sandbox/sources.tsv" | cut -f2)
+    entries="$entries{\"name\":\"$name\",\"source\":$source},"
+  done
+  mkdir -p "$plugins/marketplaces/$marketplace/.claude-plugin"
+  printf '{"name":"%s","plugins":[%s]}\n' "$marketplace" "${entries%,}" \
+    >"$plugins/marketplaces/$marketplace/.claude-plugin/marketplace.json"
+}
+
+write_settings() {
+  local id keys=""
+  for id in "$@"; do keys="$keys\"$id\":true,"; done
+  mkdir -p "$HOME/.claude"
+  printf '{"enabledPlugins":{%s}}\n' "${keys%,}" >"$HOME/.claude/settings.json"
+}
+
+# Render the fixture rows into what `claude plugin list --json` reports and what
+# installed_plugins.json records, so the two always agree.
+write_plugin_list() {
+  awk -F'\t' 'BEGIN { print "[" } {
+    printf "%s{\"id\":\"%s@%s\",\"scope\":\"user\",\"enabled\":true,\"installPath\":\"%s\"}\n",
+      (NR > 1 ? "," : ""), $1, $2, $3
+  } END { print "]" }' "$sandbox/plugins.tsv" >"$HOME/plugin-list.json"
+
+  awk -F'\t' -v sha="$recorded_sha" 'BEGIN { print "[{\"key\":\"plugins\",\"value\":{" } {
+    printf "%s\"%s@%s\":[{\"installPath\":\"%s\",\"gitCommitSha\":\"%s\"}]\n",
+      (NR > 1 ? "," : ""), $1, $2, $3, sha
+  } END { print "}}]" }' "$sandbox/plugins.tsv" >"$plugins/installed_plugins.json"
+}
+
+# An installed plugin its marketplace stopped offering. Nothing can update it,
+# so the update pass has to leave it alone and the audit has to name it.
+add_orphan() {
+  write_plugin ghost first "$plugins/cache/first/ghost/1.0.0"
+  write_plugin_list
+}
+
+BeforeEach 'setup'
+
+# `zsh -f` skips ~/.zshenv, which after bootstrap re-runs `brew shellenv` and
+# reorders PATH, pushing $stubdir below a real claude/git and shadowing the stubs.
+call_upgrade() { PATH="$stubdir:$PATH" zsh -fc 'source "$1"; shift; "$@"' _ "$upgrade" "$@"; }
+run_audit() { PATH="$stubdir:$PATH" zsh -f "$audit"; }
+inventory_ids() { call_upgrade plugin_inventory | cut -f1 | paste -sd, -; }
+
+Describe "plugin enumeration"
+  # The filter this replaced kept only ids ending in the first-party marketplace
+  # name, so every third-party plugin went unattempted for months.
+  It "includes plugins from every marketplace"
+    When call call_upgrade plugin_inventory
+    The status should be success
+    The output should include "alpha@first"
+    The output should include "beta@third"
+  End
+
+  It "emits one row per plugin"
+    When call inventory_ids
+    The status should be success
+    The output should equal "alpha@first,beta@third,delta@third,gamma@first"
+  End
+
+  It "points a duplicated plugin at the payload that exists"
+    When call call_upgrade plugin_inventory
+    The status should be success
+    The output should include "cache/first/gamma/1.0.0"
+    The output should not include "gamma/unknown"
+  End
+End
+
+Describe "update_plugins"
+  It "updates every installed plugin"
+    When call call_upgrade update_plugins
+    The status should be success
+    The contents of file "$CLAUDE_PLUGIN_LOG" should include "update alpha@first"
+    The contents of file "$CLAUDE_PLUGIN_LOG" should include "update beta@third"
+  End
+
+  # Counting failures and returning 0 is what let a machine where every update
+  # failed still report success and file no to-do.
+  It "fails when an update fails"
+    export CLAUDE_UPDATE_FAILS="beta@third"
+    When call call_upgrade update_plugins
+    The status should be failure
+  End
+
+  It "leaves a plugin its marketplace dropped alone"
+    add_orphan
+    When call call_upgrade update_plugins
+    The status should be success
+    The contents of file "$CLAUDE_PLUGIN_LOG" should not include "ghost@first"
+  End
+End
+
+Describe "claude-plugin-audit"
+  It "passes when every payload matches its marketplace"
+    When call run_audit
+    The status should be success
+    The output should include "4 plugins current"
+  End
+
+  It "flags a payload that lost a file"
+    rm "$plugins/cache/third/beta/abc123/README.md"
+    When call run_audit
+    The status should be failure
+    The output should include "beta@third"
+    The output should include "stale"
+  End
+
+  # A plugin that ships its own .claude-plugin stays compared. Excluding the
+  # directory outright to spare the plugins Claude Code synthesizes one for
+  # would blind the audit to every manifest change.
+  It "flags a payload whose manifest fell behind"
+    printf '{"name":"alpha","version":"2"}\n' \
+      >"$plugins/marketplaces/first/plugins/alpha/.claude-plugin/plugin.json"
+    When call run_audit
+    The status should be failure
+    The output should include "alpha@first"
+    The output should include "stale"
+  End
+
+  It "flags a payload behind the commit its repo points at"
+    export REMOTE_SHA="2222222222222222222222222222222222222222"
+    When call run_audit
+    The status should be failure
+    The output should include "delta@third"
+    The output should include "222222222222"
+  End
+
+  It "flags a plugin its marketplace dropped"
+    add_orphan
+    When call run_audit
+    The status should be failure
+    The output should include "ghost@first"
+    The output should include "orphaned"
+  End
+End

--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -56,14 +56,15 @@ setup() {
   printf 'gamma\n' >"$plugins/marketplaces/first/plugins/gamma/README.md"
   cp -R "$plugins/marketplaces/first/plugins/gamma/." "$plugins/cache/first/gamma/1.0.0/"
 
-  # delta lives in its own repo rather than in the marketplace tree, so it is
-  # checked against the commit that repo currently points at.
+  # delta lives in its own repo, so it is checked against the commit that repo
+  # currently points at.
   write_plugin delta third "$plugins/cache/third/delta/1.0.0" \
     '{"source":"github","repo":"example/delta"}'
 
   write_marketplace first alpha gamma
   write_marketplace third beta delta
   write_settings alpha@first beta@third gamma@first delta@third
+  write_known_marketplaces
   write_plugin_list
 
   cat >"$stubdir/claude" <<'CLAUDE'
@@ -80,14 +81,18 @@ exit 0
 CLAUDE
   chmod +x "$stubdir/claude"
 
-  # Only ls-remote is stubbed; the audit uses git for nothing else.
+  # Only ls-remote and rev-parse are stubbed; the audit uses git for nothing else.
   cat >"$stubdir/git" <<'GIT'
 #!/usr/bin/env bash
-[ "$1" = "ls-remote" ] && printf '%s\trefs/heads/main\n' "$REMOTE_SHA"
+case "$1" in
+  ls-remote) printf '%s\trefs/heads/main\n' "$REMOTE_SHA" ;;
+  -C)        [ "$3" = "rev-parse" ] && printf '%s\n' "$CLONE_SHA" ;;
+esac
 exit 0
 GIT
   chmod +x "$stubdir/git"
   export REMOTE_SHA="$recorded_sha"
+  export CLONE_SHA="$recorded_sha"
 
   printf '#!/usr/bin/env bash\nexit 0\n' >"$stubdir/gum"
   chmod +x "$stubdir/gum"
@@ -95,7 +100,7 @@ GIT
 
 # Record a plugin's install metadata. Extra arguments are either further
 # installPaths (duplicate records) or, when JSON, the plugin's marketplace
-# source; a source implies the install is tracked by commit rather than content.
+# source. A source implies the install is tracked by commit.
 write_plugin() {
   local name="$1" marketplace="$2" path="$3"
   shift 3
@@ -128,7 +133,25 @@ write_settings() {
   local id keys=""
   for id in "$@"; do keys="$keys\"$id\":true,"; done
   mkdir -p "$HOME/.claude"
-  printf '{"enabledPlugins":{%s}}\n' "${keys%,}" >"$HOME/.claude/settings.json"
+  printf '{"enabledPlugins":{%s,"disabled@first":false}}\n' "${keys%,}" \
+    >"$HOME/.claude/settings.json"
+}
+
+# first is a git clone, so its freshness is checkable. third is materialized
+# from a tarball and has no clone to read.
+write_known_marketplaces() {
+  mkdir -p "$plugins/marketplaces/first/.git"
+  jq -n --arg plugins "$plugins" '
+    ["first", "third"]
+    | map({
+        key: .,
+        value: {
+          source: {source: "github", repo: ("example/" + .)},
+          installLocation: ($plugins + "/marketplaces/" + .)
+        }
+      })
+    | from_entries
+  ' >"$plugins/known_marketplaces.json"
 }
 
 # Render the fixture rows into what `claude plugin list --json` reports and what
@@ -176,6 +199,14 @@ Describe "plugin enumeration"
     The output should equal "alpha@first,beta@third,delta@third,gamma@first"
   End
 
+  # settings.json records a plugin turned off as a false value rather than
+  # dropping the key, so reading the keys alone would install it.
+  It "leaves out a plugin settings.json turned off"
+    When call inventory_ids
+    The status should be success
+    The output should not include "disabled@first"
+  End
+
   It "points a duplicated plugin at the payload that exists"
     When call call_upgrade plugin_inventory
     The status should be success
@@ -212,7 +243,26 @@ Describe "claude-plugin-audit"
   It "passes when every payload matches its marketplace"
     When call run_audit
     The status should be success
-    The output should include "4 plugins current"
+    The output should include "5 checks current"
+  End
+
+  # The marketplace clones are what every payload is compared against, and
+  # `claude plugin marketplace update` only warns when it fails.
+  It "flags a marketplace clone behind its source"
+    export CLONE_SHA="3333333333333333333333333333333333333333"
+    When call run_audit
+    The status should be failure
+    The output should include "marketplace/first"
+    The output should include "stale"
+  End
+
+  # A comparison that could not be made is a flaky network far more often than
+  # a real change, so failing on one would file a to-do the next run clears.
+  It "reports what it cannot verify without failing"
+    When call run_audit
+    The status should be success
+    The output should include "marketplace/third"
+    The output should include "unverified"
   End
 
   It "flags a payload that lost a file"

--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -69,6 +69,7 @@ setup() {
 
   cat >"$stubdir/claude" <<'CLAUDE'
 #!/usr/bin/env bash
+[ -n "$CLAUDE_DRAINS_STDIN" ] && cat >/dev/null
 case "$2" in
   list)   cat "$HOME/plugin-list.json" ;;
   update)
@@ -80,6 +81,7 @@ esac
 exit 0
 CLAUDE
   chmod +x "$stubdir/claude"
+  export CLAUDE_DRAINS_STDIN=""
 
   # Only ls-remote and rev-parse are stubbed; the audit uses git for nothing else.
   cat >"$stubdir/git" <<'GIT'
@@ -137,10 +139,8 @@ write_settings() {
     >"$HOME/.claude/settings.json"
 }
 
-# first is a git clone, so its freshness is checkable. third is materialized
-# from a tarball and has no clone to read.
 write_known_marketplaces() {
-  mkdir -p "$plugins/marketplaces/first/.git"
+  mkdir -p "$plugins/marketplaces/first/.git" "$plugins/marketplaces/third/.git"
   jq -n --arg plugins "$plugins" '
     ["first", "third"]
     | map({
@@ -237,13 +237,35 @@ Describe "update_plugins"
     The status should be success
     The contents of file "$CLAUDE_PLUGIN_LOG" should not include "ghost@first"
   End
+
+  # The loop's stdin is the inventory. One CLI invocation that reads stdin would
+  # swallow the rest of it and leave every plugin after it unattempted, with
+  # nothing in the exit status to say so.
+  It "updates every plugin even when the CLI reads stdin"
+    export CLAUDE_DRAINS_STDIN=1
+    When call call_upgrade update_plugins
+    The status should be success
+    The contents of file "$CLAUDE_PLUGIN_LOG" should include "update alpha@first"
+    The contents of file "$CLAUDE_PLUGIN_LOG" should include "update gamma@first"
+  End
+
+  # An inventory that could not be read is not an empty one: updating nothing
+  # and reporting success is the failure this job exists to make loud.
+  It "fails when the inventory cannot be read"
+    printf 'not json\n' >"$HOME/.claude/settings.json"
+    When call call_upgrade update_plugins
+    The status should be failure
+    The contents of file "$CLAUDE_PLUGIN_LOG" should equal ""
+    # jq's own complaint reaches the captured log, so the to-do names the cause.
+    The stderr should be defined
+  End
 End
 
 Describe "claude-plugin-audit"
   It "passes when every payload matches its marketplace"
     When call run_audit
     The status should be success
-    The output should include "5 checks current"
+    The output should include "6 checks current"
   End
 
   # The marketplace clones are what every payload is compared against, and
@@ -259,10 +281,31 @@ Describe "claude-plugin-audit"
   # A comparison that could not be made is a flaky network far more often than
   # a real change, so failing on one would file a to-do the next run clears.
   It "reports what it cannot verify without failing"
+    rm -rf "$plugins/marketplaces/first/.git"
     When call run_audit
     The status should be success
-    The output should include "marketplace/third"
+    The output should include "marketplace/first"
     The output should include "unverified"
+  End
+
+  # A stale clone matches every stale payload under it, so calling those current
+  # is how one unchecked marketplace hides every install it serves.
+  It "does not call a payload current against a marketplace it cannot vouch for"
+    rm -rf "$plugins/marketplaces/first/.git"
+    When call run_audit
+    The status should be success
+    The output should include "alpha@first"
+    The output should include "itself unverified"
+  End
+
+  # An inventory that could not be read is not an empty one. Reporting
+  # everything current over it is the silence this tool exists to break.
+  It "refuses to report on an inventory it could not read"
+    printf 'not json\n' >"$HOME/.claude/settings.json"
+    When call run_audit
+    The status should equal 2
+    The stderr should include "could not enumerate"
+    The output should not include "current"
   End
 
   It "flags a payload that lost a file"

--- a/scripts/lib/claude-plugins.sh
+++ b/scripts/lib/claude-plugins.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=bash
+# Sourceable inventory of the Claude Code plugins installed on this machine.
+# Shared by bin/claude-upgrade, which updates them, and bin/claude-plugin-audit,
+# which checks the update landed.
+#
+# claude_plugins_dir
+#   Root of the plugin state directory.
+#
+# plugin_inventory
+#   Print "<id>\t<installPath>" for every user-scope plugin, one per line.
+#   The rows are the union of what `claude plugin list` reports and the
+#   enabledPlugins keys in settings.json, so a plugin enabled but never
+#   installed still appears, with an empty installPath.
+#
+# plugin_source <id>
+#   Print the plugin's `source` value, as JSON, from its marketplace manifest.
+#   Exit 3 when the marketplace has no readable manifest, 4 when the manifest no
+#   longer lists the plugin.
+
+claude_plugins_dir() {
+  printf '%s\n' "$HOME/.claude/plugins"
+}
+
+plugin_inventory() {
+  local list settings rows id best row_id row_path
+
+  list=$(claude plugin list --json 2>/dev/null)
+  [ -n "$list" ] || list='[]'
+
+  settings='{}'
+  [ -f "$HOME/.claude/settings.json" ] && settings=$(cat "$HOME/.claude/settings.json")
+
+  rows=$(jq -rn --argjson list "$list" --argjson settings "$settings" '
+      [ $list[] | select(.scope == "user") | [.id, .installPath // ""] ]
+    + [ ($settings.enabledPlugins // {}) | keys[] | [., ""] ]
+    | .[] | @tsv
+  ' 2>/dev/null) || return 1
+
+  # A plugin can hold several records: an uninstall that left its metadata
+  # behind writes a duplicate pointing at a path that was never created, and
+  # `claude plugin list` prints both. The payload that exists is the real one.
+  printf '%s\n' "$rows" | cut -f1 | sort -u | while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    best=""
+    while IFS=$'\t' read -r row_id row_path; do
+      [ "$row_id" = "$id" ] || continue
+      [ -n "$row_path" ] || continue
+      [ -n "$best" ] || best="$row_path"
+      if [ -d "$row_path" ]; then
+        best="$row_path"
+        break
+      fi
+    done <<EOF
+$rows
+EOF
+    printf '%s\t%s\n' "$id" "$best"
+  done
+}
+
+plugin_source() {
+  local id="$1" name="${1%@*}" marketplace="${1##*@}" manifest source
+
+  manifest="$(claude_plugins_dir)/marketplaces/$marketplace/.claude-plugin/marketplace.json"
+  [ -f "$manifest" ] || return 3
+
+  source=$(jq -c --arg name "$name" \
+    'first((.plugins // [])[] | select(.name == $name) | .source) // empty' \
+    "$manifest" 2>/dev/null) || return 3
+  [ -n "$source" ] || return 4
+
+  printf '%s\n' "$source"
+}

--- a/scripts/lib/claude-plugins.sh
+++ b/scripts/lib/claude-plugins.sh
@@ -8,9 +8,11 @@
 #
 # plugin_inventory
 #   Print "<id>\t<installPath>" for every user-scope plugin, one per line.
-#   The rows are the union of what `claude plugin list` reports and the
-#   enabledPlugins keys in settings.json, so a plugin enabled but never
-#   installed still appears, with an empty installPath.
+#   The rows are the union of what `claude plugin list` reports and the plugins
+#   settings.json enables, so a plugin enabled but never installed still
+#   appears, with an empty installPath. A plugin enabled by a project or a
+#   settings.local.json is out of scope: `claude plugin update` works at user
+#   scope, so those are not this job's to update.
 #
 # plugin_source <id>
 #   Print the plugin's `source` value, as JSON, from its marketplace manifest.
@@ -32,7 +34,7 @@ plugin_inventory() {
 
   rows=$(jq -rn --argjson list "$list" --argjson settings "$settings" '
       [ $list[] | select(.scope == "user") | [.id, .installPath // ""] ]
-    + [ ($settings.enabledPlugins // {}) | keys[] | [., ""] ]
+    + [ ($settings.enabledPlugins // {}) | to_entries[] | select(.value) | [.key, ""] ]
     | .[] | @tsv
   ' 2>/dev/null) || return 1
 

--- a/scripts/lib/claude-plugins.sh
+++ b/scripts/lib/claude-plugins.sh
@@ -21,9 +21,10 @@
 #
 # plugin_source <id>
 #   Print the plugin's `source` value, as JSON, from its marketplace manifest.
-#   Exits $PLUGIN_SOURCE_UNREADABLE when the marketplace has no readable
-#   manifest, $PLUGIN_SOURCE_ABSENT when the manifest no longer lists the
-#   plugin. Both are named because two callers branch on them.
+#   Exits $PLUGIN_SOURCE_UNREADABLE when the manifest is missing, unparseable,
+#   or lists the plugin without a source, and $PLUGIN_SOURCE_ABSENT only when
+#   the manifest no longer lists the plugin at all. Both are named because two
+#   callers branch on them, and only ABSENT means uninstalling is the fix.
 
 PLUGIN_SOURCE_UNREADABLE=3
 PLUGIN_SOURCE_ABSENT=4
@@ -72,15 +73,23 @@ EOF
 }
 
 plugin_source() {
-  local name="${1%@*}" marketplace="${1##*@}" manifest source
+  local name="${1%@*}" marketplace="${1##*@}" manifest entry source
 
   manifest="$(claude_plugins_dir)/marketplaces/$marketplace/.claude-plugin/marketplace.json"
   [ -f "$manifest" ] || return "$PLUGIN_SOURCE_UNREADABLE"
 
-  source=$(jq -c --arg name "$name" \
-    'first((.plugins // [])[] | select(.name == $name) | .source) // empty' \
+  entry=$(jq -c --arg name "$name" \
+    'first((.plugins // [])[] | select(.name == $name)) // empty' \
     "$manifest" 2>/dev/null) || return "$PLUGIN_SOURCE_UNREADABLE"
-  [ -n "$source" ] || return "$PLUGIN_SOURCE_ABSENT"
+  [ -n "$entry" ] || return "$PLUGIN_SOURCE_ABSENT"
+
+  # Resolved from the entry rather than in one pass, so a plugin listed with no
+  # source reads as an unreadable manifest. Collapsing it into ABSENT would skip
+  # the plugin in every update and then tell you to uninstall something the
+  # marketplace still carries.
+  source=$(printf '%s\n' "$entry" | jq -c '.source // empty') ||
+    return "$PLUGIN_SOURCE_UNREADABLE"
+  [ -n "$source" ] || return "$PLUGIN_SOURCE_UNREADABLE"
 
   printf '%s\n' "$source"
 }

--- a/scripts/lib/claude-plugins.sh
+++ b/scripts/lib/claude-plugins.sh
@@ -14,10 +14,19 @@
 #   settings.local.json is out of scope: `claude plugin update` works at user
 #   scope, so those are not this job's to update.
 #
+#   Exits non-zero when the inventory could not be read. Callers must check:
+#   an unparseable settings.json or a stray line on the CLI's stdout would
+#   otherwise read as "no plugins installed", and a job that updates nothing
+#   and reports success is the failure this whole file exists to remove.
+#
 # plugin_source <id>
 #   Print the plugin's `source` value, as JSON, from its marketplace manifest.
-#   Exit 3 when the marketplace has no readable manifest, 4 when the manifest no
-#   longer lists the plugin.
+#   Exits $PLUGIN_SOURCE_UNREADABLE when the marketplace has no readable
+#   manifest, $PLUGIN_SOURCE_ABSENT when the manifest no longer lists the
+#   plugin. Both are named because two callers branch on them.
+
+PLUGIN_SOURCE_UNREADABLE=3
+PLUGIN_SOURCE_ABSENT=4
 
 claude_plugins_dir() {
   printf '%s\n' "$HOME/.claude/plugins"
@@ -26,21 +35,25 @@ claude_plugins_dir() {
 plugin_inventory() {
   local list settings rows id best row_id row_path
 
-  list=$(claude plugin list --json 2>/dev/null)
+  list=$(claude plugin list --json </dev/null 2>/dev/null) || return 1
   [ -n "$list" ] || list='[]'
 
   settings='{}'
-  [ -f "$HOME/.claude/settings.json" ] && settings=$(cat "$HOME/.claude/settings.json")
+  if [ -f "$HOME/.claude/settings.json" ]; then
+    settings=$(cat "$HOME/.claude/settings.json") || return 1
+  fi
 
   rows=$(jq -rn --argjson list "$list" --argjson settings "$settings" '
       [ $list[] | select(.scope == "user") | [.id, .installPath // ""] ]
     + [ ($settings.enabledPlugins // {}) | to_entries[] | select(.value) | [.key, ""] ]
     | .[] | @tsv
-  ' 2>/dev/null) || return 1
+  ') || return 1
 
   # A plugin can hold several records: an uninstall that left its metadata
   # behind writes a duplicate pointing at a path that was never created, and
-  # `claude plugin list` prints both. The payload that exists is the real one.
+  # `claude plugin list` prints both. Prefer a payload that exists, and among
+  # those one Claude Code has not superseded, since it keeps the directory it
+  # replaced around under an .orphaned_at marker.
   printf '%s\n' "$rows" | cut -f1 | sort -u | while IFS= read -r id; do
     [ -n "$id" ] || continue
     best=""
@@ -48,10 +61,9 @@ plugin_inventory() {
       [ "$row_id" = "$id" ] || continue
       [ -n "$row_path" ] || continue
       [ -n "$best" ] || best="$row_path"
-      if [ -d "$row_path" ]; then
-        best="$row_path"
-        break
-      fi
+      [ -d "$row_path" ] || continue
+      best="$row_path"
+      [ -e "$row_path/.orphaned_at" ] || break
     done <<EOF
 $rows
 EOF
@@ -60,15 +72,15 @@ EOF
 }
 
 plugin_source() {
-  local id="$1" name="${1%@*}" marketplace="${1##*@}" manifest source
+  local name="${1%@*}" marketplace="${1##*@}" manifest source
 
   manifest="$(claude_plugins_dir)/marketplaces/$marketplace/.claude-plugin/marketplace.json"
-  [ -f "$manifest" ] || return 3
+  [ -f "$manifest" ] || return "$PLUGIN_SOURCE_UNREADABLE"
 
   source=$(jq -c --arg name "$name" \
     'first((.plugins // [])[] | select(.name == $name) | .source) // empty' \
-    "$manifest" 2>/dev/null) || return 3
-  [ -n "$source" ] || return 4
+    "$manifest" 2>/dev/null) || return "$PLUGIN_SOURCE_UNREADABLE"
+  [ -n "$source" ] || return "$PLUGIN_SOURCE_ABSENT"
 
   printf '%s\n' "$source"
 }

--- a/scripts/lib/report-failure.sh
+++ b/scripts/lib/report-failure.sh
@@ -4,7 +4,7 @@
 # notify <title> <message> [sound]
 #   Darwin-guarded osascript notification (default sound: Basso).
 #
-# report_failure <job> <title> <command> <output> <revision> [extra_meta] [output_heading]
+# report_failure <job> <title> <command> <output> <revision> [extra_meta] [output_heading] [fingerprint]
 #   File a Things to-do describing the failure and notify, but only on the
 #   transition into a failed state. A per-job latch under
 #   ${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/<job>.status records ok
@@ -15,6 +15,12 @@
 #   markdown appended to the host/time/revision header; <output_heading> names
 #   the section holding <output>, for a job whose output is a finding list
 #   rather than an error (default: "Error Output").
+#
+#   <fingerprint> is an optional summary of what is wrong, stored in the latch.
+#   A job that reports a set of findings rather than one failure needs it: with
+#   a plain latch, the first standing finding suppresses every finding that
+#   appears after it, however long it stands. When the fingerprint changes the
+#   latch reopens and a fresh to-do names the new set.
 #
 # report_success <job>
 #   Clear the latch.
@@ -48,15 +54,17 @@ report_failure() {
   local revision="$5"
   local extra_meta="$6"
   local output_heading="${7:-Error Output}"
+  local fingerprint="${8:-}"
 
-  local status_file prior
+  local status_file prior latch="failed"
+  [[ -n "$fingerprint" ]] && latch="failed $fingerprint"
   status_file=$(report_status_file "$job")
   # `|| true` keeps a missing latch (first-ever failure) from killing
   # `set -e` callers before the to-do is filed.
   prior=$(cat "$status_file" 2>/dev/null || true)
-  echo failed >"$status_file"
+  echo "$latch" >"$status_file"
 
-  if [[ "$prior" == "failed" ]]; then
+  if [[ "$prior" == "$latch" ]]; then
     gum log --level info "$job still failing - to-do already filed, staying quiet"
     return 0
   fi

--- a/scripts/spec/report_failure_spec.sh
+++ b/scripts/spec/report_failure_spec.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+#
+# Locks the latch that decides whether an unattended job's failure reaches
+# Things. The latch is the whole point of the file: a job that files a to-do
+# every night trains you to ignore it, and one that files none after the first
+# leaves later breakage silent. The fingerprint cases cover a job whose output
+# is a set of findings, where the second of those failures is the live risk.
+
+# shellcheck source=../lib/report-failure.sh
+Include "$SHELLSPEC_PROJECT_ROOT/lib/report-failure.sh"
+
+setup() {
+  sandbox="$SHELLSPEC_TMPBASE/report-failure"
+  stubdir="$sandbox/stub"
+  rm -rf "$sandbox"
+  mkdir -p "$stubdir"
+  stub_gum "$stubdir"
+  stub_osascript "$stubdir"
+
+  export XDG_STATE_HOME="$sandbox/state"
+  export TODO_LOG="$sandbox/todos.log"
+  : >"$TODO_LOG"
+
+  # `open` is the only way a to-do is created, so logging it is the whole
+  # observation: a line means a to-do was filed, no line means the latch held.
+  printf '%s\n' '#!/usr/bin/env bash' 'printf "todo\n" >>"$TODO_LOG"' \
+    >"$stubdir/open"
+  chmod +x "$stubdir/open"
+}
+
+BeforeEach 'setup'
+
+fail() {
+  PATH="$stubdir:$PATH" report_failure drift "Stale" "audit" "$1" "abc123" "" "Findings" "$2"
+}
+todos() { wc -l <"$TODO_LOG" | tr -d ' '; }
+
+Describe "report_failure latch"
+  It "files a to-do on the first failure"
+    When call fail "one plugin stale" ""
+    The status should be success
+    The stderr should be defined
+    The result of function todos should equal 1
+  End
+
+  It "stays quiet while the job keeps failing the same way"
+    fail "one plugin stale" "" >/dev/null 2>&1
+    When call fail "one plugin stale" ""
+    The status should be success
+    The stderr should be defined
+    The result of function todos should equal 1
+  End
+
+  It "files again after report_success clears the latch"
+    fail "one plugin stale" "" >/dev/null 2>&1
+    report_success drift
+    When call fail "one plugin stale" ""
+    The status should be success
+    The stderr should be defined
+    The result of function todos should equal 2
+  End
+End
+
+Describe "report_failure fingerprint"
+  # Without this, the first plugin to go stale suppresses every plugin that goes
+  # stale afterwards, for as long as the first one stays broken.
+  It "files again when the findings change"
+    fail "alpha stale" "alpha" >/dev/null 2>&1
+    When call fail "alpha stale, beta stale" "alpha-beta"
+    The status should be success
+    The stderr should be defined
+    The result of function todos should equal 2
+  End
+
+  It "stays quiet when the findings are unchanged"
+    fail "alpha stale" "alpha" >/dev/null 2>&1
+    When call fail "alpha stale" "alpha"
+    The status should be success
+    The stderr should be defined
+    The result of function todos should equal 1
+  End
+End


### PR DESCRIPTION
`claude-upgrade` has reported success every night for months while most installed plugins sat frozen. A worktrunk skill was running v0.52.0 code (May) against a v0.68.0 pin (July), which sent a subagent into the wrong repo. Investigation found three independent failures, each of which produces a green run on its own.

**Enumeration.** `update_plugins` selected enabled ids with `endswith("@" + $m)` against the first-party marketplace name, so every third-party plugin was never attempted. `claude plugin update worktrunk@worktrunk` repaired it instantly by hand, so nothing but the filter was in the way.

**Unreportable failure.** `update_plugins` counted failures, logged a warning, and returned 0. `main` read `${pipestatus[1]}`, saw 0, and called `report_success`. Every plugin update on the machine could fail with no to-do filed.

**Version-string no-op.** `claude plugin update` compares declared version strings. A plugin declaring `version: "1.0.0"` whose source has moved prints `already at the latest version` and exits 0 with the install still stale. Fixing the first two does not fix this, which is why the fix is not only a better updater.

## The audit

`bin/claude-plugin-audit` checks the outcome rather than trusting the updater. A green update is not evidence anything moved. Comparing what is installed against what the marketplace currently offers is the only check that catches all three failure modes, and the next one.

It compares content rather than the recorded `gitCommitSha`, because a forced refresh restores current content while leaving that field at its old value. The field lies exactly when you have just repaired something.

The exclusion list in `compare_payload` was derived empirically, not guessed: `.in_use` and `.orphaned_at` are runtime markers, `node_modules` is an install-time artifact, and `.git` belongs to a marketplace whose whole repo is the plugin. `.claude-plugin` is excluded only when the marketplace source lacks it, so the plugins that ship their own manifest stay covered. With those, every current plugin on this machine compares clean, which is the acceptance bar for a detector like this: any systematic materialization difference would have meant dozens of false positives on night one and a tool nobody trusts.

`compare_payload` keeps `diff`'s stderr separate from its stdout. On macOS, `diff` can hit a path it can't read, a dangling symlink for instance, and still exit 0 while writing the complaint to stderr. Folding that onto stdout made an unreadable file read as drift that no plugin update could ever clear. Those paths report unverified now.

The audit reports and never repairs. Repairing a version-keyed plugin means `rm -rf <installPath>`, and payload directories carry `.in_use` markers naming live session PIDs. Deleting one out from under a 3am session breaks its skill loads until restart, which is worse than a to-do sitting in Things.

There is deliberately no fast path that skips no-op updates. Gating updates on the same comparison the audit uses would make the check self-certifying: one bug would both skip the update and report clean. The whole set costs about 30s nightly.

## Decisions worth flagging

**Updates cover every installed plugin, enabled or not.** `claude plugin enable` does not update, so a disabled plugin skipped here comes back stale whenever it is re-enabled. Costs roughly 15s per run.

**Both passes are user scope only.** `claude plugin update` operates at user scope and exits 1 with `not installed at scope user` for a project-scoped install, so including those would fail the run forever.

**The update pass skips plugins the marketplace no longer lists.** `claude plugin update calendar@bendrucker` exits 1 with `Plugin "calendar" not found`, and 15 such plugins exist here. Counting them would make every run red. The audit reports them as `orphaned` instead, where the action is to uninstall.

**A plugin listed without a source keeps updating.** A missing `source` field is not the marketplace dropping the plugin. Conflating the two skipped the plugin in every update pass and had the audit recommend uninstalling something still on offer. Only a marketplace that stops listing the plugin at all counts as orphaned now.

**Marketplace clones are checked too.** They are the ground truth every payload comparison reads, and `claude plugin marketplace update` warns rather than fails. A clone that quietly stopped advancing would match a stale install and hide the drift from both sides. `claude-plugins-official` is materialized from a tarball with no `.git`, so it is reported as unverifiable rather than assumed fresh.

**A verdict is only as good as the tree behind it.** A plugin matching a marketplace the audit could not vouch for reports as unverified, not current.

**Unverifiable is not a finding.** At 3am an unreachable remote is a flaky network far more often than a real change, so those print but do not fail. A plugin or marketplace inventory that could not be read is the opposite: it exits 2 and reports nothing, because calling zero plugins current is the silence this exists to break.

**Both latches carry a fingerprint.** `report_failure` gained an optional eighth argument stored in the latch. Without it the first plugin to go stale suppresses every plugin that goes stale afterwards for as long as the first stays broken, which is the same silence in a new place. Drift keys on the subject and verdict of each finding, so drift deepening on a plugin already named stays quiet while a newly affected one reopens it.

## Verification

`shellspec` covers both directories. Beyond the regression cases, the specs pin the behaviors that are invisible when they break: a CLI that reads the loop's stdin no longer truncates the inventory, an unreadable inventory fails instead of reading as empty, and a payload matching an unvouched marketplace is not called current.

A full `bin/claude-upgrade` run repaired everything that had been frozen (47 checks current, up from 32) and filed one drift to-do. Re-running with the same findings stays quiet, so the latch behaves.

The audit also found a case the investigation had missed: `ralph-wiggum@claude-code-plugins` is version-keyed at `1.0.0` with content three files behind, which is the same failure as `agents-md` in a plugin nobody was looking at.

## Follow-ups

Two changes live in other repos: dropping the stale marketplace ref pins in `bendrucker/claude` with a CI check that every enabled id resolves, and removing the `version` field from `bendrucker/claude-code-agents-md` so it becomes commit-keyed like every other first-party plugin. `agents-md` and `gopls-lsp` stay flagged here until those land and a forced refresh runs.
