### PR TITLE
herdr: fail when a composed manifest loses its cache

### DIFF
--- a/bin/herdr-agent-detection
+++ b/bin/herdr-agent-detection
@@ -166,7 +166,17 @@ sync_agent () {
   local composed
 
   if [[ ! -s "$base" ]]; then
-    print -u2 -- "herdr has no cached $agent manifest; leaving $installed as it is"
+    # Nothing cached and nothing installed is a machine that has not run herdr
+    # yet, and the first run fixes it. Nothing cached with a generated file
+    # already in place is the opposite: herdr is reading a composed manifest
+    # that can no longer be rebuilt, from a cache path this script only knows
+    # by convention. Every other path here would leave that quiet, so it has to
+    # be a failure, or the to-do that exists to report it clears as success.
+    if [[ -f "$installed" ]] && is_generated "$installed"; then
+      print -u2 -- "herdr has no cached $agent manifest, so $installed can no longer be recomposed"
+      return 1
+    fi
+    print -u2 -- "herdr has no cached $agent manifest; nothing to compose"
     return 0
   fi
 

--- a/herdr/spec/agent_detection_spec.sh
+++ b/herdr/spec/agent_detection_spec.sh
@@ -88,6 +88,21 @@ TOML
     The status should be success
   End
 
+  # The other direction of the same situation: something is installed, so herdr
+  # is serving a composed manifest, and the cache it was composed from is gone.
+  # Silence here would leave that file frozen for good.
+  It "fails when a cache it already composed from has gone missing"
+    lost_base() {
+      write_base
+      run_script sync >/dev/null || return
+      rm -f "$base"
+      run_script sync 2>&1
+    }
+    When call lost_base
+    The status should be failure
+    The output should include "can no longer be recomposed"
+  End
+
   It "reports an install left behind by a newer manifest"
     stale() {
       write_base


### PR DESCRIPTION
`sync` composes the shipped overlay onto the manifest herdr caches under `~/.local/state/herdr/agent-detection/remote`. Nothing documents that path, so it going away is the likeliest way this breaks.

It handled that badly. A missing cache printed to stderr and returned success, so the run left `breaks` empty and cleared the very to-do latch that exists to report it. On the nightly nobody reads stderr. The installed override would sit frozen indefinitely with no signal anywhere, which is the failure the curation rule asks a customization to rule out.

Missing cache with nothing installed is still fine and still returns zero. That is a machine that has not run herdr yet, and its first run resolves it. Missing cache with a generated file already in place is the opposite: herdr is serving a composed manifest nothing can rebuild, and that now fails and files the to-do.
