### PR TITLE
tailscale: guard the completion eval

### DIFF
--- a/tailscale/completion.zsh
+++ b/tailscale/completion.zsh
@@ -1,5 +1,8 @@
 #!/usr/bin/env zsh
 
+# The macOS app's CLI prints its own startup failures to stdout and still exits
+# 0, so an unguarded eval runs the error text as shell code.
 if (( $+commands[tailscale] )); then
-  eval "$(tailscale completion zsh)"
+  local completion="$(tailscale completion zsh 2>/dev/null)"
+  [[ $completion == '#compdef '* ]] && eval "$completion"
 fi


### PR DESCRIPTION
Every new shell printed `(eval):1: number expected` above the first prompt.

The macOS Tailscale app's CLI is broken on this machine: it prints `The Tailscale CLI failed to start: The operation couldn't be completed. (Tailscale.CLIError error 1.)` and exits 0. Since the exit status is clean and the message goes to stdout, `eval "$(tailscale completion zsh)"` ran that sentence as zsh. `(Tailscale.CLIError error 1.)` parses as a glob qualifier, and `number expected` is glob.c complaining about `error 1.`, which is why the message named no command.

Every `completion.zsh` in this repo guards on the command existing. That is the wrong test for a tool that can be present and broken. This one now also checks the output starts with `#compdef `, the first line of the cobra template Tailscale generates from, so only a real completion script gets evaluated.

Verified by running a full interactive startup against the dev tree, which is now silent.

The CLI failure itself is a system problem, not a dotfiles one. `tailscale status` and the app binary at `/Applications/Tailscale.app/Contents/MacOS/Tailscale` fail the same way, with the daemon running and `/Library/Tailscale/sameuserproof-62873` readable. Completions come back on their own once the app works again.
