### PR TITLE
terminal: install Monaspice from the stock cask

### DIFF
--- a/scripts/install-cask-variants
+++ b/scripts/install-cask-variants
@@ -42,6 +42,12 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+cask_conflicts() {
+  cask_conflicts_info=$(brew info --json=v2 --cask "$1" 2>/dev/null) || return 1
+  printf '%s\n' "$cask_conflicts_info" |
+    jq -r '.casks[0].conflicts_with.cask // [] | .[]' 2>/dev/null
+}
+
 # Confirm every candidate before removing any, so a metadata failure part way
 # through cannot leave earlier casks uninstalled with nothing reinstalled.
 #
@@ -54,15 +60,22 @@ confirmed=$(
     # Unreadable metadata is a different answer from "they don't conflict", and
     # collapsing the two would leave the cask in place and hand brew bundle a
     # conflict error that says nothing about why.
-    if ! info=$(brew info --json=v2 --cask "$new" 2>/dev/null) ||
-      ! conflicts=$(printf '%s\n' "$info" |
-        jq -r '.casks[0].conflicts_with.cask // [] | .[]' 2>/dev/null); then
+    if ! conflicts=$(cask_conflicts "$new"); then
       echo "install-cask-variants: cannot read Homebrew metadata for $new, so its conflict with the installed $old is unconfirmed." >&2
       echo "  brew bundle will fail while $old remains. Run: brew uninstall --cask $old" >&2
       exit 1
     fi
 
-    printf '%s\n' "$conflicts" | grep -qxF "$old" || continue
+    # Only the side that knows its sibling exists declares the conflict. A
+    # personal tap's @variant names the upstream cask it stands in for, and
+    # upstream names nothing, so retiring that variant means reading the
+    # variant's own metadata. Unreadable there is not fatal: the declared cask
+    # answered, so the pair is merely unconfirmed rather than unknown.
+    if ! printf '%s\n' "$conflicts" | grep -qxF "$old"; then
+      reverse=$(cask_conflicts "$old") || continue
+      printf '%s\n' "$reverse" | grep -qxF "$new" || continue
+    fi
+
     printf '%s\t%s\n' "$old" "$new"
   done
 ) || exit 1

--- a/scripts/spec/install_cask_variants_spec.sh
+++ b/scripts/spec/install_cask_variants_spec.sh
@@ -90,6 +90,32 @@ Describe "install-cask-variants"
     The result of function uninstalled should equal ""
   End
 
+  # Homebrew's own cask cannot name a personal tap's variant, so retiring that
+  # variant works only if the variant's own metadata is consulted.
+  It "uninstalls a variant when only the variant declares the conflict"
+    declared font-monaspice-nerd-font
+    installed font-monaspice-nerd-font@tip
+    printf '{"casks":[{"conflicts_with":{"cask":[]}}]}\n' > "$sandbox/info-font-monaspice-nerd-font.json"
+    printf '{"casks":[{"conflicts_with":{"cask":["font-monaspice-nerd-font"]}}]}\n' > "$sandbox/info-font-monaspice-nerd-font@tip.json"
+
+    When call run_script
+    The status should be success
+    The output should include "uninstalling font-monaspice-nerd-font@tip, superseded by font-monaspice-nerd-font"
+    The result of function uninstalled should equal "font-monaspice-nerd-font@tip"
+  End
+
+  # The declared cask answered, so the pair is unconfirmed rather than unknown.
+  It "skips without failing when only the installed cask's metadata is unreadable"
+    declared ghostty@tip
+    installed ghostty
+    printf '{"casks":[{"conflicts_with":{"cask":[]}}]}\n' > "$sandbox/info-ghostty@tip.json"
+    printf 'not json at all\n' > "$sandbox/info-ghostty.json"
+
+    When call run_script
+    The status should be success
+    The result of function uninstalled should equal ""
+  End
+
   # Aborting mid-run would leave an app uninstalled with its replacement not yet
   # installed, so confirmation for every candidate has to finish first.
   It "uninstalls nothing when a later candidate cannot be confirmed"

--- a/terminal/Brewfile
+++ b/terminal/Brewfile
@@ -1,17 +1,5 @@
-tap 'bendrucker/fonts'
-
 cask 'iterm2'
-# Monaspice patched from nerd-fonts master. Same family name as
-# font-monaspice-nerd-font, so nothing downstream of the font changes. 3.4.0
-# predates the Codicon brand marks (see terminal/glyphs.conf) and nerd-fonts has
-# cut no release since. Swap back to font-monaspice-nerd-font once one ships
-# containing U+EC82. The tap opens an issue when that happens.
-#
-# The @tip suffix is what makes that swap automatic in both directions:
-# install-cask-variants matches variants by stripping at the @, so it retires
-# whichever sibling the Brewfile stopped declaring. A -tip suffix would not
-# match, and bundle would fail on the cask's conflicts_with instead.
-cask 'font-monaspice-nerd-font@tip'
+cask 'font-monaspice-nerd-font'
 brew 'glow'
 brew 'shellspec'
 brew 'yazi'

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -96,13 +96,11 @@ to `~/.config/ghostty/config` by `install.sh`.
 
 ## Fonts
 
-Ghostty renders `MonaspiceNe NFM`, installed by `font-monaspice-nerd-font@tip`
-from the [`bendrucker/fonts`](https://github.com/bendrucker/homebrew-fonts) tap.
-That tap patches Monaspace from nerd-fonts `master` instead of a release,
-because 3.4.0 shipped in April 2025, predates the Codicon brand marks for
-Claude, OpenAI, and Cursor, and is still the newest release. The family name
-matches upstream's cask, so swapping back to `font-monaspice-nerd-font` when
-3.5.0 lands changes nothing else.
+Ghostty renders `MonaspiceNe NFM`, installed by `font-monaspice-nerd-font`.
+Nerd Fonts 3.5.0 carries the Codicon brand marks for Claude, OpenAI, and Cursor,
+so the stock cask covers everything `glyphs.conf` declares. The
+[`bendrucker/fonts`](https://github.com/bendrucker/homebrew-fonts) tap bridged
+the gap while 3.4.0 was the newest release and is now archived.
 
 ### Client Coverage
 
@@ -112,11 +110,22 @@ so a glyph cannot be varied per client. The usable set is the intersection of
 every client's coverage. That is why the font goes onto every client, rather
 than holding the glyphs back to what a stock release covers.
 
-Rootshell and Moshi both import a TTF/OTF. Open the tap's latest release on the
-device and import the four `.otf` assets. They are uploaded individually so a
-single file can be tapped from Safari without unzipping. Release notes list the
-codepoints each build gained, so a re-import only matters when one of them turns
-up in `glyphs.conf`.
+Rootshell and Moshi both import a TTF/OTF. Upstream publishes Monaspace only as
+a 269 MB `.zip` or an 18 MB `.tar.xz`, and iOS unpacks neither, so the four
+styles are staged in iCloud Drive where the Files app can hand a single `.otf`
+to an app:
+
+```sh
+dest="$HOME/Library/Mobile Documents/com~apple~CloudDocs/Downloads/MonaspiceNe-NFM-3.5.0"
+mkdir -p "$dest"
+curl -sL "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.0/Monaspace.tar.xz" |
+  tar -xJ -C "$dest" \
+    MonaspiceNeNerdFontMono-Regular.otf MonaspiceNeNerdFontMono-Bold.otf \
+    MonaspiceNeNerdFontMono-Italic.otf MonaspiceNeNerdFontMono-BoldItalic.otf
+```
+
+A re-import only matters when a codepoint new to a release turns up in
+`glyphs.conf`.
 
 ### `glyphs.conf`
 


### PR DESCRIPTION
Nerd Fonts 3.5.0 ships the Codicon brand marks, `U+EC82` (`cod-claude`) among them. That was the one condition the `bendrucker/fonts` tap existed to bridge. This drops the tap, installs Monaspice from the stock cask, and archives the tap.

Retiring the variant surfaced a bug in `install-cask-variants`. It confirmed a conflict only from the declared cask's metadata, and Homebrew's own cask cannot name a personal tap's variant. So the retirement was skipped silently. `brew bundle` would then have failed on the font files `font-monaspice-nerd-font@tip` still owned.

Either side's declaration now confirms the pair. Unreadable metadata on the installed side stays non-fatal, since the declared cask already answered.

All 12 codepoints `glyphs.conf` declares are present in all four styles of the upstream 3.5.0 build, and `glyph-scan --font` passes against the installed cask. The stock cask brings 150 font files where the variant brought 4. That is the cost of tracking a release.

Upstream publishes Monaspace only as a 269 MB `.zip` or an 18 MB `.tar.xz`, and iOS unpacks neither. The README now documents staging the four styles in iCloud Drive for Rootshell and Moshi to import.
