### PR TITLE
herdr: unpin the plugin list

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,28 +15,6 @@
         "(?m)^(?<depName>[^\\s#/]+/[^\\s#]+)\\s+(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "github-releases"
-    },
-    {
-      "description": "herdr plugins, pinned to commits so herdr-lazy's own update path stays out of the way. git-refs needs a branch to take digests from, and these repos default to main.",
-      "customType": "regex",
-      "fileMatch": ["^herdr/plugins\\.list$"],
-      "matchStrings": [
-        "(?m)^(?!den-tanui/)(?<depName>[^\\s#/]+/[^\\s#@]+)@(?<currentDigest>[0-9a-f]{40})\\s*$"
-      ],
-      "datasourceTemplate": "git-refs",
-      "packageNameTemplate": "https://github.com/{{{depName}}}",
-      "currentValueTemplate": "main"
-    },
-    {
-      "description": "den-tanui/herdr-zoxide defaults to master, so it needs its own currentValueTemplate. herdr-lazy parses plugins.list positionally, so the branch can't ride along in the line itself.",
-      "customType": "regex",
-      "fileMatch": ["^herdr/plugins\\.list$"],
-      "matchStrings": [
-        "(?m)^(?<depName>den-tanui/herdr-zoxide)@(?<currentDigest>[0-9a-f]{40})\\s*$"
-      ],
-      "datasourceTemplate": "git-refs",
-      "packageNameTemplate": "https://github.com/{{{depName}}}",
-      "currentValueTemplate": "master"
     }
   ],
   "packageRules": [

--- a/herdr/.gitignore
+++ b/herdr/.gitignore
@@ -1,6 +1,6 @@
 # herdr-lazy writes the lock beside plugins.list, which puts it in this repo.
-# Every entry in the list is pinned to a commit, so the list already is the lock.
-# Committing it would only add a file that goes stale on every Renovate bump,
-# since Renovate moves the list and nothing regenerates the lock. `sync`
-# enforces the list's pins either way.
+# The nightly upgrade rewrites it in ~/.dotfiles and has nothing that commits,
+# so tracking it would leave that checkout permanently dirty and dotfiles-sync
+# refuses to pull into a dirty tree. To reproduce a machine, copy its lock over
+# and run `herdr-lazy restore`.
 plugins.lock

--- a/herdr/install.sh
+++ b/herdr/install.sh
@@ -29,11 +29,11 @@ export HERDR_LAZY_LIST="$PWD/plugins.list"
 
 lazy_repo=natori-hrj/herdr-lazy
 
-# Take the bootstrap ref from the list itself. A second copy of the SHA here
-# would disagree with it the first time Renovate bumps one of them.
-lazy_ref=$(sed -n "s|^${lazy_repo}@||p" plugins.list | head -1)
-if [[ -z "$lazy_ref" ]]; then
-  echo "plugins.list: ${lazy_repo} is missing or unpinned; nothing to bootstrap from" >&2
+# This script installs herdr-lazy by hand, so nothing below would notice its
+# absence from the list. `update` only moves what the list names, which would
+# leave it as the one plugin frozen at whatever commit first got installed.
+if ! grep -qE "^${lazy_repo}(@|\$)" plugins.list; then
+  echo "plugins.list: ${lazy_repo} is missing; it would never be updated" >&2
   exit 1
 fi
 
@@ -47,9 +47,9 @@ lazy_root() {
 
 root=$(lazy_root)
 if [[ -z "$root" ]]; then
-  echo "› herdr plugin install ${lazy_repo}@${lazy_ref}"
+  echo "› herdr plugin install ${lazy_repo}"
   # Keep a flaky third-party build from aborting the rest under `set -e`.
-  herdr plugin install "$lazy_repo" --ref "$lazy_ref" --yes || true
+  herdr plugin install "$lazy_repo" --yes || true
   root=$(lazy_root)
 fi
 
@@ -62,6 +62,11 @@ if [[ -z "$root" || ! -x "$lazy" ]]; then
 fi
 
 "$lazy" sync || echo "✗ herdr-lazy sync did not finish; some plugins may be missing" >&2
+
+# sync only installs what is absent, and an unpinned entry is satisfied by any
+# commit, so without this every plugin would sit at whatever it first installed.
+# This is the only thing that moves them, and the nightly upgrade runs it.
+"$lazy" update || echo "✗ herdr-lazy update did not finish; some plugins may be stale" >&2
 
 # With this on, a plugin added to the list later installs on the next herdr
 # start instead of waiting for someone to re-run this script.

--- a/herdr/install.sh
+++ b/herdr/install.sh
@@ -61,12 +61,15 @@ if [[ -z "$root" || ! -x "$lazy" ]]; then
   exit 0
 fi
 
-"$lazy" sync || echo "✗ herdr-lazy sync did not finish; some plugins may be missing" >&2
+# sync counts an unpinned entry as satisfied by whatever commit is installed, so
+# update is the only thing that moves one forward, and the nightly upgrade is
+# where that happens. It reinstalls every unpinned entry, missing ones included,
+# which is why it comes first: sync then has only pinned entries left to place,
+# instead of installing everything a second time.
+"$lazy" update || echo "✗ herdr-lazy update did not run; plugins may be stale" >&2
 
-# sync only installs what is absent, and an unpinned entry is satisfied by any
-# commit, so without this every plugin would sit at whatever it first installed.
-# This is the only thing that moves them, and the nightly upgrade runs it.
-"$lazy" update || echo "✗ herdr-lazy update did not finish; some plugins may be stale" >&2
+# Pinned entries, which update skips, plus anything sitting at the wrong commit.
+"$lazy" sync || echo "✗ herdr-lazy sync did not run; some plugins may be missing" >&2
 
 # With this on, a plugin added to the list later installs on the next herdr
 # start instead of waiting for someone to re-run this script.

--- a/herdr/plugins.list
+++ b/herdr/plugins.list
@@ -1,10 +1,11 @@
-# herdr plugins, installed by herdr-lazy. Commits are managed by Renovate
-# (.github/renovate.json customManagers).
-AltanS/collie@30371790c2eb486b02dbbfc668a551d0b4438617
-den-tanui/herdr-zoxide@7be842fe84d8d017c80e54f8d7eb7f0f6ef28c44
-devashish2203/herdr-worktrunk@a3107ca566bafcd463bc138007a0c01051970784
-natori-hrj/herdr-lazy@ae0eb89127ec1cfaaeb2c065e26c4eb346398b60
-nikok6/herdr-mirror@3738bacc148470af7c5c51c1ff11b8ebdb0a4878
-ogulcancelik/herdr-browser@be6888b71cf4eb5939ee79a746bd1a1c22ade046
-persiyanov/herdr-reviewr@792b4b31475ddbf263ee4d421a984e7418031506
-smarzban/herdr-file-viewer@71d4c1c3706e7958c714789b035a99d949620a9e
+# herdr plugins, installed by herdr-lazy. Entries are unpinned, so each tracks
+# its repository's default branch and `herdr-lazy update` in install.sh moves it
+# to the latest commit on every nightly upgrade. Add an @ref to hold one still.
+AltanS/collie
+den-tanui/herdr-zoxide
+devashish2203/herdr-worktrunk
+natori-hrj/herdr-lazy
+nikok6/herdr-mirror
+ogulcancelik/herdr-browser
+persiyanov/herdr-reviewr
+smarzban/herdr-file-viewer

--- a/herdr/plugins/config/herdr-file-viewer/config.toml
+++ b/herdr/plugins/config/herdr-file-viewer/config.toml
@@ -1,6 +1,6 @@
 # Settings in herdr's own config.toml never reach a plugin.
 # https://github.com/smarzban/herdr-file-viewer/blob/main/docs/configuration.md
 
-# The installed version is the commit plugins.list pins, which Renovate moves.
-# A daily check can only ever announce a release this machine won't install.
+# herdr-lazy moves this to the latest commit on the nightly upgrade, so a daily
+# check can only ever announce something that is already on its way in.
 update_check = false


### PR DESCRIPTION
Renovate has been down repo-wide since 2026-08-10. The herdr-zoxide manager added in #653 used a negative lookahead, and custom manager regexes compile with re2, which has no lookahead. Renovate filed its config error 18 seconds after that PR merged and has opened nothing since, so rust, leaf, mise, brew, and actions updates all stopped along with the plugin digests. Closes #654.

The pins were worth reconsidering rather than repairing. They were meant to be the update mechanism, but `automerge` meant nobody read the roughly three digest PRs a day they produced, and what they actually bought was latency: a plugin push waited for a Renovate cycle, a PR, CI, and the 3am upgrade before it landed. They also disabled the tool built for this. herdr-lazy tracks each repo's default branch for an unpinned entry, and its `update` moves those to their latest commit and records what resolved in `plugins.lock`.

So the entries lose their pins, both custom managers come out, and `install.sh` calls `update`. Repairing the regex instead would have worked and is a smaller diff: dropping `currentValueTemplate` entirely is enough, because `git-refs` falls back to the repo's `HEAD` when no current value is passed, which covers `main` and `master` without the second manager. That keeps a git-recorded history of which commit was installed when, at the cost of the latency and the churn. Not worth it here.

`update` runs before `sync` because it reinstalls every unpinned entry whether or not one is already present. With `sync` first, each plugin installed twice on a fresh machine. The end-to-end run confirms the ordering: `update` reported four moved forward and one missing plugin installed, then `sync` reported seven present and zero installed.

`plugins.lock` stays ignored. The nightly upgrade rewrites it in `~/.dotfiles` and nothing commits it, so tracking it would leave that checkout permanently dirty, and `dotfiles-sync` refuses to pull into a dirty tree.

## Verification

Ran `herdr/install.sh` against the real herdr install. A full reinstall of one plugin takes about two seconds, since these plugins fetch prebuilt binaries rather than compiling, so moving all eight nightly costs roughly what one Renovate-triggered rebuild used to.

The run surfaced one pre-existing failure unrelated to this change: `devashish2203/herdr-worktrunk` cannot install because `worktrunk` is already linked from a local path on this machine. The pinned entry failed the same way. Either the list entry or the local link has to go, but that is a separate decision.

Two known gaps, both left alone. herdr-lazy's `update` exits 0 even when individual plugins fail, so the `||` warning cannot fire for the case its message describes; catching it means parsing the summary output. And a herdr-lazy predating the `update` subcommand could never move itself forward, which no current install is.
