### PR TITLE
reload config in place after a sync or install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -294,15 +294,22 @@ jobs:
             echo "$bad"
             exit 1
           fi
-      - name: Check topic reload scripts are executable
+      - name: Check topic reload scripts are discoverable
         run: |
-          # bin/dotfiles-reload skips a reload.sh without the exec bit, so one
-          # committed without it never runs and nothing says so.
+          # bin/dotfiles-reload globs <topic>/reload.sh and skips one without
+          # the exec bit. Either way it runs nothing and says nothing.
           bad=$(find . -name 'reload.sh' -not -path './.git/*' -not -perm -u+x)
           if [[ -n "$bad" ]]; then
             echo "ERROR: reload scripts are skipped unless executable."
             echo "Run chmod +x on:"
             echo "$bad"
+            exit 1
+          fi
+          deep=$(find . -mindepth 3 -name 'reload.sh' -not -path './.git/*')
+          if [[ -n "$deep" ]]; then
+            echo "ERROR: bin/dotfiles-reload only globs one level down."
+            echo "Move to <topic>/reload.sh:"
+            echo "$deep"
             exit 1
           fi
       - name: Check private-use glyphs are declared

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,6 +172,38 @@ jobs:
 
         tmux_assert_opt @thm_surface_2 || exit 1
         tmux_assert_opt prefix C-s || exit 1
+
+        # tmux/reload.sh re-sources tmux.conf into this live server. It must
+        # leave the sessions alone: sourcing re-runs TPM, which re-runs
+        # tmux-continuum, which restores the whole saved session set into a
+        # server it reads as freshly started. Zeroing the restore window is what
+        # continuum reads as an aged server, and it is also what puts this
+        # server past reload.sh's own skip, so this exercises the source path.
+        tmux set -g @continuum-restore-max-delay 0
+        until (( $(date +%s) - $(tmux display-message -p -F '#{start_time}') >= 1 )); do
+          sleep 1
+        done
+
+        sessions_before=$(tmux list-sessions -F '#S' | sort | tr '\n' ' ')
+        reload_stderr=$(mktemp)
+        reload_exit=0
+        "$GITHUB_WORKSPACE/tmux/reload.sh" 2>"$reload_stderr" || reload_exit=$?
+        if [[ $reload_exit -ne 0 ]]; then
+          echo "FAIL: tmux/reload.sh exited with code $reload_exit"
+          cat "$reload_stderr"
+          exit 1
+        fi
+
+        sessions_after=$(tmux list-sessions -F '#S' | sort | tr '\n' ' ')
+        if [[ "$sessions_before" != "$sessions_after" ]]; then
+          echo "FAIL: reload changed the sessions: [$sessions_before] -> [$sessions_after]"
+          exit 1
+        fi
+        echo "OK: reload left sessions at [$sessions_after]"
+
+        # The config the reload just re-read is still in effect.
+        tmux_assert_opt @thm_surface_2 || exit 1
+        tmux_assert_opt prefix C-s || exit 1
     - name: Benchmark shell startup
       run: |
         hyperfine --warmup 3 --runs 10 --shell=none \
@@ -259,6 +291,17 @@ jobs:
           if [[ -n "$bad" ]]; then
             echo "ERROR: Files named 'completions.zsh' bypass the zshrc completion filter."
             echo "Rename to 'completion.zsh' (singular):"
+            echo "$bad"
+            exit 1
+          fi
+      - name: Check topic reload scripts are executable
+        run: |
+          # bin/dotfiles-reload skips a reload.sh without the exec bit, so one
+          # committed without it never runs and nothing says so.
+          bad=$(find . -name 'reload.sh' -not -path './.git/*' -not -perm -u+x)
+          if [[ -n "$bad" ]]; then
+            echo "ERROR: reload scripts are skipped unless executable."
+            echo "Run chmod +x on:"
             echo "$bad"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This is a personal dotfiles repository for macOS with Linux compatibility. The r
   - `path.zsh`: Loaded first for `$PATH` setup
   - `completion.zsh`: Deferred until after first prompt renders (via `precmd` hook)
   - `install.sh`: Topic installer for non-symlink setup (e.g., plugin managers, system config)
+  - `reload.sh`: Tells an already-running program to re-read its config (see [Config Reloads](#config-reloads))
   - `Brewfile`: Homebrew packages for the topic
 - **`*/symlinks.conf`**: Per-topic declarative symlink maps (`source:target`) discovered and processed by `scripts/install-symlinks`
 - **scripts/**: Bootstrap and setup scripts
@@ -188,6 +189,18 @@ Read the remote with `git config --get remote.<name>.url`, never `git remote get
 3. `mise install` — Install language runtimes
 4. `scripts/install-symlinks` — Install declarative symlinks from `symlinks.conf`
 5. Run topic `install.sh` scripts
+6. `theme/bin/theme-sync` reconciles theme-managed configs to the active flavor
+7. `bin/dotfiles-reload` hands the new config to whatever is already running
+
+### Config Reloads
+
+`bin/dotfiles-reload` runs every `<topic>/reload.sh`. `bin/dotfiles-sync`, `scripts/install`, and `dotfiles dev enable|disable` each end by calling it, so a config change reaches a program that has been running for weeks instead of waiting for a restart. Today that is `herdr server reload-config`, `tmux source-file` on `tmux.conf`, and `SIGUSR2` to Ghostty.
+
+Every reload is in place. The program re-reads its config and keeps its state, sessions, and child processes. Nothing here may restart a server, kill a session, or drop in-flight work: this runs unattended from the 3am job, where a restart takes live work down with it. A tool whose only path to new config is a restart gets no `reload.sh` and picks the change up on its next start. That is the whole test for whether something belongs here.
+
+A `reload.sh` self-gates. Exit 0 without work when the tool isn't installed or isn't running, since a fresh machine and CI hit both cases. The dispatcher logs a failing one and carries on to the rest.
+
+The tmux reload and a theme flip both re-source the appearance configs, and tmux interleaves commands from concurrent clients, so the two serialize on the lock in `scripts/lib/tmux-source-lock.sh`. `tmux/reload.sh` also sets `@tmux_config_reloading` while it sources, because `tmux.conf` ends by running `theme-sync-tmux`, which would otherwise wait out the lock timeout and then steal a lock still in use.
 
 ## Stacked PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ This is a personal dotfiles repository for macOS with Linux compatibility. The r
    - `<topic>/<tool>.zsh` for shell configuration
    - Add a `symlinks.conf` in the topic directory for config files targeting `~/.config/<tool>/`
    - `<topic>/install.sh` only if non-symlink setup is needed (plugin managers, system config)
+   - `<topic>/reload.sh` only if the tool holds its config in memory and can re-read it without restarting (see [Config Reloads](#config-reloads))
    - `<topic>/Brewfile` for dependencies
 3. Run `scripts/install` to install links and run topic installers
 
@@ -189,18 +190,20 @@ Read the remote with `git config --get remote.<name>.url`, never `git remote get
 3. `mise install` — Install language runtimes
 4. `scripts/install-symlinks` — Install declarative symlinks from `symlinks.conf`
 5. Run topic `install.sh` scripts
-6. `theme/bin/theme-sync` reconciles theme-managed configs to the active flavor
-7. `bin/dotfiles-reload` hands the new config to whatever is already running
+6. Run `theme/bin/theme-sync` to reconcile theme-managed configs to the active flavor
+7. Run `bin/dotfiles-reload` to hand the new config to whatever is already running
 
 ### Config Reloads
 
-`bin/dotfiles-reload` runs every `<topic>/reload.sh`. `bin/dotfiles-sync`, `scripts/install`, and `dotfiles dev enable|disable` each end by calling it, so a config change reaches a program that has been running for weeks instead of waiting for a restart. Today that is `herdr server reload-config`, `tmux source-file` on `tmux.conf`, and `SIGUSR2` to Ghostty.
+`bin/dotfiles-reload` runs every `<topic>/reload.sh`, so a config change reaches a program that has been running for weeks instead of waiting for a restart. `scripts/install` and `dotfiles dev enable|disable` call it directly. `bin/dotfiles-sync` calls it only when the pull moved the tree, and its `--bootstrap` path reaches it through `scripts/install` instead. `herdr/`, `tmux/`, and `terminal/` are the topics that have one.
 
-Every reload is in place. The program re-reads its config and keeps its state, sessions, and child processes. Nothing here may restart a server, kill a session, or drop in-flight work: this runs unattended from the 3am job, where a restart takes live work down with it. A tool whose only path to new config is a restart gets no `reload.sh` and picks the change up on its next start. That is the whole test for whether something belongs here.
+Every reload is in place. The program re-reads its config and keeps its state, sessions, and child processes. Nothing here may restart a server, kill a session, or drop in-flight work. This runs unattended from the 3am job, where a restart takes live work down with it, so a tool whose only path to new config is a restart gets no `reload.sh` and picks the change up on its next start.
 
-A `reload.sh` self-gates. Exit 0 without work when the tool isn't installed or isn't running, since a fresh machine and CI hit both cases. The dispatcher logs a failing one and carries on to the rest.
+A `reload.sh` self-gates. Exit 0 without work when the tool isn't installed or isn't running, since a fresh machine and CI hit both cases. Assume roughly a minute of runtime: the dispatcher caps each script there so a wedged peer can't hang the nightly job.
 
-The tmux reload and a theme flip both re-source the appearance configs, and tmux interleaves commands from concurrent clients, so the two serialize on the lock in `scripts/lib/tmux-source-lock.sh`. `tmux/reload.sh` also sets `@tmux_config_reloading` while it sources, because `tmux.conf` ends by running `theme-sync-tmux`, which would otherwise wait out the lock timeout and then steal a lock still in use.
+A failing `reload.sh` is contained on purpose. The dispatcher logs it and carries on to the rest, and both callers downgrade its exit status to a warning, so a broken reload never fails an install or the nightly job. Leave that alone. The install it follows has already succeeded, and stale in-memory config resolves itself the next time the program starts.
+
+Re-sourcing `tmux.conf` runs `theme-sync-tmux` near the end, so a tmux reload and a theme flip collide. Both take the lock in `scripts/lib/tmux-source-lock.sh`, and `tmux/reload.sh` additionally publishes its pid in `@tmux_config_reloading` so the nested run stands down rather than waiting out the lock timeout and stealing a lock still in use. Route any new re-source trigger through one of those two scripts.
 
 ## Stacked PRs
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A file's name determines how and when it loads:
 | `Brewfile` | Homebrew packages for the topic. |
 | `mise.toml` | Pinned language/tool versions, merged into mise's config. |
 | `install.sh` | Non-symlink setup: plugin managers, system config. Run by `scripts/install`. |
+| `reload.sh` | Tells an already-running program to re-read its config (see [config reloads](#config-reloads)). |
 | `.shellspec` | Opts the topic into [integration tests](#topic-integration-tests) that run in CI. |
 
 The repo-root [`bin/`](bin/) holds executables that go on `$PATH`, like `dotfiles-upgrade` and `bench-startup`.
@@ -152,13 +153,31 @@ Three commands drive it:
 * `dotfiles dev enable` persistently repoints every symlink to the checkout and sets the flag. `dotfiles dev disable` restores the installed copy.
 * `dotfiles status` shows which root is active and its revision.
 
-Writing the flag file and re-running `install-symlinks` happen in one step.
+Writing the flag file and re-running `install-symlinks` happen in one step, which ends by [reloading](#config-reloads) whatever was already holding the old root's config.
 
 ### Sync and Upgrade
 
 A launchd agent ([`macos/com.user.dotfiles-upgrade.plist`](macos/com.user.dotfiles-upgrade.plist)) runs [`bin/dotfiles-upgrade`](bin/dotfiles-upgrade) nightly. It syncs from the remote, reruns `scripts/install`, and cleans up stale packages. On failure it files a Things task with the error.
 
 `dotfiles sync` runs the same pull by hand. It refuses to sync a dirty tree, fast-forwards only, and updates submodules.
+
+### Config Reloads
+
+Most tools read their config once per invocation, so a sync is enough. A few hold it in memory for weeks: a tmux server, a herdr server, an open Ghostty. Those would sit on the config they started with until something restarted them.
+
+[`bin/dotfiles-reload`](bin/dotfiles-reload) runs every `<topic>/reload.sh`, and the sync, the install, and a dev-mode toggle all end by calling it:
+
+| Topic | Reload |
+| --- | --- |
+| [`herdr`](herdr/reload.sh) | `herdr server reload-config` over its socket API |
+| [`tmux`](tmux/reload.sh) | `source-file` on `tmux.conf`, the same thing `prefix+r` does |
+| [`terminal`](terminal/reload.sh) | `SIGUSR2` to Ghostty, the same path as its `reload_config` keybind |
+
+Every one is in place: the program re-reads its config and keeps its state, its sessions, and its child processes. Nothing restarts. This runs unattended at 3am, and a restart would take live work down with it, so a tool whose only path to new config is a restart gets no `reload.sh` and picks the change up whenever it next starts.
+
+Each script self-gates, exiting 0 without work when its tool isn't installed or isn't running, so a fresh machine and CI both no-op. The dispatcher logs a failing one and carries on to the rest.
+
+The tmux reload and a theme flip both re-source the appearance configs, and tmux interleaves commands from concurrent clients, so the two serialize on the lock in [`scripts/lib/tmux-source-lock.sh`](scripts/lib/tmux-source-lock.sh).
 
 ### Topic Integration Tests
 
@@ -178,7 +197,7 @@ Because bootstrap runs before them, [these specs](git/spec/) verify the installe
 Two entry points split one-time setup from the repeatable reconcile step:
 
 * [`scripts/bootstrap`](scripts/bootstrap) is the **one-time** fresh-machine path: install Homebrew, prompt for git identity, init submodules, then hand off to `dotf`, which runs install.
-* [`scripts/install`](scripts/install) is the **idempotent** core, safe to rerun nightly: `brew bundle` → install mise runtimes → install symlinks → run each topic's `install.sh` → sync the theme.
+* [`scripts/install`](scripts/install) is the **idempotent** core, safe to rerun nightly: `brew bundle` → install mise runtimes → install symlinks → run each topic's `install.sh` → sync the theme → [reload](#config-reloads) whatever is running.
 
 The nightly upgrade and the dev-mode relink both call `install`.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Most tools read their config once per invocation, so a sync is enough. A few hol
 
 Every one is in place: the program re-reads its config and keeps its state, its sessions, and its child processes. Nothing restarts. This runs unattended at 3am, and a restart would take live work down with it, so a tool whose only path to new config is a restart gets no `reload.sh` and picks the change up whenever it next starts.
 
-Each script self-gates, exiting 0 without work when its tool isn't installed or isn't running, so a fresh machine and CI both no-op. The dispatcher logs a failing one and carries on to the rest.
+Each script self-gates, exiting 0 without work when its tool isn't installed or isn't running, so a fresh machine and CI both no-op. The dispatcher logs a failing one and carries on to the rest. It also caps each at a minute, since a wedged socket would otherwise hang the nightly job past the point where it could report anything.
 
 The tmux reload and a theme flip both re-source the appearance configs, and tmux interleaves commands from concurrent clients, so the two serialize on the lock in [`scripts/lib/tmux-source-lock.sh`](scripts/lib/tmux-source-lock.sh).
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Three commands drive it:
 * `dotfiles dev enable` persistently repoints every symlink to the checkout and sets the flag. `dotfiles dev disable` restores the installed copy.
 * `dotfiles status` shows which root is active and its revision.
 
-Writing the flag file and re-running `install-symlinks` happen in one step, which ends by [reloading](#config-reloads) whatever was already holding the old root's config.
+Writing the flag file and re-running `install-symlinks` happen in one step. It ends by [reloading](#config-reloads) the programs still holding the old root's config.
 
 ### Sync and Upgrade
 
@@ -165,19 +165,19 @@ A launchd agent ([`macos/com.user.dotfiles-upgrade.plist`](macos/com.user.dotfil
 
 Most tools read their config once per invocation, so a sync is enough. A few hold it in memory for weeks: a tmux server, a herdr server, an open Ghostty. Those would sit on the config they started with until something restarted them.
 
-[`bin/dotfiles-reload`](bin/dotfiles-reload) runs every `<topic>/reload.sh`, and the sync, the install, and a dev-mode toggle all end by calling it:
+A sync that moved the tree, an install, and a dev-mode toggle all end by calling [`bin/dotfiles-reload`](bin/dotfiles-reload). It runs every `<topic>/reload.sh`:
 
 | Topic | Reload |
 | --- | --- |
-| [`herdr`](herdr/reload.sh) | `herdr server reload-config` over its socket API |
-| [`tmux`](tmux/reload.sh) | `source-file` on `tmux.conf`, the same thing `prefix+r` does |
-| [`terminal`](terminal/reload.sh) | `SIGUSR2` to Ghostty, the same path as its `reload_config` keybind |
+| [`herdr`](herdr/reload.sh) | `herdr server reload-config` over its socket API, for `config.toml` only |
+| [`tmux`](tmux/reload.sh) | `source-file` on the installed `tmux.conf`, the same thing `prefix+r` does |
+| [`terminal`](terminal/reload.sh) | `SIGUSR2` to Ghostty, the same path as its `reload_config` action |
 
-Every one is in place: the program re-reads its config and keeps its state, its sessions, and its child processes. Nothing restarts. This runs unattended at 3am, and a restart would take live work down with it, so a tool whose only path to new config is a restart gets no `reload.sh` and picks the change up whenever it next starts.
+Every one is in place. The program re-reads its config and keeps its state, sessions, and child processes, and nothing restarts. This runs unattended at 3am, where a restart would take live work down with it. So a tool whose only path to new config is a restart gets no `reload.sh`, and picks the change up whenever it next starts.
 
-Each script self-gates, exiting 0 without work when its tool isn't installed or isn't running, so a fresh machine and CI both no-op. The dispatcher logs a failing one and carries on to the rest. It also caps each at a minute, since a wedged socket would otherwise hang the nightly job past the point where it could report anything.
+Each script self-gates, exiting 0 without work when its tool isn't installed or isn't running, so a fresh machine and CI both do nothing. The dispatcher logs a failing script and carries on to the rest. It caps each at a minute, since a wedged socket would otherwise hang the nightly job past the point where it could report anything.
 
-The tmux reload and a theme flip both re-source the appearance configs, and tmux interleaves commands from concurrent clients, so the two serialize on the lock in [`scripts/lib/tmux-source-lock.sh`](scripts/lib/tmux-source-lock.sh).
+The tmux reload and a theme flip both re-source the appearance configs, and tmux interleaves commands from concurrent clients, so the two serialize on the lock in [`scripts/lib/tmux-source-lock.sh`](scripts/lib/tmux-source-lock.sh). The lock alone isn't enough, because re-sourcing `tmux.conf` runs [`theme-sync-tmux`](theme/bin/theme-sync-tmux) from inside the reload's own lock. The reload publishes its pid in `@tmux_config_reloading` so that nested run stands down instead of waiting out the timeout and stealing a lock still in use.
 
 ### Topic Integration Tests
 

--- a/bin/dotfiles-reload
+++ b/bin/dotfiles-reload
@@ -22,8 +22,8 @@ root="$(cd "$(dirname "$0")/.." && pwd)"
 # unattended and reports failures by creating a Things task, so a hang is worse
 # than a failure: it never reports, and it holds the job open under every later
 # run. A minute is far past what any of these take. `timeout` comes from
-# coreutils and isn't on a stock macOS, so a machine without it runs unbounded
-# rather than not reloading.
+# coreutils, which system/Brewfile declares for the macOS machines that have no
+# stock copy. A machine that somehow lacks it still reloads, unbounded.
 if command -v timeout >/dev/null 2>&1; then
   bound() { timeout 60 "$@"; }
 else

--- a/bin/dotfiles-reload
+++ b/bin/dotfiles-reload
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Tell the long-running programs that hold this repo's config in memory to
+# re-read it, so a sync or an install lands without waiting for a restart.
+#
+# Every reload here is in place: the program re-reads its config and keeps its
+# state, sessions, and child processes. Nothing restarts a server, because this
+# runs unattended from the nightly upgrade and a restart would take live work
+# down with it. A tool whose only path to new config is a restart therefore has
+# no `reload.sh` and picks the change up whenever it next starts.
+#
+# Each `<topic>/reload.sh` self-gates and exits 0 without work when its tool
+# isn't installed or isn't running. Most tools need nothing here at all: they
+# read their config once per invocation, so the next invocation has it.
+set -uo pipefail
+shopt -s nullglob
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+
+status=0
+for reload in "$root"/*/reload.sh; do
+  [[ -x "$reload" ]] || continue
+  # Not `if ! "$reload"`: that reads $? off the negation, which is always 0.
+  "$reload" && continue
+  status=$?
+  gum log --level error "$(basename "$(dirname "$reload")")/reload.sh exited $status"
+done
+exit "$status"

--- a/bin/dotfiles-reload
+++ b/bin/dotfiles-reload
@@ -17,11 +17,24 @@ shopt -s nullglob
 
 root="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Every reload talks to a running program, over a socket or a tmux command, and
+# a wedged one would otherwise hang here forever. The nightly upgrade runs
+# unattended and reports failures by creating a Things task, so a hang is worse
+# than a failure: it never reports, and it holds the job open under every later
+# run. A minute is far past what any of these take. `timeout` comes from
+# coreutils and isn't on a stock macOS, so a machine without it runs unbounded
+# rather than not reloading.
+if command -v timeout >/dev/null 2>&1; then
+  bound() { timeout 60 "$@"; }
+else
+  bound() { "$@"; }
+fi
+
 status=0
 for reload in "$root"/*/reload.sh; do
   [[ -x "$reload" ]] || continue
-  # Not `if ! "$reload"`: that reads $? off the negation, which is always 0.
-  "$reload" && continue
+  # Not `if ! bound "$reload"`: that reads $? off the negation, which is always 0.
+  bound "$reload" && continue
   status=$?
   gum log --level error "$(basename "$(dirname "$reload")")/reload.sh exited $status"
 done

--- a/bin/dotfiles-sync
+++ b/bin/dotfiles-sync
@@ -39,4 +39,10 @@ notify "Dotfiles Sync" "Updated to $new_rev" "Glass"
 if [[ "$1" == "--bootstrap" ]] && [[ -x "$DOTFILES_HOME/scripts/bootstrap" ]]; then
   gum log --level info "Running bootstrap..."
   "$DOTFILES_HOME/scripts/bootstrap" --no-prompt
+else
+  # The symlinks didn't move, but the files they point at just did, so anything
+  # holding the old config is now behind. Only on this branch: bootstrap
+  # reaches the same reload through scripts/install, once its own changes are
+  # in place.
+  "$DOTFILES_HOME/bin/dotfiles-reload" || gum log --level warn "some config reloads had issues"
 fi

--- a/herdr/reload.sh
+++ b/herdr/reload.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Re-read config.toml in the running herdr server. Workspaces, tabs, panes, and
+# the agents in them keep running.
+#
+# Only config.toml. The agent detection overlays have their own reload, which
+# bin/herdr-agent-detection fires when it installs one, and herdr exposes
+# nothing for the plugin configs under plugins/config.
+set -uo pipefail
+
+command -v herdr >/dev/null 2>&1 || exit 0
+
+# A machine with no server running is the ordinary case, and it fails here the
+# same way a server that refused the request does. Neither is worth a nonzero
+# exit out of an unattended upgrade: without a server there is nothing holding
+# stale config, and a refusal leaves herdr on the config it already had.
+out=$(herdr server reload-config 2>/dev/null) || exit 0
+
+# reload-config reports a bad config.toml as diagnostics rather than as a
+# failure, and herdr goes on serving the old config either way. Nothing else
+# would say so.
+command -v jq >/dev/null 2>&1 || exit 0
+if [[ "$(jq -r '.result.diagnostics | length' <<<"$out" 2>/dev/null)" != "0" ]]; then
+  gum log --level warn "herdr kept its old config: $(jq -c '.result.diagnostics' <<<"$out")"
+fi

--- a/herdr/reload.sh
+++ b/herdr/reload.sh
@@ -16,10 +16,15 @@ command -v herdr >/dev/null 2>&1 || exit 0
 # stale config, and a refusal leaves herdr on the config it already had.
 out=$(herdr server reload-config 2>/dev/null) || exit 0
 
+command -v jq >/dev/null 2>&1 || exit 0
+
 # reload-config reports a bad config.toml as diagnostics rather than as a
 # failure, and herdr goes on serving the old config either way. Nothing else
-# would say so.
-command -v jq >/dev/null 2>&1 || exit 0
-if [[ "$(jq -r '.result.diagnostics | length' <<<"$out" 2>/dev/null)" != "0" ]]; then
-  gum log --level warn "herdr kept its old config: $(jq -c '.result.diagnostics' <<<"$out")"
-fi
+# would say so. --exit-status covers the other shape this can take: a response
+# carrying no diagnostics field at all, from a herdr that answers something
+# other than what this expects, is not a rejected config and must not warn
+# like one.
+diagnostics=$(jq --compact-output --exit-status '.result.diagnostics' <<<"$out" 2>/dev/null) || exit 0
+[[ "$diagnostics" == "[]" ]] && exit 0
+
+gum log --level warn "herdr kept its old config: $diagnostics"

--- a/scripts/install
+++ b/scripts/install
@@ -53,3 +53,9 @@ find . -name install.sh "${excludes[@]}" | while read -r installer; do "${instal
 # installer so each config exists and tmux plugins are present; failures here
 # shouldn't abort an otherwise successful install.
 ./theme/bin/theme-sync || gum log --level warn "theme-sync had issues"
+
+# Hand the new config to whatever is already running with the old one. After
+# theme-sync, which re-themes tmux under the same lock the tmux reload takes.
+# Reloads are in place and never restart anything, so this is safe from the
+# nightly job. A failure here shouldn't abort an otherwise successful install.
+./bin/dotfiles-reload || gum log --level warn "some config reloads had issues"

--- a/scripts/lib/tmux-source-lock.sh
+++ b/scripts/lib/tmux-source-lock.sh
@@ -14,7 +14,11 @@ TMUX_SOURCE_LOCK="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/theme-sync-tmux.lock"
 # second, so a holder that outlives the wait is dead or wedged. Steal its lock.
 # Returns nonzero only when even the steal fails.
 tmux_source_lock_acquire() {
-  mkdir -p "$(dirname "$TMUX_SOURCE_LOCK")"
+  # Checked rather than left to `set -e`, which bash suppresses inside a
+  # function whose call is the left side of `||`. That is how both callers
+  # invoke this, so an unwritable cache directory would otherwise fall into the
+  # retry loop and spin out the whole timeout before failing.
+  mkdir -p "$(dirname "$TMUX_SOURCE_LOCK")" || return 1
 
   local _
   for _ in $(seq 1 100); do

--- a/scripts/lib/tmux-source-lock.sh
+++ b/scripts/lib/tmux-source-lock.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+# Serializes anything that re-sources tmux's appearance configs.
+#
+# tmux interleaves commands from concurrent clients, so two overlapping
+# re-sources corrupt state: the catppuccin plugin assembles the window formats
+# with a chain of appends, and status.conf's capture can grab another run's
+# wrapper, which renders every window tab as an empty string. A retheme
+# (theme/bin/theme-sync-tmux) and a full config reload (tmux/reload.sh) both do
+# that, so both take this lock. Route any new trigger through one of them.
+
+TMUX_SOURCE_LOCK="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/theme-sync-tmux.lock"
+
+# mkdir is the portable atomic lock. Either operation takes well under a
+# second, so a holder that outlives the wait is dead or wedged. Steal its lock.
+# Returns nonzero only when even the steal fails.
+tmux_source_lock_acquire() {
+  mkdir -p "$(dirname "$TMUX_SOURCE_LOCK")"
+
+  local _
+  for _ in $(seq 1 100); do
+    mkdir "$TMUX_SOURCE_LOCK" 2>/dev/null && return 0
+    sleep 0.1
+  done
+
+  rmdir "$TMUX_SOURCE_LOCK" 2>/dev/null || true
+  mkdir "$TMUX_SOURCE_LOCK" 2>/dev/null
+}
+
+tmux_source_lock_release() {
+  rmdir "$TMUX_SOURCE_LOCK" 2>/dev/null || true
+}

--- a/scripts/spec/dotfiles_reload_spec.sh
+++ b/scripts/spec/dotfiles_reload_spec.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe "dotfiles-reload"
+  dotfiles_reload="$SHELLSPEC_PROJECT_ROOT/../bin/dotfiles-reload"
+
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/dotfiles-reload"
+    stubdir="$sandbox/stub"
+    rm -rf "$sandbox"
+    mkdir -p "$stubdir" "$sandbox/bin"
+
+    stub_gum "$stubdir"
+
+    # The dispatcher globs topics relative to its own parent, so it has to run
+    # from a copy inside the fixture rather than from the repo.
+    cp "$dotfiles_reload" "$sandbox/bin/dotfiles-reload"
+  }
+
+  # topic <name> <exit status>
+  topic() {
+    mkdir -p "$sandbox/$1"
+    printf '#!/usr/bin/env bash\necho "%s reloaded"\nexit %s\n' "$1" "$2" \
+      > "$sandbox/$1/reload.sh"
+    chmod +x "$sandbox/$1/reload.sh"
+  }
+
+  run_reload() {
+    PATH="$stubdir:$PATH" "$sandbox/bin/dotfiles-reload"
+  }
+
+  BeforeEach 'setup'
+
+  It "runs every topic's reload.sh"
+    topic alpha 0
+    topic beta 0
+    When call run_reload
+    The status should be success
+    The output should include "alpha reloaded"
+    The output should include "beta reloaded"
+  End
+
+  It "exits 0 when no topic declares a reload"
+    When call run_reload
+    The status should be success
+  End
+
+  # One tool refusing to reload must not stop the rest, the same way a failing
+  # topic installer doesn't abort the install.
+  It "keeps going past a failing topic and reports its status"
+    topic alpha 3
+    topic beta 0
+    When call run_reload
+    The status should equal 3
+    The output should include "beta reloaded"
+    The stderr should include "alpha/reload.sh exited 3"
+  End
+
+  # A reload.sh that lost its exec bit would otherwise be run through the
+  # shell's interpreter guess, or fail as "permission denied" every night.
+  It "skips a reload.sh that is not executable"
+    topic alpha 0
+    chmod -x "$sandbox/alpha/reload.sh"
+    When call run_reload
+    The status should be success
+    The output should not include "alpha reloaded"
+  End
+End

--- a/scripts/spec/dotfiles_reload_spec.sh
+++ b/scripts/spec/dotfiles_reload_spec.sh
@@ -45,8 +45,6 @@ Describe "dotfiles-reload"
     The status should be success
   End
 
-  # One tool refusing to reload must not stop the rest, the same way a failing
-  # topic installer doesn't abort the install.
   It "keeps going past a failing topic and reports its status"
     topic alpha 3
     topic beta 0

--- a/system/Brewfile
+++ b/system/Brewfile
@@ -1,5 +1,6 @@
 brew 'bash'
 brew 'btop'
+brew 'coreutils'
 brew 'eza'
 brew 'findutils'
 brew 'fzf'

--- a/terminal/reload.sh
+++ b/terminal/reload.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Nudge a running Ghostty to re-read ~/.config/ghostty/config. SIGUSR2 is the
+# same path as its reload_config keybind, so open windows, tabs, and the shells
+# in them keep running.
+#
+# Ghostty is the only thing this topic installs that holds its config in
+# memory. yazi reads its theme at startup, and zoxide's config is environment
+# variables in a shell that already has them.
+set -uo pipefail
+
+# pkill exits 1 with nothing to signal, which is every machine without Ghostty
+# running, CI included.
+pkill -USR2 -x ghostty 2>/dev/null || true

--- a/theme/bin/theme-sync
+++ b/theme/bin/theme-sync
@@ -8,9 +8,10 @@ bin_dir="$(cd "$(dirname "$0")" && pwd)"
 status=0
 for sync in "$bin_dir"/theme-sync-*; do
   [[ -x "$sync" ]] || continue
-  if ! "$sync"; then
-    status=$?
-    gum log --level error "$(basename "$sync") exited $status"
-  fi
+  # Not `if ! "$sync"`: that reads $? off the negation, which is always 0, so
+  # every failure reported "exited 0" and the loop exited 0 along with it.
+  "$sync" && continue
+  status=$?
+  gum log --level error "$(basename "$sync") exited $status"
 done
 exit "$status"

--- a/theme/bin/theme-sync-tmux
+++ b/theme/bin/theme-sync-tmux
@@ -21,9 +21,14 @@ tmux list-sessions >/dev/null 2>&1 || exit 0
 # tmux/reload.sh holds the lock below while it re-sources tmux.conf, whose last
 # lines run this script. Waiting would burn the full timeout and then steal a
 # lock the reload is still using, so stand down instead: the reload re-applies
-# the flavor itself, through the plugin.
+# the flavor itself, through the plugin, and re-runs this script once it lets
+# the lock go. The option carries the reload's pid, so a reload killed before
+# it could clear the option leaves a pid that is gone, and this proceeds rather
+# than standing down for the life of the server.
 reloading=$(tmux show -gv @tmux_config_reloading 2>/dev/null || echo "")
-[[ "$reloading" == "1" ]] && exit 0
+if [[ -n "$reloading" ]] && kill -0 "$reloading" 2>/dev/null; then
+  exit 0
+fi
 
 # Plugin not installed yet (fresh bootstrap): nothing to retheme. A partial
 # checkout (one conf present, the other missing) would half-apply the theme

--- a/theme/bin/theme-sync-tmux
+++ b/theme/bin/theme-sync-tmux
@@ -8,7 +8,8 @@
 # them: tmux interleaves commands from concurrent clients, so unserialized
 # re-themes corrupt the window formats mid-build (the plugin assembles them
 # with a chain of appends) or capture the window-status wrapper into itself,
-# which renders every window tab empty.
+# which renders every window tab empty. tmux/reload.sh re-sources the same
+# files and shares the lock, which lives in scripts/lib/tmux-source-lock.sh.
 set -euo pipefail
 
 bin_dir="$(cd "$(dirname "$0")" && pwd)"
@@ -16,6 +17,13 @@ flavor="$("$bin_dir/theme-flavor")"
 
 # No tmux server, nothing to sync. Next `tmux` will pick up the flavor at startup.
 tmux list-sessions >/dev/null 2>&1 || exit 0
+
+# tmux/reload.sh holds the lock below while it re-sources tmux.conf, whose last
+# lines run this script. Waiting would burn the full timeout and then steal a
+# lock the reload is still using, so stand down instead: the reload re-applies
+# the flavor itself, through the plugin.
+reloading=$(tmux show -gv @tmux_config_reloading 2>/dev/null || echo "")
+[[ "$reloading" == "1" ]] && exit 0
 
 # Plugin not installed yet (fresh bootstrap): nothing to retheme. A partial
 # checkout (one conf present, the other missing) would half-apply the theme
@@ -30,23 +38,11 @@ for f in "${plugin_confs[@]}"; do
   fi
 done
 
-# mkdir is the portable atomic lock. A retheme takes well under a second, so
-# a holder that outlives the wait is dead or wedged; steal its lock.
-lock="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/theme-sync-tmux.lock"
-mkdir -p "$(dirname "$lock")"
-acquire() {
-  local _
-  for _ in $(seq 1 100); do
-    mkdir "$lock" 2>/dev/null && return 0
-    sleep 0.1
-  done
-  return 1
-}
-if ! acquire; then
-  rmdir "$lock" 2>/dev/null || true
-  mkdir "$lock" 2>/dev/null || exit 1
-fi
-trap 'rmdir "$lock" 2>/dev/null' EXIT
+# shellcheck source=../../scripts/lib/tmux-source-lock.sh
+source "$bin_dir/../../scripts/lib/tmux-source-lock.sh"
+
+tmux_source_lock_acquire || exit 1
+trap tmux_source_lock_release EXIT
 
 # Gate under the lock so queued triggers see the winner's flavor and no-op.
 # Read globally on purpose: a stray session-scoped @catppuccin_flavor would

--- a/tmux/reload.sh
+++ b/tmux/reload.sh
@@ -9,26 +9,56 @@
 # no-op rather than a wrapper captured into itself.
 set -uo pipefail
 
+root="$(cd "$(dirname "$0")/.." && pwd)"
+
 command -v tmux >/dev/null 2>&1 || exit 0
 
 # No server, so nothing is holding the old config. The next one reads it fresh.
 tmux list-sessions >/dev/null 2>&1 || exit 0
 
+# A server this young read the current config when it started, so there is
+# nothing here to update. Skipping also keeps this out of tmux-continuum's
+# restore window. Re-sourcing tmux.conf re-runs TPM, which re-runs continuum's
+# entrypoint, and that restores the entire saved session set whenever the
+# server started under @continuum-restore-max-delay seconds ago. Sourcing
+# inside the window resurrects saved sessions into a live server and re-runs
+# @resurrect-processes in their panes.
+started=$(tmux display-message -p -F '#{start_time}' 2>/dev/null || echo "")
+window=$(tmux show -gv @continuum-restore-max-delay 2>/dev/null || echo 10)
+[[ "$window" =~ ^[0-9]+$ ]] || window=10
+# continuum reads an unreadable start time as a just-started server and
+# restores on it, so match that reading rather than sourcing into it.
+[[ "$started" =~ ^[0-9]+$ ]] || exit 0
+(( $(date +%s) - started <= window )) && exit 0
+
 # shellcheck source=../scripts/lib/tmux-source-lock.sh
-source "$(cd "$(dirname "$0")/.." && pwd)/scripts/lib/tmux-source-lock.sh"
+source "$root/scripts/lib/tmux-source-lock.sh"
 
 tmux_source_lock_acquire || exit 1
 
 # tmux.conf ends by running theme-sync-tmux, which takes the same lock. The
-# flag tells it to stand down for the duration rather than wait out the
-# timeout and steal a lock still in use. Re-sourcing tmux.conf re-applies the
-# flavor on its own, through the plugin: @catppuccin_flavor is set with -o, so
-# the value theme-sync-tmux chose survives the reload.
+# option tells it to stand down for the duration rather than wait out the
+# timeout and steal a lock still in use. It carries this process's pid rather
+# than a bare flag: a reload killed before its trap runs would otherwise leave
+# the option set for the life of the server, silently ending every later theme
+# flip. A pid that is gone reads as no reload in progress.
 release() {
   tmux set -gu @tmux_config_reloading 2>/dev/null
   tmux_source_lock_release
 }
 trap release EXIT
 
-tmux set -g @tmux_config_reloading 1
+tmux set -g @tmux_config_reloading $$
 tmux source-file "${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"
+rc=$?
+
+release
+trap - EXIT
+
+# A flavor flip that fired inside the window above found a reload in progress
+# and stood down, and nothing would retry it. Re-run it now the lock is free.
+# It re-reads the system appearance and no-ops when the server already agrees,
+# so this costs nothing on the ordinary path.
+"$root/theme/bin/theme-sync-tmux" || true
+
+exit "$rc"

--- a/tmux/reload.sh
+++ b/tmux/reload.sh
@@ -16,20 +16,26 @@ command -v tmux >/dev/null 2>&1 || exit 0
 # No server, so nothing is holding the old config. The next one reads it fresh.
 tmux list-sessions >/dev/null 2>&1 || exit 0
 
-# A server this young read the current config when it started, so there is
-# nothing here to update. Skipping also keeps this out of tmux-continuum's
-# restore window. Re-sourcing tmux.conf re-runs TPM, which re-runs continuum's
-# entrypoint, and that restores the entire saved session set whenever the
-# server started under @continuum-restore-max-delay seconds ago. Sourcing
-# inside the window resurrects saved sessions into a live server and re-runs
-# @resurrect-processes in their panes.
+# Re-sourcing tmux.conf re-runs TPM, which re-runs continuum's entrypoint, and
+# that restores the entire saved session set whenever the server started under
+# @continuum-restore-max-delay seconds ago. Sourcing inside that window
+# resurrects saved sessions into a live server and re-runs @resurrect-processes
+# in their panes. Wait it out instead. The server read the current config at
+# startup, so all this delays is a change that landed in the seconds since.
 started=$(tmux display-message -p -F '#{start_time}' 2>/dev/null || echo "")
 window=$(tmux show -gv @continuum-restore-max-delay 2>/dev/null || echo 10)
 [[ "$window" =~ ^[0-9]+$ ]] || window=10
 # continuum reads an unreadable start time as a just-started server and
 # restores on it, so match that reading rather than sourcing into it.
 [[ "$started" =~ ^[0-9]+$ ]] || exit 0
-(( $(date +%s) - started <= window )) && exit 0
+
+remaining=$(( window - ($(date +%s) - started) + 1 ))
+if (( remaining > 0 )); then
+  # A window widened past the minute the dispatcher allows each reload isn't
+  # worth waiting out, and the server is still on config it read moments ago.
+  (( remaining > 30 )) && exit 0
+  sleep "$remaining"
+fi
 
 # shellcheck source=../scripts/lib/tmux-source-lock.sh
 source "$root/scripts/lib/tmux-source-lock.sh"

--- a/tmux/reload.sh
+++ b/tmux/reload.sh
@@ -22,20 +22,28 @@ tmux list-sessions >/dev/null 2>&1 || exit 0
 # resurrects saved sessions into a live server and re-runs @resurrect-processes
 # in their panes. Wait it out instead. The server read the current config at
 # startup, so all this delays is a change that landed in the seconds since.
-started=$(tmux display-message -p -F '#{start_time}' 2>/dev/null || echo "")
 window=$(tmux show -gv @continuum-restore-max-delay 2>/dev/null || echo 10)
 [[ "$window" =~ ^[0-9]+$ ]] || window=10
-# continuum reads an unreadable start time as a just-started server and
-# restores on it, so match that reading rather than sourcing into it.
-[[ "$started" =~ ^[0-9]+$ ]] || exit 0
 
-remaining=$(( window - ($(date +%s) - started) + 1 ))
-if (( remaining > 0 )); then
+# Read twice, because the server can exit during the sleep and a replacement
+# take the socket. Sourcing on the first server's start time would then land in
+# the replacement's restore window, which is the case this exists to avoid.
+for _ in 1 2; do
+  started=$(tmux display-message -p -F '#{start_time}' 2>/dev/null || echo "")
+  # continuum reads an unreadable start time as a just-started server and
+  # restores on it, so match that reading rather than sourcing into it.
+  [[ "$started" =~ ^[0-9]+$ ]] || exit 0
+
+  remaining=$(( window - ($(date +%s) - started) + 1 ))
+  (( remaining <= 0 )) && break
   # A window widened past the minute the dispatcher allows each reload isn't
   # worth waiting out, and the server is still on config it read moments ago.
   (( remaining > 30 )) && exit 0
   sleep "$remaining"
-fi
+done
+# Still inside a window on the second read means a replacement server, which
+# has the current config anyway.
+(( remaining > 0 )) && exit 0
 
 # shellcheck source=../scripts/lib/tmux-source-lock.sh
 source "$root/scripts/lib/tmux-source-lock.sh"

--- a/tmux/reload.sh
+++ b/tmux/reload.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Re-source the tmux config in the running server, the same thing prefix+r
+# does. Sessions, panes, and the processes in them are untouched.
+#
+# The config is written to survive this: core/unbinds.conf tombstones removed
+# bindings, since source-file cannot unbind a key by forgetting it, and
+# responsive.conf and status.conf guard their captures so a second source is a
+# no-op rather than a wrapper captured into itself.
+set -uo pipefail
+
+command -v tmux >/dev/null 2>&1 || exit 0
+
+# No server, so nothing is holding the old config. The next one reads it fresh.
+tmux list-sessions >/dev/null 2>&1 || exit 0
+
+# shellcheck source=../scripts/lib/tmux-source-lock.sh
+source "$(cd "$(dirname "$0")/.." && pwd)/scripts/lib/tmux-source-lock.sh"
+
+tmux_source_lock_acquire || exit 1
+
+# tmux.conf ends by running theme-sync-tmux, which takes the same lock. The
+# flag tells it to stand down for the duration rather than wait out the
+# timeout and steal a lock still in use. Re-sourcing tmux.conf re-applies the
+# flavor on its own, through the plugin: @catppuccin_flavor is set with -o, so
+# the value theme-sync-tmux chose survives the reload.
+release() {
+  tmux set -gu @tmux_config_reloading 2>/dev/null
+  tmux_source_lock_release
+}
+trap release EXIT
+
+tmux set -g @tmux_config_reloading 1
+tmux source-file "${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"

--- a/tmux/reload.sh
+++ b/tmux/reload.sh
@@ -25,25 +25,28 @@ tmux list-sessions >/dev/null 2>&1 || exit 0
 window=$(tmux show -gv @continuum-restore-max-delay 2>/dev/null || echo 10)
 [[ "$window" =~ ^[0-9]+$ ]] || window=10
 
-# Read twice, because the server can exit during the sleep and a replacement
-# take the socket. Sourcing on the first server's start time would then land in
-# the replacement's restore window, which is the case this exists to avoid.
-for _ in 1 2; do
+# Seconds left on the window, reading the age fresh each call. The server can
+# exit and a replacement take the socket at any point here, so the answer has to
+# describe whichever server is about to be sourced into.
+window_remaining() {
+  local started
   started=$(tmux display-message -p -F '#{start_time}' 2>/dev/null || echo "")
   # continuum reads an unreadable start time as a just-started server and
   # restores on it, so match that reading rather than sourcing into it.
-  [[ "$started" =~ ^[0-9]+$ ]] || exit 0
+  [[ "$started" =~ ^[0-9]+$ ]] || { echo $(( window + 1 )); return; }
+  echo $(( window - ($(date +%s) - started) + 1 ))
+}
 
-  remaining=$(( window - ($(date +%s) - started) + 1 ))
-  (( remaining <= 0 )) && break
+remaining=$(window_remaining)
+if (( remaining > 0 )); then
   # A window widened past the minute the dispatcher allows each reload isn't
   # worth waiting out, and the server is still on config it read moments ago.
   (( remaining > 30 )) && exit 0
   sleep "$remaining"
-done
-# Still inside a window on the second read means a replacement server, which
-# has the current config anyway.
-(( remaining > 0 )) && exit 0
+  # Still inside a window means the socket turned over during the sleep. The
+  # replacement read the current config when it started.
+  (( $(window_remaining) > 0 )) && exit 0
+fi
 
 # shellcheck source=../scripts/lib/tmux-source-lock.sh
 source "$root/scripts/lib/tmux-source-lock.sh"
@@ -61,6 +64,13 @@ release() {
   tmux_source_lock_release
 }
 trap release EXIT
+
+# Acquiring the lock can take seconds, which is another chance for the socket to
+# turn over. This is the last look before the source, so it is the one that
+# matters.
+if (( $(window_remaining) > 0 )); then
+  exit 0
+fi
 
 tmux set -g @tmux_config_reloading $$
 tmux source-file "${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"

--- a/zsh/active-root.zsh
+++ b/zsh/active-root.zsh
@@ -44,7 +44,10 @@ _dotfiles_switch_root() {
   # holding the config of the root we just left. Every reload is in place, so a
   # mode toggle costs no sessions. Guarded because the root being switched to
   # can be a checkout predating this script.
+  # Downgraded to a warning, as in scripts/install and bin/dotfiles-sync: the
+  # flag and the symlinks have already moved, so the switch succeeded whatever
+  # the reload did, and returning its status would report otherwise.
   if [[ -x "$root/bin/dotfiles-reload" ]]; then
-    "$root/bin/dotfiles-reload"
+    "$root/bin/dotfiles-reload" || gum log --level warn "some config reloads had issues"
   fi
 }

--- a/zsh/active-root.zsh
+++ b/zsh/active-root.zsh
@@ -39,4 +39,12 @@ _dotfiles_switch_root() {
     root="$DOTFILES_HOME"
   fi
   "$root/scripts/install-symlinks" "$root"
+
+  # The links now resolve into a different tree, so anything already running is
+  # holding the config of the root we just left. Every reload is in place, so a
+  # mode toggle costs no sessions. Guarded because the root being switched to
+  # can be a checkout predating this script.
+  if [[ -x "$root/bin/dotfiles-reload" ]]; then
+    "$root/bin/dotfiles-reload"
+  fi
 }


### PR DESCRIPTION
A sync updates the files on disk, but a tmux server, a herdr server, or an open Ghostty goes on running whatever config it read weeks ago. Adds a `<topic>/reload.sh` convention and a `bin/dotfiles-reload` dispatcher, called at the end of `scripts/install`, of a sync that moved the tree, and of a dev-mode toggle.

Three topics earn one: herdr's socket API, `tmux source-file`, and `SIGUSR2` to Ghostty. Everything else either reads its config per invocation or can't re-read it short of a restart. Restart cases stay out: this runs unattended from the 3am job, where restarting a server takes live work down with it, so reloading in place is the membership test.

## Reload Hazards

Re-sourcing `tmux.conf` re-runs TPM, which re-runs tmux-continuum, which restores the entire saved session set whenever it reads the server as freshly started. Reproduced on an isolated server: one session named `solo` became five, and with `@resurrect-processes '"~claude"'` set, each restored pane would have re-run `claude` unattended. So `tmux/reload.sh` waits until the server is past `@continuum-restore-max-delay` before sourcing. At most ten seconds, and only on a server that just started.

`tmux.conf` also runs `theme-sync-tmux` near its end, so a reload holding the shared source lock triggers a nested run that waits out the timeout and then steals the lock. The reload publishes its pid in `@tmux_config_reloading` so the nested run stands down. A pid rather than a flag, because a reload killed before its trap fires would otherwise leave the option set for the life of the server and silently end every later theme flip.

## Containment

The dispatcher logs a failing reload and carries on, and every caller downgrades its status to a warning, so a broken `reload.sh` never fails an install or the nightly job. The install it follows already succeeded, and stale config resolves itself on the program's next start.

Each script is capped at a minute. A wedged socket would otherwise hang the launchd job past the point where it could file its failure task. That needs `timeout`, so `coreutils` is now declared.

Separately, `theme/bin/theme-sync` read `$?` off an `if !` negation, which is always 0. Every failing theme sync had reported "exited 0", and the install's warning had never fired.
