### PR TITLE
herdr: pick a Linear issue and open it as work

### DIFF
--- a/bin/linear-work
+++ b/bin/linear-work
@@ -1,0 +1,306 @@
+#!/usr/bin/env zsh
+# linear-work: pick an assigned Linear issue and open it as herdr work.
+#
+# Bound to prefix+i as a herdr popup (herdr/config.toml). Lists the issues
+# assigned to you that are unstarted or started, and on selection builds the
+# terminal location for the issue: a worktree on Linear's branch name with
+# Claude started on the `issue` skill. Alternate fzf keys pick a different
+# topology, or drop the agent for a plain shell.
+#
+# Selecting an issue herdr already has open focuses that location instead of
+# building a second one. Acting on an unstarted issue moves it to the team's
+# started state.
+
+set -uo pipefail
+
+# jq emits records separated by this rather than tabs, because tab is IFS
+# whitespace and `read` would collapse an empty field away.
+US=$'\037'
+
+repo_state="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/linear-repos"
+
+ASSIGNED_QUERY='{ viewer { assignedIssues(
+  filter: { state: { type: { in: ["unstarted", "started"] } } }
+  first: 100
+) { nodes {
+  identifier title branchName url priority updatedAt
+  state { name type } team { key } project { name }
+} } } }'
+
+# Started before unstarted, then by Linear priority, then most recently
+# touched. Priority 0 is "no priority" rather than the most urgent, so it
+# sorts past 4 (Low). updatedAt carries milliseconds, which fromdateiso8601
+# will not parse.
+SORT_ISSUES='[ .data.viewer.assignedIssues.nodes[] ] | sort_by(
+  (if .state.type == "started" then 0 else 1 end),
+  (if (.priority // 0) == 0 then 5 else .priority end),
+  -(.updatedAt | split(".")[0] + "Z" | fromdateiso8601)
+)'
+
+ISSUE_FIELDS='.[] | [
+  .identifier,
+  (.state.name // ""),
+  (.title // "" | gsub("\\s+"; " ")),
+  (.project.name // ""),
+  (.branchName // "")
+] | join($us)'
+
+die() {
+  gum log --level error "$@" >&2
+  exit 1
+}
+
+# wt applies its `sanitize` filter to the branch when it builds the worktree
+# path, and that filter only replaces forward slashes.
+sanitize_branch() {
+  print -r -- "${1//\//-}"
+}
+
+fetch_issues() {
+  local raw
+  raw=$(linear api "$ASSIGNED_QUERY") || return 1
+  if print -r -- "$raw" | jq -e 'has("errors")' >/dev/null; then
+    print -r -- "$raw" | jq -r '.errors[]?.message // empty' >&2
+    return 1
+  fi
+  print -r -- "$raw" | jq -c "$SORT_ISSUES"
+}
+
+# Everywhere herdr could already be holding an issue, keyed by the two names
+# it would be under: the identifier this script labels a location with, and
+# the sanitized branch, which is the directory a worktree lands in whether
+# this script or the worktrunk plugin created it.
+#
+# Panes come last so their tab wins over the workspace's active one. A pane's
+# own cwd stays at the repo it was created in, since wt replaces itself with
+# the agent rather than the pane's shell ever changing directory, so the
+# worktree only shows up as foreground_cwd.
+typeset -gA location_workspace location_tab
+
+index_locations() {
+  # Not `path`, which zsh ties to $PATH.
+  local ws tab label dir
+
+  while IFS=$US read -r ws tab label dir; do
+    [[ -n "$label" ]] && { location_workspace[$label]=$ws; location_tab[$label]=$tab }
+    [[ -n "$dir" ]] && { location_workspace[${dir:t}]=$ws; location_tab[${dir:t}]=$tab }
+  done < <(
+    herdr workspace list 2>/dev/null | jq -r --arg us "$US" '.result.workspaces[]
+      | [.workspace_id, (.active_tab_id // ""), (.label // ""),
+         (.worktree.checkout_path // "")] | join($us)'
+    herdr tab list 2>/dev/null | jq -r --arg us "$US" '.result.tabs[]
+      | [.workspace_id, .tab_id, (.label // ""), ""] | join($us)'
+    herdr pane list 2>/dev/null | jq -r --arg us "$US" '.result.panes[]
+      | [.workspace_id, .tab_id, (.label // ""),
+         (.foreground_cwd // .cwd // "")] | join($us)'
+  )
+}
+
+# Prints "<workspace_id><US><tab_id>" for the first key herdr knows.
+find_location() {
+  local key
+  for key in "$@"; do
+    if [[ -n "${location_workspace[$key]:-}" ]]; then
+      print -r -- "${location_workspace[$key]}$US${location_tab[$key]:-}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Rows read `IDENT ● STATE  TITLE · PROJECT`, keeping the identifier in the
+# first whitespace-delimited field so fzf's preview can pass it as {1}. The
+# marker calls out an issue herdr already has a location for.
+issue_rows() {
+  local ident state title project branch marker suffix row
+  local -a idents states titles projects branches
+  local -i ident_width=0 state_width=0 i
+
+  while IFS=$US read -r ident state title project branch; do
+    [[ -n "$ident" ]] || continue
+    idents+=("$ident"); states+=("$state"); titles+=("$title")
+    projects+=("$project"); branches+=("$branch")
+    (( ${#ident} > ident_width )) && ident_width=${#ident}
+    (( ${#state} > state_width )) && state_width=${#state}
+  done < <(print -r -- "$1" | jq -r --arg us "$US" "$ISSUE_FIELDS")
+
+  (( ${#idents} )) || return 1
+
+  for (( i = 1; i <= ${#idents}; i++ )); do
+    marker=' '
+    find_location "${idents[i]}" "$(sanitize_branch "${branches[i]}")" >/dev/null && marker='●'
+    suffix=''
+    [[ -n "${projects[i]}" ]] && suffix="  · ${projects[i]}"
+    printf -v row '%-*s %s %-*s  %s%s' \
+      "$ident_width" "${idents[i]}" "$marker" \
+      "$state_width" "${states[i]}" "${titles[i]}" "$suffix"
+    print -r -- "$row"
+  done
+}
+
+# The pane to split from. The popup is session-modal and is not the pane the
+# user is looking at, so it is excluded by ID and the focused pane behind it
+# is used instead.
+resolve_split_pane() {
+  local panes id tab
+  panes=$(herdr pane list 2>/dev/null) || return 1
+  id=$(print -r -- "$panes" | jq -r --arg self "${HERDR_PANE_ID:-}" \
+    'first(.result.panes[] | select(.focused and .pane_id != $self) | .pane_id) // empty')
+  if [[ -z "$id" ]]; then
+    tab=$(herdr workspace list 2>/dev/null \
+      | jq -r 'first(.result.workspaces[] | select(.focused)) | .active_tab_id // empty')
+    [[ -n "$tab" ]] && id=$(print -r -- "$panes" \
+      | jq -r --arg t "$tab" --arg self "${HERDR_PANE_ID:-}" \
+        'first(.result.panes[] | select(.tab_id == $t and .pane_id != $self) | .pane_id) // empty')
+  fi
+  [[ -n "$id" ]] || return 1
+  print -r -- "$id"
+}
+
+# Split a wide pane to the right and a narrow one down. A cell is about twice
+# as tall as it is wide, so the comparison doubles the height.
+split_direction() {
+  local dims
+  dims=$(herdr pane layout --pane "$1" 2>/dev/null | jq -r --arg p "$1" \
+    'first(.result.layout.panes[] | select(.pane_id == $p) | .rect)
+     | "\(.width) \(.height)"')
+  local -a wh=(${=dims})
+  if (( ${#wh} == 2 && wh[1] <= wh[2] * 2 )); then
+    print -r -- down
+  else
+    print -r -- right
+  fi
+}
+
+remembered_repo() {
+  [[ -f "$repo_state" ]] || return 1
+  local dir
+  dir=$(awk -F'\t' -v team="$1" '$1 == team { found = $2 } END { print found }' "$repo_state")
+  [[ -n "$dir" && -e "$dir/.git" ]] || return 1
+  print -r -- "$dir"
+}
+
+remember_repo() {
+  local team=$1 dir=$2 tmp
+  mkdir -p "${repo_state:h}" || return 1
+  tmp="${repo_state}.$$"
+  {
+    [[ -f "$repo_state" ]] && awk -F'\t' -v team="$team" '$1 != team' "$repo_state"
+    printf '%s\t%s\n' "$team" "$dir"
+  } >"$tmp" && mv "$tmp" "$repo_state"
+}
+
+pick_repo() {
+  local team=$1 remembered=$2 dir
+  local -a candidates
+  [[ -n "$remembered" ]] && candidates+=("$remembered")
+  for dir in ${(f)"$(zoxide query -l 2>/dev/null)"}; do
+    [[ -n "$dir" && -e "$dir/.git" ]] && candidates+=("$dir")
+  done
+  candidates=(${(u)candidates})
+  (( ${#candidates} )) || { gum log --level error "no git repos from zoxide" >&2; return 1 }
+
+  print -rl -- "${candidates[@]}" | fzf \
+    --no-sort \
+    --border --border-label " linear · repo for $team " \
+    --prompt '  '
+}
+
+[[ "${HERDR_ENV:-}" == 1 ]] \
+  || die "linear-work builds herdr topology; run it from a herdr session"
+
+issues=$(fetch_issues) || die "could not read assigned issues from linear"
+(( $(print -r -- "$issues" | jq 'length') )) || {
+  gum log --level warn "no unstarted or started issues assigned to you"
+  exit 0
+}
+
+index_locations
+
+selection=$(issue_rows "$issues" | fzf \
+  --no-sort \
+  --border --border-label ' linear · assigned ' \
+  --prompt '  ' \
+  --header 'enter/alt-t tab · alt-p pane · alt-w workspace · shift for a shell' \
+  --preview 'linear issue view {1} --no-pager' \
+  --preview-window 'right,50%,border-left' \
+  --expect=enter,alt-t,alt-p,alt-w,alt-T,alt-P,alt-W) || exit 0
+
+key=${selection%%$'\n'*}
+row=${selection#*$'\n'}
+[[ -n "$row" && "$row" != "$key" ]] || exit 0
+
+identifier=${row%% *}
+issue=$(print -r -- "$issues" | jq -c --arg id "$identifier" \
+  'first(.[] | select(.identifier == $id))')
+[[ -n "$issue" && "$issue" != null ]] || die "no issue matching $identifier"
+
+IFS=$US read -r branch url team state_type <<<"$(print -r -- "$issue" \
+  | jq -r --arg us "$US" '[.branchName, .url, (.team.key // ""), (.state.type // "")] | join($us)')"
+[[ -n "$branch" ]] || die "$identifier has no branch name"
+
+case "$key" in
+  alt-p) topology=pane;      use_agent=1 ;;
+  alt-w) topology=workspace; use_agent=1 ;;
+  alt-T) topology=tab;       use_agent=0 ;;
+  alt-P) topology=pane;      use_agent=0 ;;
+  alt-W) topology=workspace; use_agent=0 ;;
+  *)     topology=tab;       use_agent=1 ;;
+esac
+
+# Backgrounded so the popup closes on selection rather than on a round trip
+# to Linear. nohup because closing the popup takes down the pty this was
+# launched from, and the transition should outlive it. Every path below ends
+# here, including the focus-what-exists one.
+start_issue() {
+  [[ "$state_type" == unstarted ]] || return 0
+  nohup linear issue update "$identifier" --state started >/dev/null 2>&1 &!
+}
+
+if location=$(find_location "$identifier" "$(sanitize_branch "$branch")"); then
+  workspace=${location%%$US*}
+  tab=${location#*$US}
+  [[ -n "$workspace" ]] && herdr workspace focus "$workspace" >/dev/null
+  [[ -n "$tab" ]] && herdr tab focus "$tab" >/dev/null
+  start_issue
+  exit 0
+fi
+
+repo=$(pick_repo "$team" "$(remembered_repo "$team")") || exit 0
+[[ -n "$repo" ]] || exit 0
+remember_repo "$team" "$repo"
+
+case "$topology" in
+  tab)
+    created=$(herdr tab create --cwd "$repo" --label "$identifier" --focus) \
+      || die "could not create a tab"
+    pane=$(print -r -- "$created" | jq -r '.result.root_pane.pane_id')
+    ;;
+  workspace)
+    created=$(herdr workspace create --cwd "$repo" --label "$identifier" --focus) \
+      || die "could not create a workspace"
+    pane=$(print -r -- "$created" | jq -r '.result.root_pane.pane_id')
+    ;;
+  pane)
+    from=$(resolve_split_pane) || die "no pane to split"
+    created=$(herdr pane split --pane "$from" --direction "$(split_direction "$from")" \
+      --cwd "$repo" --focus) || die "could not split a pane"
+    pane=$(print -r -- "$created" | jq -r '.result.pane.pane_id')
+    ;;
+esac
+[[ -n "$pane" && "$pane" != null ]] || die "herdr returned no pane id"
+
+# wt creates the worktree, runs its pre-start hooks, and replaces itself with
+# the command, so the pane goes from a prompt straight to a running agent.
+typeset -a switch=(wt switch)
+git -C "$repo" show-ref --verify --quiet "refs/heads/$branch" \
+  || git -C "$repo" show-ref --verify --quiet "refs/remotes/origin/$branch" \
+  || switch+=(--create)
+switch+=("$branch")
+(( use_agent )) && switch+=(-x claude -- "/issue $url")
+
+herdr pane run "$pane" "${(j: :)${(@q)switch}}" >/dev/null \
+  || die "could not run wt in $pane"
+herdr pane rename "$pane" "$identifier" >/dev/null
+
+start_issue

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -99,6 +99,21 @@ type = "plugin_action"
 command = "worktrunk.open-current"
 description = "worktree: switch / create (current branch)"
 
+# --- Scripts ---------------------------------------------------------------
+
+# bin/linear-work. A popup rather than a pane, because the picker is a modal
+# question and the answer is new layout: leaving the tab alone until the
+# script builds the location keeps the transition to one step. The script
+# reaches back through the herdr CLI, so it needs no size beyond fitting fzf
+# and its preview.
+[[keys.command]]
+key = "prefix+i"
+type = "popup"
+command = "linear-work"
+width = "85%"
+height = "80%"
+description = "linear: work an assigned issue"
+
 [ui]
 agent_panel_sort = "priority"
 

--- a/herdr/spec/linear_work_spec.sh
+++ b/herdr/spec/linear_work_spec.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe "linear-work"
+  script="$SHELLSPEC_PROJECT_ROOT/../bin/linear-work"
+
+  setup() {
+    root=$(mktemp -d)
+    export XDG_STATE_HOME="$root/state"
+    fixtures="$root/fixtures"
+    mkdir -p "$fixtures" "$root/stub" "$root/empty" "$root/repo"
+
+    export FIXTURE_DIR="$fixtures"
+    export HERDR_CAPTURE="$root/herdr-calls"
+    export LINEAR_CAPTURE="$root/linear-calls"
+    export FZF_CAPTURE="$root/fzf"
+    : >"$HERDR_CAPTURE"
+    : >"$LINEAR_CAPTURE"
+
+    git -C "$root/repo" init --quiet
+    write_issues
+    write_locations '[]' '[]' '[]'
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "$root"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # The script is zsh, so ~/.zshenv runs and brew shellenv in it can put the
+  # real linear, herdr, and wt back ahead of the stubs. An empty ZDOTDIR
+  # leaves $PATH alone.
+  run_script() {
+    PATH="$root/stub:$PATH" ZDOTDIR="$root/empty" HERDR_ENV=1 HERDR_PANE_ID=w1:p1 \
+      "$script"
+  }
+
+  # Each stub records what it was asked for and answers from a fixture, so a
+  # test asserts on the herdr topology the script decided to build rather than
+  # on anything it drew.
+  write_stubs() {
+    cat >"$root/stub/linear" <<'SH'
+#!/bin/sh
+printf 'linear %s\n' "$1 $2 $3" >> "$LINEAR_CAPTURE"
+[ "$1" = api ] && cat "$FIXTURE_DIR/issues.json"
+exit 0
+SH
+
+    cat >"$root/stub/herdr" <<'SH'
+#!/bin/sh
+printf 'herdr %s\n' "$*" >> "$HERDR_CAPTURE"
+case "$1 $2" in
+  "workspace list") cat "$FIXTURE_DIR/workspaces.json" ;;
+  "tab list")       cat "$FIXTURE_DIR/tabs.json" ;;
+  "pane list")      cat "$FIXTURE_DIR/panes.json" ;;
+  "pane layout")    echo '{"result":{"layout":{"panes":[{"pane_id":"w1:p2","rect":{"width":250,"height":82}}]}}}' ;;
+  "tab create")     echo '{"result":{"root_pane":{"pane_id":"w9:p1"}}}' ;;
+  "workspace create") echo '{"result":{"root_pane":{"pane_id":"w9:p1"}}}' ;;
+  "pane split")     echo '{"result":{"pane":{"pane_id":"w1:p5"}}}' ;;
+  *)                echo '{"result":{"type":"ok"}}' ;;
+esac
+SH
+
+    # Two fzf calls: the issue picker, which passes --expect and so prints the
+    # pressed key first, and the repo picker, which does not.
+    cat >"$root/stub/fzf" <<'SH'
+#!/bin/sh
+input="$FZF_CAPTURE.in.$$"
+cat > "$input"
+for arg in "$@"; do
+  case "$arg" in
+    --expect=*)
+      cp "$input" "$FZF_CAPTURE.issues"
+      printf '%s\n' "${FZF_KEY:-enter}"
+      sed -n "${FZF_PICK:-1}p" "$input"
+      rm -f "$input"
+      exit 0
+      ;;
+  esac
+done
+cp "$input" "$FZF_CAPTURE.repos"
+sed -n '1p' "$input"
+rm -f "$input"
+SH
+
+    printf '#!/bin/sh\nprintf "%%s\\n" "$REPO_DIR"\n' >"$root/stub/zoxide"
+    printf '#!/bin/sh\nexit 0\n' >"$root/stub/gum"
+
+    chmod +x "$root"/stub/*
+    export REPO_DIR="$root/repo"
+  }
+
+  # One unstarted issue and one started one, in the order the script's own
+  # sort would leave them.
+  write_issues() {
+    cat >"$fixtures/issues.json" <<'JSON'
+{"data":{"viewer":{"assignedIssues":{"nodes":[
+  {"identifier":"BEN-15","title":"Started already","branchName":"ben/ben-15-started-already",
+   "url":"https://linear.app/ben/issue/BEN-15/started-already","priority":2,
+   "updatedAt":"2026-08-10T22:00:00.000Z","state":{"name":"In Progress","type":"started"},
+   "team":{"key":"BEN"},"project":{"name":"Tooling"}},
+  {"identifier":"BEN-16","title":"Not started yet","branchName":"ben/ben-16-not-started-yet",
+   "url":"https://linear.app/ben/issue/BEN-16/not-started-yet","priority":0,
+   "updatedAt":"2026-08-10T22:30:00.000Z","state":{"name":"Todo","type":"unstarted"},
+   "team":{"key":"BEN"},"project":null}
+]}}}}
+JSON
+  }
+
+  write_locations() {
+    printf '{"result":{"workspaces":%s}}\n' "$1" >"$fixtures/workspaces.json"
+    printf '{"result":{"tabs":%s}}\n' "$2" >"$fixtures/tabs.json"
+    printf '{"result":{"panes":%s}}\n' "$3" >"$fixtures/panes.json"
+  }
+
+  no_locations() {
+    write_locations \
+      '[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true,"label":"repo"}]' \
+      '[{"workspace_id":"w1","tab_id":"w1:t1","label":"1"}]' \
+      '[{"workspace_id":"w1","tab_id":"w1:t1","label":"","cwd":"/elsewhere","focused":true,"pane_id":"w1:p1"},
+        {"workspace_id":"w1","tab_id":"w1:t1","label":"","cwd":"/elsewhere","focused":false,"pane_id":"w1:p2"}]'
+  }
+
+  herdr_calls() { cat "$HERDR_CAPTURE"; }
+  linear_calls() { cat "$LINEAR_CAPTURE"; }
+
+  Describe "the picker"
+    It "sorts started issues above unstarted ones"
+      rows() { no_locations; run_script >/dev/null 2>&1; cat "$FZF_CAPTURE.issues"; }
+      When call rows
+      The status should be success
+      The line 1 should include "BEN-15"
+      The line 2 should include "BEN-16"
+    End
+
+    It "shows the state and project alongside the title"
+      rows() { no_locations; run_script >/dev/null 2>&1; head -1 "$FZF_CAPTURE.issues"; }
+      When call rows
+      The output should include "In Progress"
+      The output should include "Started already"
+      The output should include "· Tooling"
+    End
+
+    # fzf hands the preview {1}, so nothing may precede the identifier.
+    It "leads every row with the identifier"
+      first_fields() {
+        no_locations; run_script >/dev/null 2>&1
+        awk '{ print $1 }' "$FZF_CAPTURE.issues"
+      }
+      When call first_fields
+      The line 1 should equal "BEN-15"
+      The line 2 should equal "BEN-16"
+    End
+
+    It "marks a row herdr already has open"
+      marked() {
+        write_locations '[]' '[]' \
+          '[{"workspace_id":"w3","tab_id":"w3:t1","label":"BEN-15","cwd":"/elsewhere","pane_id":"w3:p1"}]'
+        run_script >/dev/null 2>&1
+        cat "$FZF_CAPTURE.issues"
+      }
+      When call marked
+      The line 1 should include "●"
+      The line 2 should not include "●"
+    End
+  End
+
+  Describe "reuse"
+    # wt's sanitize filter only flattens slashes, so this is the directory the
+    # branch's worktree lands in.
+    It "focuses a pane whose foreground directory is the issue's worktree"
+      focus() {
+        write_locations '[]' '[]' \
+          '[{"workspace_id":"w4","tab_id":"w4:t2","label":"",
+             "cwd":"/repo","foreground_cwd":"/wt/ben-ben-15-started-already","pane_id":"w4:p1"}]'
+        run_script >/dev/null 2>&1
+        herdr_calls
+      }
+      When call focus
+      The output should include "workspace focus w4"
+      The output should include "tab focus w4:t2"
+      The output should not include "tab create"
+    End
+
+    It "focuses a location labelled with the identifier"
+      focus() {
+        write_locations '[]' '[{"workspace_id":"w5","tab_id":"w5:t1","label":"BEN-15"}]' '[]'
+        run_script >/dev/null 2>&1
+        herdr_calls
+      }
+      When call focus
+      The output should include "tab focus w5:t1"
+      The output should not include "tab create"
+    End
+
+    # The alternates choose a topology for new work. They never duplicate a
+    # location that already exists.
+    It "focuses rather than splitting when an alternate key is pressed"
+      focus() {
+        write_locations '[]' '[{"workspace_id":"w5","tab_id":"w5:t1","label":"BEN-15"}]' '[]'
+        FZF_KEY=alt-p run_script >/dev/null 2>&1
+        herdr_calls
+      }
+      When call focus
+      The output should include "tab focus w5:t1"
+      The output should not include "pane split"
+    End
+  End
+
+  Describe "building a location"
+    It "opens a tab on enter and hands the pane wt plus claude"
+      built() { no_locations; run_script >/dev/null 2>&1; herdr_calls; }
+      When call built
+      The output should include "tab create --cwd $root/repo --label BEN-15 --focus"
+      The output should include "pane run w9:p1 wt switch --create ben/ben-15-started-already -x claude"
+      The output should include "pane rename w9:p1 BEN-15"
+    End
+
+    It "passes the issue URL to the issue skill"
+      built() { no_locations; run_script >/dev/null 2>&1; herdr_calls; }
+      When call built
+      The output should include "/issue\\ https://linear.app/ben/issue/BEN-15/started-already"
+    End
+
+    It "drops the agent for a shift variant"
+      built() { no_locations; FZF_KEY=alt-T run_script >/dev/null 2>&1; herdr_calls; }
+      When call built
+      The output should include "pane run w9:p1 wt switch --create ben/ben-15-started-already"
+      The output should not include "claude"
+    End
+
+    It "splits a pane on alt-p"
+      built() { no_locations; FZF_KEY=alt-p run_script >/dev/null 2>&1; herdr_calls; }
+      When call built
+      The output should include "pane split --pane w1:p2 --direction right --cwd $root/repo"
+      The output should include "pane run w1:p5 wt switch"
+    End
+
+    It "creates a workspace on alt-w"
+      built() { no_locations; FZF_KEY=alt-w run_script >/dev/null 2>&1; herdr_calls; }
+      When call built
+      The output should include "workspace create --cwd $root/repo --label BEN-15 --focus"
+    End
+
+    # wt refuses --create for a branch it can already see.
+    It "omits --create when the branch exists"
+      built() {
+        no_locations
+        git -C "$root/repo" commit --quiet --allow-empty -m init
+        git -C "$root/repo" branch ben/ben-15-started-already
+        run_script >/dev/null 2>&1
+        herdr_calls
+      }
+      When call built
+      The output should include "wt switch ben/ben-15-started-already"
+      The output should not include "--create"
+    End
+  End
+
+  Describe "the team to repo memory"
+    state_file() { cat "$XDG_STATE_HOME/dotfiles/linear-repos"; }
+
+    It "records the repo chosen for the issue's team"
+      choose() { no_locations; run_script >/dev/null 2>&1; state_file; }
+      When call choose
+      The output should equal "$(printf 'BEN\t%s' "$root/repo")"
+    End
+
+    It "offers the remembered repo before anything zoxide knows"
+      seeded() {
+        no_locations
+        mkdir -p "$XDG_STATE_HOME/dotfiles" "$root/remembered"
+        git -C "$root/remembered" init --quiet
+        printf 'BEN\t%s\n' "$root/remembered" >"$XDG_STATE_HOME/dotfiles/linear-repos"
+        run_script >/dev/null 2>&1
+        head -1 "$FZF_CAPTURE.repos"
+      }
+      When call seeded
+      The output should equal "$root/remembered"
+    End
+
+    It "replaces the team's entry rather than appending to it"
+      rewritten() {
+        no_locations
+        mkdir -p "$XDG_STATE_HOME/dotfiles"
+        printf 'DIS\t/other\nBEN\t/stale\n' >"$XDG_STATE_HOME/dotfiles/linear-repos"
+        run_script >/dev/null 2>&1
+        state_file
+      }
+      When call rewritten
+      The output should include "DIS"
+      The output should not include "/stale"
+      The lines of output should equal 2
+    End
+  End
+
+  Describe "the state transition"
+    It "starts an unstarted issue"
+      started() { no_locations; FZF_PICK=2 run_script >/dev/null 2>&1; sleep 1; linear_calls; }
+      When call started
+      The output should include "issue update BEN-16"
+    End
+
+    It "leaves an already started issue alone"
+      started() { no_locations; run_script >/dev/null 2>&1; sleep 1; linear_calls; }
+      When call started
+      The output should not include "issue update"
+    End
+  End
+
+  It "refuses to run outside a herdr session"
+    outside() {
+      PATH="$root/stub:$PATH" ZDOTDIR="$root/empty" HERDR_ENV='' "$script"
+    }
+    When call outside
+    The status should be failure
+    The stdout should equal ""
+  End
+End


### PR DESCRIPTION
Working an issue used to mean reading it in the GUI, copying the branch name, hunting down the repo, creating the worktree, then starting Claude and pasting the URL. Everything after the picking already existed. This adds the front half.

`prefix+i` opens a popup of the issues assigned to you that are unstarted or started. Selecting one creates a tab on a worktree for Linear's branch name, starts Claude on the `issue` skill, and moves the issue to the team's started state.

`alt-p` and `alt-w` reach the other two topologies. The shift variants leave a shell. All of them are fzf keys inside the picker, so the keymap only spends one binding on this.

Selecting an issue herdr already holds focuses it instead of building a second copy. The match runs against `foreground_cwd`, because `wt` execs the agent and the pane's own shell never leaves the repo root. Pane and tab labels are indexed too, which keeps an issue findable once its agent exits.

## Verification

The worktree lands at the worktrunk path, the `pre-start` hooks run, and herdr recognizes what comes up as a `claude` agent. I also drove the script end to end with `herdr pane send-keys`: the alt chords reach fzf, and a second run marks the row and focuses the tab that already exists.

## Open Items

The binding is not live until this merges, since dev mode points at another worktree. Run `bin/linear-work` from a pane until then.

fzf's preview renders blank inside a herdr pane. The process runs. Its output just never reaches the screen, and a bare `--preview 'echo hi'` does the same thing, so this is herdr and not this script.
