### PR TITLE
claude: guard peekaboo behind OS.mac?

### DIFF
--- a/claude/Brewfile
+++ b/claude/Brewfile
@@ -8,4 +8,6 @@ cask 'commander'
 brew 'agent-browser'
 brew 'ast-grep'
 brew 'rjyo/moshi/moshi-hook', start_service: true
-brew 'steipete/tap/peekaboo'
+if OS.mac?
+  brew 'steipete/tap/peekaboo'
+end


### PR DESCRIPTION
The `steipete/tap/peekaboo` formula added `depends_on macos: :sequoia` in 3.10.0, so `brew bundle` on the Linux CI runner now refuses it and `bootstrap (linux)` fails on every branch, including main. Wrap the declaration in the same `if OS.mac?` guard `macos/Brewfile` already uses so Linux skips it.

Unblocks `bootstrap (linux)` for #638 and #639.