### PR TITLE
terraform: add hcp cli

### DIFF
--- a/terraform/Brewfile
+++ b/terraform/Brewfile
@@ -11,3 +11,6 @@ brew 'tfschema'
 
 tap 'pulumi/tap'
 brew 'pulumi'
+
+tap 'hashicorp/tap'
+brew 'hashicorp/tap/hcp'


### PR DESCRIPTION
Adds the HCP CLI to the terraform topic.

It only ships from `hashicorp/tap`, with nothing in homebrew-core and no mise registry entry, so Homebrew with an explicit tap is the only option. The formula declares `conflicts_with "hcp"`, so this uses the tap-qualified `hashicorp/tap/hcp` rather than the bare name the neighboring entries use. That keeps resolution unambiguous if a core `hcp` ever lands.

No `completion.zsh` entry: `hcp` has no completion command.
