### PR TITLE
macos: avoid self-bootout in launch agent install

### DIFF
--- a/macos/.shellspec
+++ b/macos/.shellspec
@@ -1,0 +1,1 @@
+--shell bash

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -11,44 +11,8 @@ do
   bash "$file"
 done
 
-install_launch_agent() {
-  local plist_name="$1"
-  local description="$2"
-  local plist_src="$ZSH/macos/$plist_name"
-  local plist_dst="$HOME/Library/LaunchAgents/$plist_name"
-  local label="${plist_name%.plist}"
-
-  if [[ ! -f "$plist_src" ]]; then
-    gum log --level warn "$description plist not found, skipping"
-    return
-  fi
-
-  gum log --level info "setting up $description"
-
-  mkdir -p "$HOME/Library/LaunchAgents"
-
-  launchctl bootout "gui/$UID/$label" 2>/dev/null || true
-
-  # launchd expands nothing outside ProgramArguments, which the shell handles,
-  # so keys it reads itself (WatchPaths) carry __HOME__ and get it here.
-  sed "s|__HOME__|$HOME|g" "$plist_src" >"$plist_dst"
-
-  # bootout of a running service is asynchronous; an immediate bootstrap can
-  # race the teardown and fail, so retry briefly.
-  local _attempt
-  for _attempt in 1 2 3 4 5; do
-    launchctl bootstrap "gui/$UID" "$plist_dst" 2>/dev/null && break
-    sleep 0.5
-  done
-
-  if launchctl print "gui/$UID/$label" >/dev/null 2>&1; then
-    gum log --level info "$description launchd agent installed"
-  else
-    gum log --level error "$description launchd agent failed to load; run: launchctl bootstrap gui/$UID $plist_dst"
-    launchd_failed=1
-    return 1
-  fi
-}
+# shellcheck source=lib/launch-agent.sh
+source "$ZSH/macos/lib/launch-agent.sh"
 
 setup_dotfiles_upgrade() {
   # Remove old sync job (replaced by upgrade job which includes sync)

--- a/macos/lib/launch-agent.sh
+++ b/macos/lib/launch-agent.sh
@@ -98,7 +98,7 @@ install_launch_agent() {
   printf '%s\n' "$rendered" >"$plist_dst"
 
   if [[ "$plan" == defer ]]; then
-    gum log --level warn "$description launchd agent is the job running this install, so it keeps its old config; it picks the new one up at next login, or now via: launchctl bootout gui/$UID/$label && launchctl bootstrap gui/$UID $plist_dst"
+    gum log --level warn "$description launchd agent is the job running this install, so it keeps its old config. It picks the new one up at next login, or now via: launchctl bootout gui/$UID/$label && launchctl bootstrap gui/$UID $plist_dst"
     return
   fi
 
@@ -113,7 +113,7 @@ install_launch_agent() {
   if launchctl print "gui/$UID/$label" >/dev/null 2>&1; then
     gum log --level info "$description launchd agent installed"
   else
-    gum log --level error "$description launchd agent failed to load; run: launchctl bootstrap gui/$UID $plist_dst"
+    gum log --level error "$description launchd agent failed to load. Run: launchctl bootstrap gui/$UID $plist_dst"
     # shellcheck disable=SC2034 # macos/install.sh exits on this
     launchd_failed=1
     return 1

--- a/macos/lib/launch-agent.sh
+++ b/macos/lib/launch-agent.sh
@@ -1,0 +1,121 @@
+# shellcheck shell=bash
+# LaunchAgent installation, sourced by macos/install.sh.
+#
+# The nightly com.user.dotfiles-upgrade job runs scripts/install, so this code
+# routinely runs as a descendant of a job it is about to reinstall. launchctl
+# bootout tears down the job's whole process tree, so reinstalling that label
+# kills the run partway: the bootstrap that would put the job back never
+# executes, launchd is left without it, and nothing reports the failure because
+# the reporting code died with the rest of the tree.
+
+# Does launchd hold a job for this label?
+launch_agent_loaded() {
+  launchctl print "gui/$UID/$1" >/dev/null 2>&1
+}
+
+# Is this process part of the job for this label? launchd puts XPC_SERVICE_NAME
+# in the job's own environment, but libxpc rewrites it on every exec, so a
+# descendant as deep as a topic installer is only recognized by the pid walk.
+launch_agent_is_self() {
+  local label="$1"
+
+  [[ "${XPC_SERVICE_NAME:-}" == "$label" ]] && return 0
+
+  local job_pid
+  job_pid=$(launchctl print "gui/$UID/$label" 2>/dev/null |
+    awk '$1 == "pid" && $2 == "=" { print $3; exit }')
+  [[ -n "$job_pid" ]] || return 1
+
+  local pid=$$
+  while [[ -n "$pid" ]] && [[ "$pid" -gt 1 ]]; do
+    [[ "$pid" == "$job_pid" ]] && return 0
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+  done
+
+  return 1
+}
+
+# What installing a label should do, given whether the rendered plist already
+# matches the installed one, whether launchd has the job, and whether this
+# process is running under that job.
+#
+#   skip       leave the file and launchd alone
+#   defer      write the plist and leave the running job on its old config
+#   bootstrap  write and load, with nothing to tear down first
+#   reinstall  tear the job down and load it again
+launch_agent_plan() {
+  local unchanged="$1" loaded="$2" is_self="$3"
+
+  if ((unchanged && loaded)); then
+    echo skip
+  elif ((is_self && loaded)); then
+    echo defer
+  elif ((!loaded)); then
+    echo bootstrap
+  else
+    echo reinstall
+  fi
+}
+
+install_launch_agent() {
+  local plist_name="$1"
+  local description="$2"
+  local plist_src="$ZSH/macos/$plist_name"
+  local plist_dst="$HOME/Library/LaunchAgents/$plist_name"
+  local label="${plist_name%.plist}"
+
+  if [[ ! -f "$plist_src" ]]; then
+    gum log --level warn "$description plist not found, skipping"
+    return
+  fi
+
+  mkdir -p "$HOME/Library/LaunchAgents"
+
+  # launchd expands nothing outside ProgramArguments, which the shell handles,
+  # so keys it reads itself (WatchPaths) carry __HOME__ and get it here.
+  local rendered
+  rendered=$(sed "s|__HOME__|$HOME|g" "$plist_src")
+
+  local unchanged=0 loaded=0 is_self=0
+  [[ -f "$plist_dst" ]] && [[ "$rendered" == "$(cat "$plist_dst")" ]] && unchanged=1
+  launch_agent_loaded "$label" && loaded=1
+  launch_agent_is_self "$label" && is_self=1
+
+  local plan
+  plan=$(launch_agent_plan "$unchanged" "$loaded" "$is_self")
+
+  if [[ "$plan" == skip ]]; then
+    gum log --level info "$description launchd agent already current"
+    return
+  fi
+
+  gum log --level info "setting up $description"
+
+  if [[ "$plan" == reinstall ]]; then
+    launchctl bootout "gui/$UID/$label" 2>/dev/null || true
+  fi
+
+  printf '%s\n' "$rendered" >"$plist_dst"
+
+  if [[ "$plan" == defer ]]; then
+    gum log --level warn "$description launchd agent is the job running this install, so it keeps its old config; it picks the new one up at next login, or now via: launchctl bootout gui/$UID/$label && launchctl bootstrap gui/$UID $plist_dst"
+    return
+  fi
+
+  # bootout of a running service is asynchronous; an immediate bootstrap can
+  # race the teardown and fail, so retry briefly.
+  local _attempt
+  for _attempt in 1 2 3 4 5; do
+    launchctl bootstrap "gui/$UID" "$plist_dst" 2>/dev/null && break
+    sleep 0.5
+  done
+
+  if launchctl print "gui/$UID/$label" >/dev/null 2>&1; then
+    gum log --level info "$description launchd agent installed"
+  else
+    gum log --level error "$description launchd agent failed to load; run: launchctl bootstrap gui/$UID $plist_dst"
+    # shellcheck disable=SC2034 # macos/install.sh exits on this
+    launchd_failed=1
+    return 1
+  fi
+}

--- a/macos/spec/launch_agent_spec.sh
+++ b/macos/spec/launch_agent_spec.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "launch_agent_plan"
+  Include lib/launch-agent.sh
+
+  Describe "for every combination of inputs"
+    Parameters
+      # unchanged loaded is_self  plan
+      1 1 0 skip
+      1 1 1 skip
+      1 0 0 bootstrap
+      1 0 1 bootstrap
+      0 1 0 reinstall
+      0 1 1 defer
+      0 0 0 bootstrap
+      0 0 1 bootstrap
+    End
+
+    It "plans $4 when unchanged=$1 loaded=$2 is_self=$3"
+      When call launch_agent_plan "$1" "$2" "$3"
+      The status should be success
+      The output should equal "$4"
+    End
+  End
+
+  It "never boots out the job this process runs under"
+    plans_for_self() {
+      local unchanged loaded
+      for unchanged in 0 1; do
+        for loaded in 0 1; do
+          launch_agent_plan "$unchanged" "$loaded" 1
+        done
+      done
+    }
+    When call plans_for_self
+    The output should not include "reinstall"
+  End
+
+  It "reloads a job whose plist is installed but unloaded"
+    When call launch_agent_plan 1 0 0
+    The output should equal "bootstrap"
+  End
+End


### PR DESCRIPTION
## Root Cause

The nightly `com.user.dotfiles-upgrade` job runs `bin/dotfiles-upgrade` -> `scripts/install` -> `macos/install.sh`, so `install_launch_agent` reinstalls the label it's running under every night. The old code always ran `launchctl bootout` first. Bootout tears down the job's whole process tree. It killed the run before the matching `bootstrap` could put the job back.

launchd was left without the job. Every later night did nothing, and the failure stayed silent because `report-failure.sh` died with the rest of the tree. I traced this on my own Mac: `dotfiles-upgrade` and `com.user.herdr-agent-detection` had both dropped out of launchd, and herdr's composed detection manifest was stale at base `2026.08.04.1`.

## Fix

`install_launch_agent` now decides from three inputs instead of always tearing down: whether the rendered plist matches the installed one, whether launchd has the job loaded, and whether this process is running under it.

- Unchanged and loaded: no-op. Covers the nightly steady state.
- Loaded, and this process is running under the label: write the plist, leave the job alone. A stale-but-running job beats a dead one.
- Plist present but unloaded: bootstrap. This heals a machine already poisoned by this bug, on its next `scripts/install`, with no manual fix needed.
- Anything else: reinstall, tearing the job down first.

The decision moved to `macos/lib/launch-agent.sh`, so `launch_agent_plan` is a pure function a shellspec suite can pin directly. The suite asserts the invariant that matters most: no input combination where this process runs under the label ever plans a `reinstall`.

## Repair

I hand-repaired this machine rather than waiting for a nightly run to pick up the fix: both jobs re-bootstrapped, and herdr's manifest recomposed.

## Known Gaps

I'm leaving three correctness gaps open here, to keep this PR to the fix rather than a redesign:

- `macos/install.sh` sources `lib/launch-agent.sh` with no error check and no `set -e`. If the source ever fails, every `install_launch_agent` call becomes a silent no-op, `launchd_failed` never gets set, and the script still exits 0.
- `launch_agent_is_self`'s process-ancestry walk fails open to "not self" on any interruption (a `ps` hiccup, or `launchctl print` output drifting from the `pid = <n>` shape the `awk` parse assumes). That routes to `reinstall` and reproduces the exact self-bootout bug this PR fixes.
- After a `defer`, the plist on disk matches the rendered one, so the next run sees `unchanged && loaded` and skips silently. The running job only picks up the new config at the next login, or via the manual command the warn log prints. Nothing re-flags it in between.
