### PR TITLE
sync: pin the fetch url past an insteadOf rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,11 @@ The nightly jobs run at 3am against a locked Mac, where Secretive refuses to sig
 
 `claude-upgrade` also calls `git_https_env`, which exports the same rewrite as an `insteadOf` rule. That covers the marketplace and plugin clones Claude Code makes for itself, which it creates with `git@github.com:` URLs and re-clones on every update. An `insteadOf` rule outranks a `pushurl`, so the exports are scoped to the plugin steps rather than the whole script.
 
-Read the remote with `git config --get remote.<name>.url`, never `git remote get-url`. The latter resolves `insteadOf` rules, so it reports HTTPS while `.git/config` still holds the SSH URL, and a rewrite keyed on it silently never fires.
+Storing an HTTPS URL does not settle which transport the fetch uses. An org that standardizes on SSH installs a `url.<base>.insteadOf` rule mapping `https://github.com/` back to `git@github.com:`, and that rule rewrites whatever is stored. Nothing written to the remote escapes it. `git_https_pin` covers that. Git applies the longest matching rule, so one keyed on the remote's full HTTPS URL and mapping it to itself outranks any broader `github.com` rule. It goes in the repo's own config and names a single URL, so every other remote is left alone. The pin is written only when git resolves the remote somewhere other than that URL, and the SSH URL the rule was producing stays behind as the `pushurl`. A rule of equal length registered earlier still wins the tie. The pin is written once and logs where the remote resolves instead, so the run that cannot win leaves the config no larger.
+
+Only the stored URL decides whether a remote is a github remote. A rule can send some other host to github, but one that rewrites the host without keeping the repo path would have us store a URL naming a repository that does not exist, so `git_https_remote` acts on what `.git/config` holds and nothing else.
+
+`git config --get remote.<name>.url` gives the stored URL, which is what a rewrite keys on. Never read that with `git remote get-url`: it resolves `insteadOf` rules, so it reports HTTPS while `.git/config` still holds the SSH URL, and a rewrite keyed on it silently never fires. `git ls-remote --get-url` gives the URL the fetch will actually open, which is how the pin tells whether it took.
 
 ### Manual Commands
 

--- a/scripts/lib/git-sync.sh
+++ b/scripts/lib/git-sync.sh
@@ -13,6 +13,11 @@
 #   reads need no credentials, while pushes stay on the transport that already
 #   has them. Other hosts and URL forms are left alone.
 #
+# git_https_pin <repo_dir> <remote> <https_url>
+#   Hold the remote on HTTPS when an insteadOf rule would send it back to SSH.
+#   Called by git_https_remote. The comment above the function covers why
+#   storing an HTTPS URL is not by itself enough.
+#
 # git_https_env
 #   Export the same rewrite as an insteadOf rule, for child processes cloning
 #   github.com remotes this repo does not own. Appends to any GIT_CONFIG_COUNT
@@ -47,6 +52,26 @@ git_default_branch() {
 }
 
 GIT_HTTPS_SSH_PREFIXES=("git@github.com:" "ssh://git@github.com/")
+GIT_HTTPS_BASE="https://github.com/"
+
+# Echo the anonymous HTTPS form of a github.com URL. A URL pointing anywhere
+# else echoes nothing, since only github.com is public enough to read without
+# credentials.
+git_https_url() {
+  local url="$1" prefix
+
+  if [[ "$url" == "$GIT_HTTPS_BASE"* ]]; then
+    echo "$url"
+    return 0
+  fi
+
+  for prefix in "${GIT_HTTPS_SSH_PREFIXES[@]}"; do
+    if [[ "$url" == "$prefix"* ]]; then
+      echo "$GIT_HTTPS_BASE${url#"$prefix"}"
+      return 0
+    fi
+  done
+}
 
 git_https_remote() {
   local repo_dir="$1"
@@ -54,29 +79,72 @@ git_https_remote() {
 
   # `git remote get-url` resolves insteadOf rules, so it reports HTTPS while
   # .git/config still holds the SSH URL, and the rewrite below never fires.
+  local stored
+  stored=$(git -C "$repo_dir" config --get "remote.$remote.url" 2>/dev/null) || return 0
+
+  # Only the stored URL decides whether this is a github remote. Asking git what
+  # it resolves to would catch a rule pointing some other host at github, but a
+  # rule that rewrites the host without keeping the repo path would then have us
+  # store a URL naming a repository that does not exist.
   local url
-  url=$(git -C "$repo_dir" config --get "remote.$remote.url" 2>/dev/null) || return 0
+  url=$(git_https_url "$stored")
+  [[ -n "$url" ]] || return 0
 
-  local prefix repo_path=""
-  for prefix in "${GIT_HTTPS_SSH_PREFIXES[@]}"; do
-    if [[ "$url" == "$prefix"* ]]; then
-      repo_path="${url#"$prefix"}"
-      break
-    fi
-  done
-  [[ -n "$repo_path" ]] || return 0
+  if [[ "$stored" != "$url" ]]; then
+    gum log --level info "Fetching $remote over HTTPS, pushing over SSH"
+    git -C "$repo_dir" config --get "remote.$remote.pushurl" >/dev/null 2>&1 ||
+      git -C "$repo_dir" remote set-url --push "$remote" "$stored"
+    git -C "$repo_dir" remote set-url "$remote" "$url"
+  fi
 
-  gum log --level info "Fetching $remote over HTTPS, pushing over SSH"
+  git_https_pin "$repo_dir" "$remote" "$url"
+}
+
+# Storing an HTTPS URL does not settle which transport the fetch uses. A
+# `url.<base>.insteadOf` rule rewrites the URL on its way out of .git/config,
+# and one mapping https://github.com/ to git@github.com:, as an org that
+# standardizes on SSH would install, puts the fetch straight back on the
+# transport the rewrite exists to avoid. Nothing we store escapes it, because
+# the rule rewrites whatever is stored.
+#
+# Git applies the longest matching rule, so one keyed on this remote's full
+# HTTPS URL and mapping it to itself outranks any broader github.com rule while
+# leaving every other remote alone.
+git_https_pin() {
+  local repo_dir="$1" remote="$2" url="$3"
+
+  # --get-url resolves insteadOf without contacting the remote, so it reports
+  # the URL the fetch will really open.
+  local resolved
+  resolved=$(git -C "$repo_dir" ls-remote --get-url "$remote")
+  [[ "$resolved" == "$url" ]] && return 0
+
+  gum log --level info "Pinning $remote to HTTPS past an insteadOf rule"
+
+  # The rule was the only thing holding this remote on SSH. Record where it sent
+  # pushes before the pin takes it out of the picture, so a push keeps the
+  # transport its credentials are set up for.
   git -C "$repo_dir" config --get "remote.$remote.pushurl" >/dev/null 2>&1 ||
-    git -C "$repo_dir" remote set-url --push "$remote" "$url"
-  git -C "$repo_dir" remote set-url "$remote" "https://github.com/$repo_path"
+    git -C "$repo_dir" remote set-url --push "$remote" "$resolved"
+
+  # --add, because insteadOf is multi-valued. A plain write refuses a key that
+  # already carries more than one rule, and would drop a lone existing one. The
+  # guard matters when the pin loses: a rule of equal length registered earlier
+  # wins the tie, and an unguarded --add would append another copy every night.
+  git -C "$repo_dir" config --get-all "url.$url.insteadOf" 2>/dev/null |
+    grep -qxF "$url" ||
+    git -C "$repo_dir" config --add "url.$url.insteadOf" "$url"
+
+  resolved=$(git -C "$repo_dir" ls-remote --get-url "$remote")
+  [[ "$resolved" == "$url" ]] ||
+    gum log --level warn "$remote still resolves to $resolved"
 }
 
 git_https_env() {
   local i="${GIT_CONFIG_COUNT:-0}" prefix
 
   for prefix in "${GIT_HTTPS_SSH_PREFIXES[@]}"; do
-    export "GIT_CONFIG_KEY_$i=url.https://github.com/.insteadOf"
+    export "GIT_CONFIG_KEY_$i=url.$GIT_HTTPS_BASE.insteadOf"
     export "GIT_CONFIG_VALUE_$i=$prefix"
     i=$((i + 1))
   done

--- a/scripts/spec/git_https_remote_spec.sh
+++ b/scripts/spec/git_https_remote_spec.sh
@@ -12,12 +12,29 @@ setup() {
   mkdir -p "$stubdir"
   stub_gum "$stubdir"
   git init -q -b main "$repo"
+
+  # A url.*.insteadOf rule anywhere above the repo decides which transport a
+  # fetch uses, so these examples supply the only ones that apply.
+  global="$sandbox/gitconfig"
+  : >"$global"
+  export GIT_CONFIG_GLOBAL="$global"
+  export GIT_CONFIG_SYSTEM=/dev/null
 }
 
 BeforeEach 'setup'
 
+# What an org that standardizes on SSH installs. It undoes an HTTPS remote.
+force_ssh() {
+  git config --file "$global" "url.git@github.com:.insteadOf" "https://github.com/"
+}
+
 fetch_url() { git -C "$repo" config --get remote.origin.url; }
 push_url() { git -C "$repo" config --get "remote.origin.pushurl"; }
+effective_url() { git -C "$repo" ls-remote --get-url origin; }
+pin_key="url.https://github.com/bendrucker/claude.git.insteadOf"
+pin() { git -C "$repo" config --get "$pin_key" || true; }
+pins() { git -C "$repo" config --get-all "$pin_key" || true; }
+pin_count() { pins | grep -cxF "https://github.com/bendrucker/claude.git" | tr -d ' '; }
 
 Describe "git_https_remote"
   rewrite() {
@@ -78,6 +95,87 @@ Describe "git_https_remote"
     When call rewrite "git@github.com:bendrucker/claude.git"
     The output should equal "https://github.com/bendrucker/claude.git"
     The stderr should include "pushing over SSH"
+  End
+
+  # Regression: a remote already stored as HTTPS looks done, and every 3am fetch
+  # still went out over SSH and died on "agent refused operation", because the
+  # rule rewrote it on the way out.
+  It "holds an https remote on HTTPS against a rule mapping it back to SSH"
+    force_ssh
+    When call rewrite "https://github.com/bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The result of function effective_url should equal "https://github.com/bendrucker/claude.git"
+    The stderr should include "Pinning origin"
+  End
+
+  It "rewrites and pins an ssh remote when the rule is present"
+    force_ssh
+    When call rewrite "git@github.com:bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The result of function effective_url should equal "https://github.com/bendrucker/claude.git"
+  End
+
+  # The pin takes the rule out of the fetch path, and a push that was going over
+  # SSH has to keep going there. Its credentials are set up for that transport.
+  It "keeps pushes on SSH when it pins the fetch"
+    force_ssh
+    When call rewrite "https://github.com/bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The result of function push_url should equal "git@github.com:bendrucker/claude.git"
+  End
+
+  # Only the stored url decides. A rule that sends another host to github does
+  # not make this a github remote, and acting on one whose replacement drops the
+  # repo path would store a url naming a repository that does not exist.
+  It "leaves a non-github remote alone when a rule sends it to github"
+    git config --file "$global" "url.https://github.com/.insteadOf" "https://"
+    When call rewrite "https://bitbucket.org/bendrucker/private.git"
+    The output should equal "https://bitbucket.org/bendrucker/private.git"
+    The result of function pin should equal ""
+    The stderr should not include "Pinning"
+  End
+
+  # Most machines have no such rule. Writing the pin anyway would leave an
+  # unexplained url.*.insteadOf in every repo the nightly job touches.
+  It "writes no pin when nothing rewrites the url"
+    When call rewrite "git@github.com:bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The result of function pin should equal ""
+    The stderr should not include "Pinning"
+  End
+
+  # insteadOf is multi-valued. A plain write refuses a key already carrying two
+  # rules, which left the pin unwritten and the fetch back on SSH.
+  It "pins alongside existing rules on the key it claims"
+    force_ssh
+    git config --file "$global" "url.git@github.com:.insteadOf" "https://git.example.com/" --add
+    git -C "$repo" config --add "$pin_key" "https://mirror.example/"
+    git -C "$repo" config --add "$pin_key" "https://mirror2.example/"
+    When call rewrite "https://github.com/bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The result of function effective_url should equal "https://github.com/bendrucker/claude.git"
+    The result of function pins should include "https://mirror.example/"
+    The result of function pins should include "https://mirror2.example/"
+  End
+
+  # A rule of equal length registered earlier wins the tie, so this pin never
+  # takes. It has to stop trying rather than grow .git/config a line a night.
+  rewrite_thrice() {
+    git -C "$repo" remote add origin "$1"
+    PATH="$stubdir:$PATH" git_https_remote "$repo"
+    PATH="$stubdir:$PATH" git_https_remote "$repo"
+    PATH="$stubdir:$PATH" git_https_remote "$repo"
+    fetch_url
+  }
+
+  It "adds the pin once when an equal-length rule outranks it"
+    git config --file "$global" \
+      "url.git@github.com:bendrucker/claude.git.insteadOf" \
+      "https://github.com/bendrucker/claude.git"
+    When call rewrite_thrice "https://github.com/bendrucker/claude.git"
+    The output should equal "https://github.com/bendrucker/claude.git"
+    The result of function pin_count should equal "1"
+    The stderr should include "still resolves to"
   End
 End
 


### PR DESCRIPTION
Fixes the nightly `claude-upgrade` job failing every night on a machine that carries a `url."git@github.com:".insteadOf = https://github.com/` rule, the shape an org that standardizes on SSH installs. The fetch runs at 3am against a locked Mac, the agent refuses to sign, and four retries fail.

`git_https_remote` exists to prevent this and never fired. The remote was already stored as HTTPS, so it considered its work done and logged nothing. Git resolved the rule on the way out and the fetch opened `git@github.com:` anyway. Rewriting what is stored cannot win against a rule that rewrites whatever is stored.

`git_https_pin` writes a rule keyed on the remote's full HTTPS URL mapping it to itself. Git applies the longest match, so it outranks the broader `github.com` rule, and naming one URL in the repo's own config leaves every other remote alone. It is written only when git resolves the remote elsewhere, so a machine without such a rule gets nothing. The SSH URL stays behind as the `pushurl`.

## Two Reads

`git config --get remote.<name>.url` gives the stored URL, which is what a rewrite keys on. `git ls-remote --get-url` gives the URL the fetch will open, which is how the pin tells whether it took. `git remote get-url` resolves `insteadOf` rules, so it reports HTTPS while `.git/config` holds SSH, and a rewrite keyed on it never fires.

## Limits

A rule of equal length registered earlier takes the tie. The pin is written once and logs where the remote still resolves. The write is a guarded `--add`, since `insteadOf` is multi-valued: a plain write refuses a key already carrying two rules and drops a lone existing one, and an unguarded `--add` would append a copy every night in the case the pin cannot win.

Only the stored URL decides whether a remote is a github remote. Accepting one that git merely *resolves* to github would catch a rule pointing another host at github, but a rule that rewrites the host without keeping the repo path then has us store a URL naming a repository that does not exist. Verified with `url."https://github.com/".insteadOf = "https://"`, which turned a stored `https://bitbucket.org/bendrucker/private.git` into `https://github.com/bitbucket.org/bendrucker/private.git`.

## Verification

Specs cover the pin taking effect against the reverse rule, pushes staying on SSH, pinning alongside existing rules on its key, writing nothing where no rule applies, adding once when an equal-length rule outranks it, and leaving a non-github remote alone.

Checked against real GitHub with `GIT_SSH_COMMAND=false` and the rule in a temp `GIT_CONFIG_GLOBAL`: the fetch succeeds over HTTPS and the push URL stays SSH.

`git_sync` is shared, so this fixes `dotfiles-upgrade` on the same machine.
