### PR TITLE
neovim: fix lualine catppuccin theme name

### DIFF
--- a/neovim/config/lua/config/statusline.lua
+++ b/neovim/config/lua/config/statusline.lua
@@ -1,6 +1,6 @@
 require("lualine").setup({
   options = {
-    theme = "catppuccin",
+    theme = "catppuccin-nvim",
     component_separators = { left = "│", right = "│" },
     section_separators = { left = "", right = "" },
     globalstatus = true,

--- a/neovim/spec/neovim_spec.sh
+++ b/neovim/spec/neovim_spec.sh
@@ -15,6 +15,15 @@ Describe "neovim"
     The status should be success
   End
 
+  It "resolves the configured statusline theme"
+    check_statusline() {
+      nvim --headless -c 'luafile spec/support/statusline_check.lua' 2>&1
+    }
+    When call check_statusline
+    The status should be success
+    The output should include "resolves"
+  End
+
   It "installs a working parser for every declared treesitter language"
     check_treesitter() {
       nvim --headless -c 'luafile spec/support/treesitter_check.lua' 2>&1

--- a/neovim/spec/support/statusline_check.lua
+++ b/neovim/spec/support/statusline_check.lua
@@ -1,0 +1,46 @@
+-- Asserts that the theme name configured in config.statusline actually resolves.
+-- lualine wraps its theme load in pcall and degrades to `auto`/`gruvbox` through
+-- vim.notify, so a renamed or misspelled theme leaves startup clean and only
+-- shows up as the wrong statusline colors. Run headless; exits non-zero on
+-- failure.
+
+local failures = {}
+
+local function fail(fmt, ...)
+  local message = string.format(fmt, ...)
+  table.insert(failures, message)
+  io.stderr:write("FAIL: " .. message .. "\n")
+end
+
+local function ok(fmt, ...)
+  io.stdout:write("OK: " .. string.format(fmt, ...) .. "\n")
+end
+
+local theme = require("lualine").get_config().options.theme
+
+if type(theme) ~= "string" then
+  ok("theme is a %s, nothing to resolve by name", type(theme))
+else
+  local resolved, err = pcall(require("lualine.utils.loader").load_theme, theme)
+  if resolved then
+    ok("theme %s resolves", theme)
+  else
+    fail("theme %s does not resolve, lualine falls back: %s", theme, err)
+  end
+end
+
+-- A resolved theme still has to reach the statusline, and create_highlight_groups
+-- is what puts it there.
+local normal = vim.api.nvim_get_hl(0, { name = "lualine_a_normal" })
+if next(normal) == nil then
+  fail("lualine_a_normal is undefined; no theme highlights were created")
+else
+  ok("lualine_a_normal is defined")
+end
+
+if #failures > 0 then
+  io.stderr:write(string.format("\n%d statusline check(s) failed\n", #failures))
+  vim.cmd("cquit 1")
+end
+
+vim.cmd("quit")


### PR DESCRIPTION
Neovim reported this on startup:

```
Theme `catppuccin` not found, falling back to `auto`. Check if spelling is right.
```

Catppuccin renamed its colorscheme and special integrations from `catppuccin` to `catppuccin-nvim` ([catppuccin/nvim#977](https://github.com/catppuccin/nvim/issues/977), [#979](https://github.com/catppuccin/nvim/issues/979)). The plugin now ships:

```
catppuccin-frappe  catppuccin-latte  catppuccin-macchiato  catppuccin-mocha  catppuccin-nvim
```

There is no plain `catppuccin.lua`, and lualine has no built-in catppuccin theme, so `options.theme` fell through to `auto`.

`catppuccin-nvim` is the right target rather than a flavour-specific theme like `catppuccin-latte`. It is `require("catppuccin.utils.lualine")()` with no argument, so it resolves the active flavour at load time. That keeps the statusline in step with `flavour = "auto"` and the `theme-flavor` SIGUSR1 switching in `colorscheme.lua`.

The colorscheme itself was never broken. Upstream kept a `colors/catppuccin.lua` shim, so `colorscheme("catppuccin")` in `colorscheme.lua:50` still resolves and `colors_name` was already `catppuccin-latte`. Only lualine lost the old name.

## Test coverage

`neovim/spec/neovim_spec.sh` missed this. It greps for `E[0-9]+:` and `stack traceback`, and lualine produces neither: the theme load is wrapped in `pcall` and the failure surfaces through `vim.notify`, so startup exits clean and the only symptom is the wrong statusline colors.

The new `spec/support/statusline_check.lua` resolves whatever name `config.statusline` configures through lualine's own loader, so it catches any renamed or misspelled theme rather than catppuccin specifically. It fails on the previous `theme = "catppuccin"` and passes on `catppuccin-nvim`.

## Verification

Reloaded the module in a running Neovim and read back the highlight groups, which now carry the Latte palette:

| Group | bg | fg |
| --- | --- | --- |
| `lualine_a_normal` | `#1e66f5` (blue) | `#e6e9ef` (mantle) |
| `lualine_b_normal` | `#ccd0da` (surface0) | `#1e66f5` (blue) |
| `lualine_a_insert` | `#40a02b` (green) | `#eff1f5` (base) |
