### PR TITLE
herdr: add herdr-nvim

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -84,6 +84,24 @@ type = "shell"
 command = "herdr plugin action invoke toggle --plugin persiyanov.reviewr"
 description = "reviewr diff (toggle)"
 
+# herdr-nvim — a per-tab nvim in a full-height split, plus a picker over the
+# files the agent just touched. The plugin has an nvim half too, declared in
+# neovim/config/init.lua, which is what sends annotations back to an agent.
+# Its README suggests prefix+e and prefix+o, both of which herdr already binds
+# (edit_scrollback, open_notification_target), so these take the shift variants
+# the same way the file viewer does above.
+[[keys.command]]
+key = "prefix+shift+e"
+type = "plugin_action"
+command = "chmarax.herdr-nvim.toggle"
+description = "nvim sidebar (toggle)"
+
+[[keys.command]]
+key = "prefix+shift+o"
+type = "plugin_action"
+command = "chmarax.herdr-nvim.pick-file"
+description = "nvim sidebar: open a file the agent touched"
+
 # worktrunk — routes worktree creation through wt instead of herdr's native
 # flow (see new_worktree above). prefix+shift+g reuses the native flow's key
 # so muscle memory carries. prefix+ctrl+g is the stacking entry point.

--- a/herdr/plugins.list
+++ b/herdr/plugins.list
@@ -2,6 +2,7 @@
 # its repository's default branch and `herdr-lazy update` in install.sh moves it
 # to the latest commit on every nightly upgrade. Add an @ref to hold one still.
 AltanS/collie
+ChmaraX/herdr-nvim
 den-tanui/herdr-zoxide
 devashish2203/herdr-worktrunk
 natori-hrj/herdr-lazy

--- a/neovim/config/init.lua
+++ b/neovim/config/init.lua
@@ -8,6 +8,7 @@ vim.pack.add({
   "https://github.com/christoomey/vim-tmux-navigator",
   "https://github.com/nvim-lualine/lualine.nvim",
   "https://github.com/lewis6991/gitsigns.nvim",
+  "https://github.com/ChmaraX/herdr-nvim",
 })
 
 require("config.options")
@@ -15,6 +16,7 @@ require("config.colorscheme")
 require("config.statusline")
 require("config.gitsigns")
 require("config.keymaps")
+require("config.herdr")
 require("config.treesitter")
 require("config.lsp")
 require("config.completion")

--- a/neovim/config/lua/config/herdr.lua
+++ b/neovim/config/lua/config/herdr.lua
@@ -1,0 +1,8 @@
+-- The nvim half of the herdr-nvim plugin: comment lines like a code review,
+-- then send the batch to any agent in the workspace with file:line and git
+-- context. The herdr half (sidebar, file picker) is installed by herdr-lazy
+-- from herdr/plugins.list and keyed in herdr/config.toml.
+--
+-- Comments live in memory and clear on a successful send, which is why the
+-- lualine statusline carries the pending count.
+require("herdr-nvim").setup({})

--- a/neovim/config/lua/config/statusline.lua
+++ b/neovim/config/lua/config/statusline.lua
@@ -8,7 +8,11 @@ require("lualine").setup({
   sections = {
     lualine_a = { "mode" },
     lualine_b = { "branch", "diff", "diagnostics" },
-    lualine_c = { { "filename", path = 1 } },
+    lualine_c = {
+      { "filename", path = 1 },
+      -- Pending herdr-nvim comments ("● 3"); empty string when there are none.
+      { function() return require("herdr-nvim").statusline() end },
+    },
     lualine_x = { "encoding", "fileformat", "filetype" },
     lualine_y = { "progress" },
     lualine_z = { "location" },

--- a/neovim/config/nvim-pack-lock.json
+++ b/neovim/config/nvim-pack-lock.json
@@ -4,6 +4,10 @@
       "rev": "6d808f99bd63303646794406e270bd553ad7792e",
       "src": "https://github.com/lewis6991/gitsigns.nvim"
     },
+    "herdr-nvim": {
+      "rev": "40aadeab3cef3702ef5e05069181c7168084794f",
+      "src": "https://github.com/ChmaraX/herdr-nvim"
+    },
     "lualine.nvim": {
       "rev": "131a558e13f9f28b15cd235557150ccb23f89286",
       "src": "https://github.com/nvim-lualine/lualine.nvim"


### PR DESCRIPTION
Adds both halves of [herdr-nvim](https://github.com/ChmaraX/herdr-nvim). The herdr plugin puts a per-tab nvim in a full-height split and a picker over the files the agent just touched. The nvim plugin sends line comments back to any agent in the workspace with `file:line` and git context, which is the return path the file viewer and reviewr don't have.

The plugin's README suggests `prefix+e` and `prefix+o`, and herdr binds both natively (`edit_scrollback` and `open_notification_target`), so these take the shift variants the way the file viewer bindings already do. `herdr config check` reports ok even on a binding naming a plugin that doesn't exist, so it says nothing about whether `chmarax.herdr-nvim.toggle` resolves through a plugin id that itself contains a dot. I pressed the key in a throwaway session running this config and read the plugin log to confirm the action fired. `herdr-nvim doctor` passes every check here: full-height root split, toggle round-trip restoring the layout exactly, daemon health, and remote-ui attach.

Comments live in memory and clear on a successful send, so lualine carries the pending count. Nothing else says a send is owed.

The pack lockfile pins the commit the herdr half installed, keeping both halves on one revision.

`herdr-fzf-links` overlaps with this. Its picker also routes file matches into nvim, and herdr-nvim registers link handlers for bare file paths and `file://` URLs. That branch is unmerged, so nothing collides today. Decide which one owns Ctrl+click before it lands.
