### PR TITLE
terminal: drop the retired tap from the font docs

### DIFF
--- a/terminal/README.md
+++ b/terminal/README.md
@@ -96,11 +96,9 @@ to `~/.config/ghostty/config` by `install.sh`.
 
 ## Fonts
 
-Ghostty renders `MonaspiceNe NFM`, installed by `font-monaspice-nerd-font`.
-Nerd Fonts 3.5.0 carries the Codicon brand marks for Claude, OpenAI, and Cursor,
-so the stock cask covers everything `glyphs.conf` declares. The
-[`bendrucker/fonts`](https://github.com/bendrucker/homebrew-fonts) tap bridged
-the gap while 3.4.0 was the newest release and is now archived.
+Ghostty renders `MonaspiceNe NFM`, installed by `font-monaspice-nerd-font`. The
+cask covers everything `glyphs.conf` declares, including the Codicon brand marks
+for Claude, OpenAI, and Cursor.
 
 ### Client Coverage
 
@@ -108,7 +106,7 @@ tmux and herdr emit bytes. The attached *client* picks the font. One session can
 be attached from Ghostty on the Mac and Rootshell on an iPad at the same time,
 so a glyph cannot be varied per client. The usable set is the intersection of
 every client's coverage. That is why the font goes onto every client, rather
-than holding the glyphs back to what a stock release covers.
+than holding the glyphs back to whatever the thinnest one already has.
 
 Rootshell and Moshi both import a TTF/OTF. Upstream publishes Monaspace only as
 a 269 MB `.zip` or an 18 MB `.tar.xz`, and iOS unpacks neither, so the four

--- a/terminal/glyphs.conf
+++ b/terminal/glyphs.conf
@@ -17,9 +17,6 @@ U+F0293 md-fullscreen
 U+F0570 md-view_grid
 U+F06A9 md-robot
 
-# Codicon brand marks. Only cod-copilot shipped in Nerd Fonts 3.4.0. The rest
-# landed on master afterwards and reach a release in 3.5.0, which is what
-# font-monaspice-nerd-font@tip exists to bridge (see terminal/Brewfile).
 U+EC1E  cod-copilot
 U+EC5C  cod-cursor
 U+EC81  cod-openai


### PR DESCRIPTION
The font docs still explained why a cask patched from nerd-fonts `master` existed and what would eventually replace it. That cask is retired, so the explanation described a state the repo no longer has.

Drops it from both places. `glyphs.conf` keeps the Codicon entries with no preamble, since the `cod-` prefix already names them and the file header still says to check a new glyph against the installed font first.

One line in Client Coverage was written against the old setup too. It argued for putting the font on every client rather than limiting the set to "what a stock release covers", which now describes what every client runs.
