### PR TITLE
macos: stop Vibe Island managing Claude hooks

### DIFF
--- a/macos/spec/vibe_island_spec.sh
+++ b/macos/spec/vibe_island_spec.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+#
+# Locks the guard around the Vibe Island preference write: it touches nothing on
+# a machine without the app, and it writes at most once, so the nightly install
+# neither rewrites a preference already set nor repeats the running-app warning.
+#
+# Black-box, following claude/spec/claude_prune_agents_spec.sh: PATH-shim stubs
+# for defaults, pgrep, and gum drive the real script, and VIBE_ISLAND_APP points
+# at a fixture bundle so no real preference domain is read or written.
+
+script="$SHELLSPEC_PROJECT_ROOT/vibe-island.sh"
+
+setup() {
+  sandbox="$SHELLSPEC_TMPBASE/vibe-island"
+  stubdir="$sandbox/stub"
+  rm -rf "$sandbox"
+  mkdir -p "$stubdir"
+
+  export DEFAULTS_LOG="$sandbox/defaults.log"
+  : >"$DEFAULTS_LOG"
+
+  # An installed app, by default. $CURRENT_VALUE is what `defaults read` answers
+  # with, empty standing for a key that was never written, which the real
+  # defaults reports as a failure rather than as empty output.
+  export VIBE_ISLAND_APP="$sandbox/Vibe Island.app"
+  mkdir -p "$VIBE_ISLAND_APP"
+  export CURRENT_VALUE=""
+  export APP_RUNNING=""
+
+  # printf, not a here-document: bash stages those through a temp file it picks
+  # itself, which a sandbox may deny. Same reasoning as scripts/spec/spec_helper.sh.
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s\n" "$*" >>"$DEFAULTS_LOG"' \
+    'if [ "$1" = read ]; then' \
+    '  [ -n "$CURRENT_VALUE" ] || exit 1' \
+    '  printf "%s\n" "$CURRENT_VALUE"' \
+    'fi' \
+    'exit 0' \
+    >"$stubdir/defaults"
+  chmod +x "$stubdir/defaults"
+
+  printf '#!/usr/bin/env bash\n[ -n "$APP_RUNNING" ]\n' >"$stubdir/pgrep"
+  chmod +x "$stubdir/pgrep"
+
+  # The real gum logs to stderr, so the warning stays off captured stdout.
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "${@: -1}" >&2\n' >"$stubdir/gum"
+  chmod +x "$stubdir/gum"
+}
+BeforeEach 'setup'
+
+run_script() { PATH="$stubdir:$PATH" bash "$script"; }
+
+Describe "macos/vibe-island.sh"
+  It "turns Vibe Island's Claude hook management off"
+    When call run_script
+    The status should be success
+    The contents of file "$DEFAULTS_LOG" should include \
+      "write app.vibeisland.macos hookAutoConfig_claude -bool false"
+  End
+
+  # The app owns this key too. A value of 1 means it has taken hook management
+  # back, so the install has to correct it.
+  It "turns it off again after the app turns it back on"
+    export CURRENT_VALUE=1
+    When call run_script
+    The status should be success
+    The contents of file "$DEFAULTS_LOG" should include "-bool false"
+  End
+
+  # The install runs nightly. Rewriting a preference already set would warn
+  # about a running app every night for a change that has already taken.
+  It "leaves a preference already set alone"
+    export CURRENT_VALUE=0
+    When call run_script
+    The status should be success
+    The contents of file "$DEFAULTS_LOG" should not include "write"
+  End
+
+  It "does nothing on a machine without the app"
+    rm -rf "$VIBE_ISLAND_APP"
+    When call run_script
+    The status should be success
+    The contents of file "$DEFAULTS_LOG" should equal ""
+  End
+
+  It "says nothing when the app is not installed but is somehow running"
+    rm -rf "$VIBE_ISLAND_APP"
+    export APP_RUNNING=1
+    When call run_script
+    The status should be success
+    The stderr should equal ""
+  End
+
+  Describe "the running-app caveat"
+    # NSUserDefaults holds what the app read at launch, and the app can write
+    # that copy back, so the write alone is not enough to report as done.
+    It "warns to restart the app when it is running"
+      export APP_RUNNING=1
+      When call run_script
+      The status should be success
+      The stderr should include "Quit and reopen"
+    End
+
+    It "stays quiet when the app is not running"
+      When call run_script
+      The status should be success
+      The stderr should equal ""
+    End
+  End
+End

--- a/macos/vibe-island.sh
+++ b/macos/vibe-island.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Vibe Island manages Claude Code's hooks by writing ~/.claude/settings.json
+# itself. It writes with an atomic rename, which replaces the dotfiles symlink
+# with a regular file, so Claude Code silently stops reading the tracked config
+# in ~/.claude-repo and every later edit there goes nowhere.
+#
+# This preference opts out of that management, recording a standing choice so a
+# new machine does not arrive with the app owning the hook config again. Opting
+# out is not passive: the app removes its hook entries from settings.json rather
+# than leaving behind whatever it last wrote.
+#
+# claude/install.sh restores the symlink when it finds one already replaced.
+# This is what keeps it from being replaced again.
+
+VIBE_ISLAND_APP="${VIBE_ISLAND_APP:-/Applications/Vibe Island.app}"
+VIBE_ISLAND_DOMAIN="app.vibeisland.macos"
+
+[ -d "$VIBE_ISLAND_APP" ] || exit 0
+
+# Already off. Stopping here keeps the nightly install silent rather than
+# warning about a running app on every run.
+if [ "$(defaults read "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude 2>/dev/null)" = 0 ]; then
+  exit 0
+fi
+
+defaults write "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude -bool false
+
+# A running app holds its own cached copy of the preference and can write that
+# copy back over this one, so the change is only reliable from the next launch.
+# dock.sh and clock.sh kill the process to apply a change, which does not carry
+# over: the Dock and SystemUIServer relaunch themselves, while quitting Vibe
+# Island would take the user's menu bar with it until they reopened it.
+if pgrep -x vibe-island >/dev/null 2>&1; then
+  gum log --level warn "Vibe Island hook management disabled for Claude. Quit and reopen Vibe Island so it does not write the old value back."
+fi


### PR DESCRIPTION
Vibe Island installs its own hooks by writing `~/.claude/settings.json`, and it writes with an atomic rename. That replaces the dotfiles symlink with a regular file, so Claude Code stops reading the tracked config in `~/.claude-repo`.

The drift is silent, because the rewrite preserves the content exactly. Nothing looks wrong until an edit to the tracked file fails to take effect.

Setting `hookAutoConfig_claude` to false opts out. It is a trade: the app also removes its hook entries, so the Vibe Island integration goes away in exchange for a `settings.json` that stays linked.

`macos/install.sh` already globs the topic's scripts, so the new file needs no wiring. The write is skipped when the app is absent, and again when the preference is already off. That keeps the nightly install from rewriting a setting that has already taken.

A running app holds its own cached copy of the preference and can write that copy back, so the change is only reliable from the next launch. `dock.sh` and `clock.sh` solve that by killing the process. It does not carry over here: the Dock relaunches itself, while quitting Vibe Island would take the menu bar with it. So the script warns.

Specs stub `defaults`, `pgrep`, and `gum` on `PATH` and point `VIBE_ISLAND_APP` at a fixture bundle. No real preference domain is read or written, and the suite still runs on CI's Linux runners.
