### PR TITLE
neovim: tune the config for editing prose

### DIFF
--- a/neovim/config/init.lua
+++ b/neovim/config/init.lua
@@ -9,6 +9,7 @@ vim.pack.add({
   "https://github.com/nvim-lualine/lualine.nvim",
   "https://github.com/lewis6991/gitsigns.nvim",
   "https://github.com/ChmaraX/herdr-nvim",
+  "https://github.com/folke/which-key.nvim",
 })
 
 require("config.options")
@@ -16,6 +17,8 @@ require("config.colorscheme")
 require("config.statusline")
 require("config.gitsigns")
 require("config.keymaps")
+require("config.whichkey")
+require("config.prose")
 require("config.herdr")
 require("config.treesitter")
 require("config.lsp")

--- a/neovim/config/lua/config/keymaps.lua
+++ b/neovim/config/lua/config/keymaps.lua
@@ -5,14 +5,8 @@ vim.keymap.set("n", "<leader>b", "<cmd>Telescope buffers<cr>", { desc = "Buffers
 -- j and k move by what's on screen rather than by logical line, so a wrapped
 -- paragraph steps a row at a time. Guarding on v:count keeps 5j counting real
 -- lines, which is what the relative number column is showing.
-local function by_display_line(key)
-  return function()
-    return vim.v.count == 0 and ("g" .. key) or key
-  end
-end
-
-vim.keymap.set({ "n", "x" }, "j", by_display_line("j"), { expr = true, desc = "Down by display line" })
-vim.keymap.set({ "n", "x" }, "k", by_display_line("k"), { expr = true, desc = "Up by display line" })
+vim.keymap.set({ "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { expr = true, desc = "Down by display line" })
+vim.keymap.set({ "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { expr = true, desc = "Up by display line" })
 
 vim.keymap.set("n", "<Esc>", "<cmd>nohlsearch<cr>", { desc = "Clear search highlight" })
 

--- a/neovim/config/lua/config/keymaps.lua
+++ b/neovim/config/lua/config/keymaps.lua
@@ -1,3 +1,21 @@
 vim.keymap.set("n", "<leader>f", "<cmd>Telescope find_files<cr>", { desc = "Find files" })
 vim.keymap.set("n", "<leader>g", "<cmd>Telescope live_grep<cr>", { desc = "Live grep" })
 vim.keymap.set("n", "<leader>b", "<cmd>Telescope buffers<cr>", { desc = "Buffers" })
+
+-- j and k move by what's on screen rather than by logical line, so a wrapped
+-- paragraph steps a row at a time. Guarding on v:count keeps 5j counting real
+-- lines, which is what the relative number column is showing.
+local function by_display_line(key)
+  return function()
+    return vim.v.count == 0 and ("g" .. key) or key
+  end
+end
+
+vim.keymap.set({ "n", "x" }, "j", by_display_line("j"), { expr = true, desc = "Down by display line" })
+vim.keymap.set({ "n", "x" }, "k", by_display_line("k"), { expr = true, desc = "Up by display line" })
+
+vim.keymap.set("n", "<Esc>", "<cmd>nohlsearch<cr>", { desc = "Clear search highlight" })
+
+-- Visual P leaves the register alone where p replaces it with whatever was
+-- selected. With clipboard=unnamedplus that difference is the system clipboard.
+vim.keymap.set("x", "p", "P", { desc = "Paste over selection" })

--- a/neovim/config/lua/config/options.lua
+++ b/neovim/config/lua/config/options.lua
@@ -9,3 +9,26 @@ vim.o.laststatus = 3
 
 -- Treesitter supplies folds; open files with all of them expanded.
 vim.o.foldlevelstart = 99
+
+-- Yank and put go through the system clipboard. Deletes land there too, since
+-- vim has no way to split the two, so d and c overwrite what you last copied.
+vim.o.clipboard = "unnamedplus"
+
+-- Wrapping defaults assume code. These are for the markdown drafts this config
+-- actually opens, usually in a split narrow enough that every paragraph wraps.
+vim.o.linebreak = true
+vim.o.breakindent = true
+vim.o.showbreak = "↪ "
+
+vim.o.ignorecase = true
+vim.o.smartcase = true
+
+-- Undo survives closing the file, which is the whole session for a draft that
+-- gets opened, edited, and closed again on the next round.
+vim.o.undofile = true
+
+-- Turns E37 on :q into a save/discard/cancel prompt.
+vim.o.confirm = true
+
+vim.o.splitright = true
+vim.o.splitbelow = true

--- a/neovim/config/lua/config/prose.lua
+++ b/neovim/config/lua/config/prose.lua
@@ -1,0 +1,15 @@
+-- Buffers this config exists to edit: the markdown drafts an agent writes into a
+-- split for review, and the commit messages that follow them.
+--
+-- spelllang is "en" rather than "en_us" because en.utf-8.spl ships in
+-- $VIMRUNTIME. A regional variant prompts to download one on first open.
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "markdown", "gitcommit" },
+  callback = function()
+    vim.opt_local.spell = true
+    vim.opt_local.spelllang = "en"
+
+    -- Don't flag the halves of identifiers that turn up in technical prose.
+    vim.opt_local.spelloptions:append("camel")
+  end,
+})

--- a/neovim/config/lua/config/treesitter.lua
+++ b/neovim/config/lua/config/treesitter.lua
@@ -2,10 +2,11 @@ local treesitter = require("nvim-treesitter")
 
 local languages = {
   "bash", "diff", "dockerfile",
-  "git_rebase", "gitcommit", "go", "gomod",
+  "git_config", "git_rebase", "gitcommit", "go", "gomod",
   "hcl", "javascript", "json", "lua",
-  "python", "ruby", "rust", "terraform", "toml",
-  "typescript", "tsx", "yaml",
+  "markdown", "markdown_inline",
+  "python", "ruby", "rust", "ssh_config", "terraform",
+  "toml", "typescript", "tsx", "yaml",
 }
 
 treesitter.install(languages)

--- a/neovim/config/lua/config/whichkey.lua
+++ b/neovim/config/lua/config/whichkey.lua
@@ -1,0 +1,6 @@
+-- Pressing a prefix and waiting shows what's bound under it, reading the desc
+-- field every keymap in config.keymaps already sets. This config is used in
+-- bursts, so the leader map is easier to be reminded of than to memorize.
+require("which-key").setup({
+  preset = "helix",
+})

--- a/neovim/config/nvim-pack-lock.json
+++ b/neovim/config/nvim-pack-lock.json
@@ -31,6 +31,10 @@
     "vim-tmux-navigator": {
       "rev": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432",
       "src": "https://github.com/christoomey/vim-tmux-navigator"
+    },
+    "which-key.nvim": {
+      "rev": "3aab2147e74890957785941f0c1ad87d0a44c15a",
+      "src": "https://github.com/folke/which-key.nvim"
     }
   }
 }


### PR DESCRIPTION
Tunes the Neovim config toward what it actually gets opened for.

Shell history says nearly every invocation is a single file. Almost all of them are markdown drafts (`plan.md`, `QUESTIONS.md`, `HANDOFF.md`, `spec.md`) or a dotfile (`~/.ssh/config.local`, `~/.gitconfig.local`). Session history shows the same pattern: an agent writes a PR body, issue draft, or review comment into a split, then I edit the prose and close the buffer to hand it back. The config carried three Telescope keymaps and five LSP servers for that, and no `markdown` treesitter parser.

The wrapping defaults are the substantive fix. In a split narrow enough that every paragraph wraps, stock Neovim breaks lines mid-word, drops the indent on wrapped bullets, and makes `j` jump a whole paragraph. `linebreak`, `breakindent`, and display-line `j`/`k` make a wrapped paragraph read and navigate like one. The motions guard on `v:count`, so `5j` still counts real lines to match the relative number column.

`clipboard=unnamedplus` is the headline ask. Yank round-trips through the system clipboard so text can go straight into a browser. The tradeoff is that vim cannot separate yank from delete, so `d` and `c` overwrite the clipboard too. Visual `p` is mapped to `P` to blunt that, since `P` pastes over a selection without replacing the register.

The rest is beginner-facing:

- `undofile` so undo survives closing a draft and reopening it on the next round
- `confirm` so `:q` on a modified buffer prompts instead of erroring with `E37`
- `ignorecase` and `smartcase`
- spell check scoped to `markdown` and `gitcommit` only

`spelllang` is `en` rather than `en_us` because `en.utf-8.spl` ships in `$VIMRUNTIME`. A regional variant prompts to download one on first open.

which-key is the one new plugin. Three leader mappings existed with nothing to surface them, which is most of why they went unused. It reads the `desc` fields the keymaps already set.

Treesitter picks up `markdown`, `markdown_inline`, `git_config`, and `ssh_config`, the filetypes actually being opened. All four register a filetype and attach a highlighter, so the existing treesitter spec covers them with no changes to the spec itself.

Exercised against a fresh XDG prefix, so the committed lockfile pin is what gets installed rather than an already-present plugin tree. That path covers headless startup, parser builds, markdown highlighting attaching to a real buffer, the count-guard behavior of the new motions, and the statusline theme check.

Not addressed: `unnamedplus` needs a clipboard tool on Linux (`xclip`/`wl-clipboard`), which nothing here declares. On a headless box there is no clipboard to integrate with, and yanks still work in the unnamed register, so this stays a macOS-first change.
