### PR TITLE
worktrunk: leave the default-branch worktree alone

### DIFF
--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -90,24 +90,19 @@ worktree_age_secs () {
   print -r -- $(( EPOCHSECONDS - created ))
 }
 
-# The repo's default branch, or nothing when neither source resolves. Reads
-# worktrunk's own persisted resolution first, so this names the same branch
-# `wt` protects; the origin/HEAD symref covers a repo worktrunk has not
-# resolved yet.
+# The repo's default branch, empty when even worktrunk cannot name one.
 #
-# No pass here can remove a linked worktree holding the default branch:
-# `wt step prune` skips it, it has no PR of its own, and `wt remove` refuses it
-# outright (removing the checkout deletes the branch, and force-delete is the
-# only override). Both the pruner and the audit gate on this name so neither
-# treats it as removable.
+# No pass here can remove a linked worktree holding it: `wt step prune` skips
+# the default branch, it has no PR of its own, and `wt remove` refuses it
+# outright, since removing the checkout deletes the branch and force-delete is
+# the only override. The pruner and the audit both gate on this name to stay
+# out of a removal that cannot succeed.
+#
+# Asking worktrunk rather than reading git config is what makes the two agree:
+# the same resolution guards `wt remove`, and it detects and caches on a miss
+# instead of reporting nothing in a clone that has never been pruned.
 default_branch () {
-  local branch remote_head
-  branch=$(git config --get worktrunk.default-branch 2>/dev/null)
-  if [[ -z "$branch" ]]; then
-    remote_head=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) || return 0
-    branch=${remote_head#origin/}
-  fi
-  print -r -- "$branch"
+  wt config state default-branch get 2>/dev/null
 }
 
 # Resolve the exact PR/MR state for a branch on the forge. Prints
@@ -291,9 +286,8 @@ main () {
       [[ "$is_main" == true ]] && continue
       [[ -n "${seen[$branch]:-}" ]] && continue
 
-      # `wt remove` rejects the default branch, so classifying this worktree as
-      # a survivor buys a failed removal per run and nothing else. Record the
-      # keep before the forge lookup, which has no PR to find for it anyway.
+      # Recorded before the forge lookup, which has no PR to find for the
+      # default branch anyway.
       if [[ -n "$default_br" && "$branch" == "$default_br" ]]; then
         (( dry_run )) && [[ -z "${WT_ALL:-}" ]] \
           && reason_rows+=("${wtpath:t}"$'\t'"$branch"$'\t'"-"$'\t'"keep"$'\t'"default branch")

--- a/bin/wt-prune
+++ b/bin/wt-prune
@@ -90,6 +90,26 @@ worktree_age_secs () {
   print -r -- $(( EPOCHSECONDS - created ))
 }
 
+# The repo's default branch, or nothing when neither source resolves. Reads
+# worktrunk's own persisted resolution first, so this names the same branch
+# `wt` protects; the origin/HEAD symref covers a repo worktrunk has not
+# resolved yet.
+#
+# No pass here can remove a linked worktree holding the default branch:
+# `wt step prune` skips it, it has no PR of its own, and `wt remove` refuses it
+# outright (removing the checkout deletes the branch, and force-delete is the
+# only override). Both the pruner and the audit gate on this name so neither
+# treats it as removable.
+default_branch () {
+  local branch remote_head
+  branch=$(git config --get worktrunk.default-branch 2>/dev/null)
+  if [[ -z "$branch" ]]; then
+    remote_head=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) || return 0
+    branch=${remote_head#origin/}
+  fi
+  print -r -- "$branch"
+}
+
 # Resolve the exact PR/MR state for a branch on the forge. Prints
 # "STATE\tNUMBER" (e.g. "MERGED\t142"), or nothing when no PR exists. gh is the
 # tested path; glab mirrors it (newest MR wins) but is untested.
@@ -262,13 +282,23 @@ main () {
   local -a reason_rows
 
   if [[ "$has_linked" == true ]]; then
-    local remote_host
+    local remote_host default_br
     remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
+    default_br=$(default_branch)
 
     local branch is_main ts clean onremote is_current wtpath pr_out pr_st pr_num
     while IFS=$'\t' read -r branch is_main ts clean onremote is_current wtpath; do
       [[ "$is_main" == true ]] && continue
       [[ -n "${seen[$branch]:-}" ]] && continue
+
+      # `wt remove` rejects the default branch, so classifying this worktree as
+      # a survivor buys a failed removal per run and nothing else. Record the
+      # keep before the forge lookup, which has no PR to find for it anyway.
+      if [[ -n "$default_br" && "$branch" == "$default_br" ]]; then
+        (( dry_run )) && [[ -z "${WT_ALL:-}" ]] \
+          && reason_rows+=("${wtpath:t}"$'\t'"$branch"$'\t'"-"$'\t'"keep"$'\t'"default branch")
+        continue
+      fi
 
       # Resolve the exact PR/MR state for this survivor. The integration pass
       # already cleared branches merged into the local default. A squash-merged

--- a/bin/wt-prune-audit
+++ b/bin/wt-prune-audit
@@ -25,6 +25,9 @@
 #
 # The MERGED rule needs no grace: the pruner's forge pass removes a merged
 # worktree at any age, so one that survives is a genuine miss.
+#
+# A worktree holding the default branch is excluded outright, since nothing the
+# pruner could do would remove it. See default_branch in bin/wt-prune.
 
 set -uo pipefail
 
@@ -71,11 +74,18 @@ main () {
     .kind == "worktree" and (.is_main | not) and (.is_current | not) and ((.branch // "") != ""))' <<<"$list_json")
   [[ "$has_candidate" == true ]] || return 0
 
-  local remote_host
+  local remote_host default_br
   remote_host=$(git remote get-url origin 2>/dev/null | sed -E 's|^[^@]*@||; s|^https?://||; s|[:/].*||')
+  default_br=$(default_branch)
 
   local branch main_state wtpath age pr_out pr_st
   while IFS=$'\t' read -r branch main_state wtpath; do
+    # A worktree holding the default branch reads as integrated because the
+    # branch is the integration target, and no prune pass can act on it. It is
+    # a permanent finding rather than drift: reporting it files the same to-do
+    # every night and no fix to the pruner ever clears it.
+    [[ -n "$default_br" && "$branch" == "$default_br" ]] && continue
+
     # Free signal: `wt list` already resolved this as integrated into the
     # default branch, so a healthy prune would have removed it, once the
     # worktree is old enough for the pruner to consider it at all. An age the

--- a/bin/wt-prune-audit
+++ b/bin/wt-prune-audit
@@ -26,8 +26,8 @@
 # The MERGED rule needs no grace: the pruner's forge pass removes a merged
 # worktree at any age, so one that survives is a genuine miss.
 #
-# A worktree holding the default branch is excluded outright, since nothing the
-# pruner could do would remove it. See default_branch in bin/wt-prune.
+# A worktree holding the default branch is excluded outright, since no prune
+# pass can remove it.
 
 set -uo pipefail
 
@@ -81,9 +81,8 @@ main () {
   local branch main_state wtpath age pr_out pr_st
   while IFS=$'\t' read -r branch main_state wtpath; do
     # A worktree holding the default branch reads as integrated because the
-    # branch is the integration target, and no prune pass can act on it. It is
-    # a permanent finding rather than drift: reporting it files the same to-do
-    # every night and no fix to the pruner ever clears it.
+    # branch is the integration target. Nothing the pruner does can clear it,
+    # so reporting it files the same to-do every night forever.
     [[ -n "$default_br" && "$branch" == "$default_br" ]] && continue
 
     # Free signal: `wt list` already resolved this as integrated into the

--- a/worktrunk/spec/wt_prune_spec.sh
+++ b/worktrunk/spec/wt_prune_spec.sh
@@ -86,11 +86,11 @@ Describe "wt-prune --dry-run and wt-prune-audit (black-box)"
     : >"$WT_REMOVE_LOG"
     : >"$WT_STEP_LOG"
 
-    # wt stub: `step prune` probe reports nothing integrated (so the survivor
-    # reaches the forge pass); `list` emits the canned fixture; `remove` only
-    # logs, so a dry-run that wrongly removed would leave a trace here;
-    # `config state default-branch get` names the branch wt would refuse to
-    # remove, which both scripts read to identify an unprunable worktree.
+    # wt stub: `step prune` probe reports nothing integrated, so the survivor
+    # reaches the forge pass. `remove` only logs, so a dry-run that wrongly
+    # removed would leave a trace here. `config state default-branch get` names
+    # the branch wt would refuse to remove, which both scripts read to identify
+    # an unprunable worktree.
     cat >"$stubdir/wt" <<'WT'
 #!/usr/bin/env bash
 case "$1" in

--- a/worktrunk/spec/wt_prune_spec.sh
+++ b/worktrunk/spec/wt_prune_spec.sh
@@ -88,13 +88,16 @@ Describe "wt-prune --dry-run and wt-prune-audit (black-box)"
 
     # wt stub: `step prune` probe reports nothing integrated (so the survivor
     # reaches the forge pass); `list` emits the canned fixture; `remove` only
-    # logs, so a dry-run that wrongly removed would leave a trace here.
+    # logs, so a dry-run that wrongly removed would leave a trace here;
+    # `config state default-branch get` names the branch wt would refuse to
+    # remove, which both scripts read to identify an unprunable worktree.
     cat >"$stubdir/wt" <<'WT'
 #!/usr/bin/env bash
 case "$1" in
   step)   printf 'step %s\n' "$*" >>"$WT_STEP_LOG"; echo "[]" ;;
   list)   cat "$WT_LIST_JSON" ;;
   remove) printf 'remove %s\n' "$*" >>"$WT_REMOVE_LOG" ;;
+  config) echo main ;;
 esac
 exit 0
 WT
@@ -124,9 +127,6 @@ GH
     git -C "$repo" -c user.email=test@example.com -c user.name=test \
       commit -q --allow-empty -m init
     git -C "$repo" remote add origin "https://github.com/test/repo.git"
-    # worktrunk persists its default-branch resolution here, and both scripts
-    # read it to identify the branch `wt remove` refuses to touch.
-    git -C "$repo" config worktrunk.default-branch main
 
     # A real linked worktree, so the age helper resolves a per-worktree git dir
     # (a .git *file* pointing at .git/worktrees/<name>) rather than the repo's

--- a/worktrunk/spec/wt_prune_spec.sh
+++ b/worktrunk/spec/wt_prune_spec.sh
@@ -124,6 +124,9 @@ GH
     git -C "$repo" -c user.email=test@example.com -c user.name=test \
       commit -q --allow-empty -m init
     git -C "$repo" remote add origin "https://github.com/test/repo.git"
+    # worktrunk persists its default-branch resolution here, and both scripts
+    # read it to identify the branch `wt remove` refuses to touch.
+    git -C "$repo" config worktrunk.default-branch main
 
     # A real linked worktree, so the age helper resolves a per-worktree git dir
     # (a .git *file* pointing at .git/worktrees/<name>) rather than the repo's
@@ -314,6 +317,50 @@ JSON
     When call run_audit_grace 30min
     The status should equal 1
     The stderr should include "cannot parse"
+    The output should equal ""
+  End
+
+  # A repo whose main worktree sits on a topic branch leaves the default branch
+  # checked out in a linked worktree. `wt step prune` skips that branch, it has
+  # no PR, and `wt remove` refuses it, so the age pass used to retry a removal
+  # that always fails while the audit filed a to-do for it every night.
+  fixture_default_branch_worktree() {
+    cat >"$WT_LIST_JSON" <<JSON
+[
+  {"kind":"worktree","branch":"topic","is_main":true,"is_current":true,
+   "path":"/repo","main_state":"is_main","commit":{"timestamp":0},
+   "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
+   "remote":{"ahead":0,"behind":0}},
+  {"kind":"worktree","branch":"main","is_main":false,"is_current":false,
+   "path":"$linked","main_state":"integrated","commit":{"timestamp":1000},
+   "working_tree":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false},
+   "remote":{"ahead":0,"behind":0}}
+]
+JSON
+  }
+
+  It "never attempts to remove a default-branch worktree that aged out"
+    fixture_default_branch_worktree
+    : >"$PR_STATE_FILE"
+    When call run_prune --before 1mo
+    The status should be success
+    The contents of file "$WT_REMOVE_LOG" should equal ""
+  End
+
+  It "dry-run explains the default-branch worktree as kept"
+    fixture_default_branch_worktree
+    : >"$PR_STATE_FILE"
+    When call run_prune --dry-run --before 1mo
+    The status should be success
+    The output should include "default branch"
+    The output should include "keep"
+  End
+
+  It "audit ignores a default-branch worktree at any age"
+    fixture_default_branch_worktree
+    : >"$PR_STATE_FILE"
+    When call run_audit_grace 0h
+    The status should be success
     The output should equal ""
   End
 


### PR DESCRIPTION
The nightly drift audit has been filing the same to-do every morning for one worktree in `terraform-credentials-keychain`, and re-running the pruner never clears it. That repo's main worktree sits on a topic branch, which leaves `master` checked out in a linked worktree. Nothing in `wt prune` can remove that:

- `wt step prune` skips the default branch outright
- the forge has no PR for it
- `wt remove` fails with "Cannot remove the default branch" unless you force-delete the branch too

The age pass classified it as a removable survivor anyway and called the removal that always fails. The audit saw a worktree whose `main_state` is trivially `integrated`, since the default branch is the integration target, and reported drift no fix could ever clear.

Both scripts now ask worktrunk which branch that is and leave it alone. The pruner records it as `keep / default branch` in the dry-run table instead of retrying the removal, and the audit skips it before the forge lookup. `wt config state default-branch get` is the source rather than `git config` or the `origin/HEAD` symref, because it is the same resolution `wt remove` enforces, and it detects and caches on a miss instead of coming back empty in a clone that has never been pruned.

Left behind rather than removed: taking the worktree would mean force-deleting `master`, and the local branch is the only thing tracking that checkout. Nothing is orphaned by keeping it. The readme commit it holds is an ancestor of `origin/master`, and the branch itself stays put.

Verified against the real repo: the audit is now silent there and the dry-run reports the keep. New spec cases lock both, plus the case that used to log a doomed `wt remove`; all three fail on `main`.
