### PR TITLE
herdr: recompose the detection override when herdr fetches

### DIFF
--- a/bin/herdr-agent-detection
+++ b/bin/herdr-agent-detection
@@ -306,6 +306,11 @@ case "${1:-sync}" in
       exit 0
     fi
 
+    # launchd watches this directory to rerun sync the moment herdr fetches a
+    # manifest, and it can only watch a path that exists. herdr creates it on
+    # its first run, which may come after this one on a new machine.
+    mkdir -p "$cache_dir"
+
     installed_any=0
     evaluated=0
     drifts=()

--- a/macos/com.user.herdr-agent-detection.plist
+++ b/macos/com.user.herdr-agent-detection.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.herdr-agent-detection</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-l</string>
+        <string>-c</string>
+        <string>$HOME/.dotfiles/bin/herdr-agent-detection sync</string>
+    </array>
+
+    <!--
+      herdr fetches manifests on its own schedule, and a local override replaces
+      whatever it fetched. Left to the nightly install, a manifest published at
+      noon would be shadowed until 3am, and the day herdr publishes one is
+      disproportionately the day Claude Code changed its UI, which is when the
+      shadowed rules matter most.
+
+      launchd does not expand anything here, so install.sh substitutes __HOME__.
+      Both entries are deliberate: a manifest arriving by atomic rename changes
+      the directory, and one written in place changes only the file.
+    -->
+    <key>WatchPaths</key>
+    <array>
+        <string>__HOME__/.local/state/herdr/agent-detection/remote</string>
+        <string>__HOME__/.local/state/herdr/agent-detection/remote/claude.toml</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/herdr-agent-detection.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/herdr-agent-detection.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -29,7 +29,9 @@ install_launch_agent() {
 
   launchctl bootout "gui/$UID/$label" 2>/dev/null || true
 
-  cp "$plist_src" "$plist_dst"
+  # launchd expands nothing outside ProgramArguments, which the shell handles,
+  # so keys it reads itself (WatchPaths) carry __HOME__ and get it here.
+  sed "s|__HOME__|$HOME|g" "$plist_src" >"$plist_dst"
 
   # bootout of a running service is asynchronous; an immediate bootstrap can
   # race the teardown and fail, so retry briefly.
@@ -78,6 +80,11 @@ install_launch_agent com.user.theme-sync.plist "theme-sync watcher"
 # aw-qt supervises the ActivityWatch capture stack. This LaunchAgent is the sole
 # autostart, so leave AW's built-in login item disabled to avoid a double launch.
 install_launch_agent com.user.activitywatch.plist "ActivityWatch capture"
+
+# Recompose the agent detection overrides when herdr fetches a manifest, rather
+# than leaving a new one shadowed until the nightly install. The job no-ops on a
+# machine without herdr, so it installs in every mode like the watcher above.
+install_launch_agent com.user.herdr-agent-detection.plist "herdr agent detection watcher"
 
 # Only setup upgrade if we're in separate-directory mode (not a symlink)
 if [[ ! -L "$HOME/.dotfiles" ]]; then


### PR DESCRIPTION
Until now `herdr/install.sh` was the only thing that reran `sync`, which means manual installs and the 3am nightly. herdr fetches manifests on its own schedule, and the composed override replaces whatever it fetched, so a manifest published at noon stayed shadowed for fifteen hours.

Most days that costs nothing. The manifest moves rarely: `claude` has sat at `2026.07.13.1` for three weeks while herdr checked daily. The day it does move is the problem. herdr's `claude` manifest exists to chase Claude Code's UI, so a publish correlates with a UI change, and the rules most likely to move are the permission-prompt ones. A missed permission prompt reads as idle while the agent waits on input, which is worse than the flapping the stack fixes and looks exactly like it.

A launchd `WatchPaths` job closes that to seconds. Some things I checked rather than assumed:

- Both write patterns fire, an atomic rename into the directory and an in-place rewrite of the file, which is why both paths are watched.
- A no-op manifest check leaves the cached files' mtimes untouched, so herdr's daily poll does not trigger it. It fires on a real change.
- `sync` was already idempotent and writes nothing under the watched path, so there is no feedback loop.

launchd expands nothing outside `ProgramArguments`, which the shell handles, so `WatchPaths` carries `__HOME__` and `install_launch_agent` renders it on copy. That substitution is a no-op for the five existing plists.

`sync` now creates the cache directory, because launchd can only watch a path that exists and herdr may not have run yet on a new machine. `install_launch_agent` re-bootstraps on every install, so a first install that ordered `macos` ahead of `herdr` arms the watch on the next one.

Rejected a herdr plugin, since no manifest-update event exists and it would poll an undocumented API to do what one plist does. Rejected anything in zsh startup against a sub-second CI gate. macOS only. Linux keeps the nightly as its floor, which is what everything had before this.
