### PR TITLE
vibe-island: defend the tracked hook config

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -35,12 +35,48 @@ revert_cosmetic_json_changes() {
   done <<< "$changed_files"
 }
 
+# Does this settings.json carry Vibe Island's own hook command? Scoped to
+# .hooks, so the string appearing anywhere else is not read as one.
+vibe_island_hook_present() {
+  jq -e '[.hooks // {} | .. | objects | .command? // empty]
+         | any(test("vibe-island/bin/vibe-island-hook"))' >/dev/null 2>&1
+}
+
+# Vibe Island writes ~/.claude/settings.json itself, through the symlink and
+# into the tracked config, replacing every hook with the command it uses on a
+# remote agent host. That binary is not installed here, so every hook event in a
+# new session fails, and the dirty tracked file stalls the sync behind it.
+# Discard it, and say so: a silent revert would leave the app taking hook
+# management back with nothing to show for it.
+revert_vibe_island_hook_rewrite() {
+  local file="user/settings.json"
+
+  [[ -f "$file" ]] || return 0
+
+  local working head
+  working=$(jq -S . "$file" 2>/dev/null) || return 0
+  head=$(git show "HEAD:$file" 2>/dev/null | jq -S . 2>/dev/null) || return 0
+
+  print -r -- "$working" | vibe_island_hook_present || return 0
+  print -r -- "$head" | vibe_island_hook_present && return 0
+
+  # A change reaching outside .hooks is a real edit this must not discard.
+  # git_review_dirty still gets to ask about those.
+  [[ "$(print -r -- "$working" | jq -S 'del(.hooks)')" == \
+     "$(print -r -- "$head" | jq -S 'del(.hooks)')" ]] || return 0
+
+  gum log --level warn "Reverting Vibe Island's hook rewrite in $file"
+  git checkout HEAD -- "$file"
+  notify "Claude Upgrade" "Reverted Vibe Island's hook rewrite in settings.json"
+}
+
 sync_repo() {
   gum log --level info "Syncing Claude repository..."
 
   cd "$CLAUDE_REPO_HOME" || return 1
 
   revert_cosmetic_json_changes
+  revert_vibe_island_hook_rewrite
 
   git_review_dirty "$CLAUDE_REPO_HOME" "Claude Upgrade" || return 1
 

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -39,14 +39,23 @@ revert_cosmetic_json_changes() {
 # replaces all of them at once, so a file where only some match holds something
 # else as well, and reverting the file would take that with it. Scoped to
 # .hooks, so the string appearing elsewhere is not read as a hook.
+#
+# The type test states what an unreadable command means here rather than
+# leaving it to jq. Without it, test() on a non-string raises, and the answer
+# these give comes from a swallowed error rather than from the predicate. It
+# lands on the same decision today, so this is about resting the decision on
+# something other than a redirect. Guard the match rather than filtering ahead
+# of it: filtering drops an unreadable command from the set, which lets the rest
+# of the file answer for it and reverts a hook nothing inspected.
 vibe_island_owns_every_hook() {
   jq -e '[.hooks // {} | .. | objects | .command? // empty]
-         | length > 0 and all(test("vibe-island/bin/vibe-island-hook"))' >/dev/null 2>&1
+         | length > 0
+           and all(type == "string" and test("vibe-island/bin/vibe-island-hook"))' >/dev/null 2>&1
 }
 
 vibe_island_hook_present() {
   jq -e '[.hooks // {} | .. | objects | .command? // empty]
-         | any(test("vibe-island/bin/vibe-island-hook"))' >/dev/null 2>&1
+         | any(type == "string" and test("vibe-island/bin/vibe-island-hook"))' >/dev/null 2>&1
 }
 
 # Vibe Island writes ~/.claude/settings.json itself, through the symlink and

--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -35,8 +35,15 @@ revert_cosmetic_json_changes() {
   done <<< "$changed_files"
 }
 
-# Does this settings.json carry Vibe Island's own hook command? Scoped to
-# .hooks, so the string appearing anywhere else is not read as one.
+# Is every hook in this settings.json Vibe Island's own command? The app
+# replaces all of them at once, so a file where only some match holds something
+# else as well, and reverting the file would take that with it. Scoped to
+# .hooks, so the string appearing elsewhere is not read as a hook.
+vibe_island_owns_every_hook() {
+  jq -e '[.hooks // {} | .. | objects | .command? // empty]
+         | length > 0 and all(test("vibe-island/bin/vibe-island-hook"))' >/dev/null 2>&1
+}
+
 vibe_island_hook_present() {
   jq -e '[.hooks // {} | .. | objects | .command? // empty]
          | any(test("vibe-island/bin/vibe-island-hook"))' >/dev/null 2>&1
@@ -57,7 +64,7 @@ revert_vibe_island_hook_rewrite() {
   working=$(jq -S . "$file" 2>/dev/null) || return 0
   head=$(git show "HEAD:$file" 2>/dev/null | jq -S . 2>/dev/null) || return 0
 
-  print -r -- "$working" | vibe_island_hook_present || return 0
+  print -r -- "$working" | vibe_island_owns_every_hook || return 0
   print -r -- "$head" | vibe_island_hook_present && return 0
 
   # A change reaching outside .hooks is a real edit this must not discard.

--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -495,7 +495,7 @@ Describe "revert_vibe_island_hook_rewrite"
   BeforeEach 'revert_setup'
 
   # What the tracked config holds: a bridge invocation guarded on the binary
-  # existing, so a machine without it runs a no-op rather than failing.
+  # existing, so a machine without it runs a no-op.
   guarded_hooks() {
     printf '%s' '"/bin/sh -c [ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && exit 0"'
   }

--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -456,3 +456,132 @@ Describe "claude-plugin-audit"
     The output should include "could not compare"
   End
 End
+
+# Vibe Island rewrites ~/.claude/settings.json through the dotfiles symlink,
+# swapping every hook for the command it runs on a remote agent host. The
+# binary it names is not installed here, so hooks fail in every new session,
+# and the dirty tracked file stalls the sync until someone looks at it. These
+# lock the self-heal: the rewrite is discarded and reported, and nothing else
+# is.
+Describe "revert_vibe_island_hook_rewrite"
+  # This block wants a real git repo, so its stubs deliberately leave out the
+  # audit's canned git.
+  revert_setup() {
+    revert_sandbox="$SHELLSPEC_TMPBASE/claude-upgrade-revert"
+    revert_stub="$revert_sandbox/stub"
+    repo="$revert_sandbox/repo"
+    rm -rf "$revert_sandbox"
+    mkdir -p "$revert_stub" "$repo/user"
+
+    export NOTIFY_LOG="$revert_sandbox/notify.log"
+    : >"$NOTIFY_LOG"
+
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >>"$NOTIFY_LOG"\n' \
+      >"$revert_stub/osascript"
+    chmod +x "$revert_stub/osascript"
+
+    printf '#!/usr/bin/env bash\n[ "$1" = log ] && printf "%%s\\n" "${@: -1}" >&2\nexit 0\n' \
+      >"$revert_stub/gum"
+    chmod +x "$revert_stub/gum"
+
+    write_settings_json "$(guarded_hooks)"
+    git -C "$repo" init -q -b main
+    git -C "$repo" config user.email spec@example.test
+    git -C "$repo" config user.name Spec
+    git -C "$repo" config commit.gpgsign false
+    git -C "$repo" add -A
+    git -C "$repo" commit -q -m "settings"
+  }
+  BeforeEach 'revert_setup'
+
+  # What the tracked config holds: a bridge invocation guarded on the binary
+  # existing, so a machine without it runs a no-op rather than failing.
+  guarded_hooks() {
+    printf '%s' '"/bin/sh -c [ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && exit 0"'
+  }
+
+  # What the app writes: the remote agent binary, plus the host it means to
+  # reach, unguarded.
+  rewritten_hooks() {
+    printf '%s' '"~/.vibe-island/bin/vibe-island-hook --host user@example"'
+  }
+
+  write_settings_json() {
+    local command="$1" extra="${2:-bar}"
+    jq -n --argjson command "$command" --arg extra "$extra" '{
+      env: {EXAMPLE: $extra},
+      hooks: {SessionStart: [{hooks: [{type: "command", command: $command}]}]}
+    }' >"$repo/user/settings.json"
+  }
+
+  call_revert() {
+    PATH="$revert_stub:$PATH" zsh -fc \
+      'cd "$1" || exit 1; source "$2"; revert_vibe_island_hook_rewrite' _ "$repo" "$upgrade"
+  }
+
+  settings_status() {
+    if [ -n "$(git -C "$repo" status --porcelain user/settings.json)" ]; then
+      printf 'dirty'
+    else
+      printf 'clean'
+    fi
+  }
+
+  It "discards the rewrite and says so"
+    write_settings_json "$(rewritten_hooks)"
+    When call call_revert
+    The status should be success
+    The stderr should include "Reverting Vibe Island's hook rewrite"
+    The contents of file "$NOTIFY_LOG" should include "hook rewrite"
+    The result of function settings_status should equal "clean"
+  End
+
+  # The app reformats the whole file while it rewrites the hooks, so the
+  # revert cannot depend on the rest of the file being byte-identical.
+  It "discards a rewrite that also reordered the file"
+    write_settings_json "$(rewritten_hooks)"
+    jq -S . "$repo/user/settings.json" >"$repo/user/settings.json.next"
+    mv "$repo/user/settings.json.next" "$repo/user/settings.json"
+    When call call_revert
+    The status should be success
+    The stderr should include "Reverting"
+    The result of function settings_status should equal "clean"
+  End
+
+  # Anything outside .hooks could be a real edit. git_review_dirty asks about
+  # those, and it cannot ask about a file this already threw away.
+  It "leaves a change outside .hooks alone"
+    write_settings_json "$(guarded_hooks)" changed
+    When call call_revert
+    The status should be success
+    The stderr should equal ""
+    The result of function settings_status should equal "dirty"
+  End
+
+  It "leaves a rewrite carrying a change outside .hooks alone"
+    write_settings_json "$(rewritten_hooks)" changed
+    When call call_revert
+    The status should be success
+    The stderr should equal ""
+    The contents of file "$NOTIFY_LOG" should equal ""
+    The result of function settings_status should equal "dirty"
+  End
+
+  # Only the app's own command is the app's doing. A hook edited by hand is a
+  # local change like any other.
+  It "leaves a hand-edited hook alone"
+    write_settings_json '"echo hello"'
+    When call call_revert
+    The status should be success
+    The stderr should equal ""
+    The result of function settings_status should equal "dirty"
+  End
+
+  It "does nothing to a clean tree"
+    When call call_revert
+    The status should be success
+    The stderr should equal ""
+    The contents of file "$NOTIFY_LOG" should equal ""
+    The result of function settings_status should equal "clean"
+  End
+End

--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -514,6 +514,17 @@ Describe "revert_vibe_island_hook_rewrite"
     }' >"$repo/user/settings.json"
   }
 
+  # Two hooks under different events, so an example can hold one of each kind.
+  write_mixed_hooks_json() {
+    jq -n --argjson session "$1" --argjson pre "$2" '{
+      env: {EXAMPLE: "bar"},
+      hooks: {
+        SessionStart: [{hooks: [{type: "command", command: $session}]}],
+        PreToolUse: [{hooks: [{type: "command", command: $pre}]}]
+      }
+    }' >"$repo/user/settings.json"
+  }
+
   call_revert() {
     PATH="$revert_stub:$PATH" zsh -fc \
       'cd "$1" || exit 1; source "$2"; revert_vibe_island_hook_rewrite' _ "$repo" "$upgrade"
@@ -575,6 +586,26 @@ Describe "revert_vibe_island_hook_rewrite"
     The status should be success
     The stderr should equal ""
     The result of function settings_status should equal "dirty"
+  End
+
+  # The revert restores the whole file, so a hand-edited hook sitting beside
+  # the app's would go with it. The app replaces every hook at once, so a file
+  # holding anything else is not the case this handles.
+  It "leaves a rewrite standing beside a hand-edited hook alone"
+    write_mixed_hooks_json "$(rewritten_hooks)" '"echo hello"'
+    When call call_revert
+    The status should be success
+    The stderr should equal ""
+    The contents of file "$NOTIFY_LOG" should equal ""
+    The result of function settings_status should equal "dirty"
+  End
+
+  It "discards a rewrite that took every hook"
+    write_mixed_hooks_json "$(rewritten_hooks)" "$(rewritten_hooks)"
+    When call call_revert
+    The status should be success
+    The stderr should include "Reverting"
+    The result of function settings_status should equal "clean"
   End
 
   It "does nothing to a clean tree"

--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -578,6 +578,19 @@ Describe "revert_vibe_island_hook_rewrite"
     The result of function settings_status should equal "dirty"
   End
 
+  # A command the predicates cannot read is a hook the revert cannot vouch for,
+  # so the file goes to git_review_dirty like any other. This holds whether the
+  # answer comes from the type test or from jq raising on it. It pins the
+  # promise made about settings.json shapes, leaving jq's route to it free.
+  It "leaves a rewrite standing beside a non-string command alone"
+    write_mixed_hooks_json "$(rewritten_hooks)" 123
+    When call call_revert
+    The status should be success
+    The stderr should equal ""
+    The contents of file "$NOTIFY_LOG" should equal ""
+    The result of function settings_status should equal "dirty"
+  End
+
   # Only the app's own command is the app's doing. A hook edited by hand is a
   # local change like any other.
   It "leaves a hand-edited hook alone"

--- a/macos/spec/vibe_island_spec.sh
+++ b/macos/spec/vibe_island_spec.sh
@@ -2,12 +2,16 @@
 # shellcheck disable=SC2329,SC2016
 #
 # Locks the guard around the Vibe Island preference write: it touches nothing on
-# a machine without the app, and it writes at most once, so the nightly install
-# neither rewrites a preference already set nor repeats the running-app warning.
+# a machine without the app, it writes at most once so the nightly install does
+# not rewrite a preference already set, and when the app is running it quits
+# before writing and reopens after. Writing under a running app is what let the
+# app put its own value back while this preference still read 0.
 #
 # Black-box, following claude/spec/claude_prune_agents_spec.sh: PATH-shim stubs
-# for defaults, pgrep, and gum drive the real script, and VIBE_ISLAND_APP points
-# at a fixture bundle so no real preference domain is read or written.
+# for defaults, pgrep, osascript, open, sleep, and gum drive the real script,
+# and VIBE_ISLAND_APP points at a fixture bundle so no real preference domain is
+# read or written. Every stub appends to one log, so an example can assert on
+# the order the script did things in.
 
 script="$SHELLSPEC_PROJECT_ROOT/vibe-island.sh"
 
@@ -17,32 +21,78 @@ setup() {
   rm -rf "$sandbox"
   mkdir -p "$stubdir"
 
-  export DEFAULTS_LOG="$sandbox/defaults.log"
-  : >"$DEFAULTS_LOG"
+  export ACTION_LOG="$sandbox/actions.log"
+  : >"$ACTION_LOG"
 
   # An installed app, by default. $CURRENT_VALUE is what `defaults read` answers
-  # with, empty standing for a key that was never written, which the real
-  # defaults reports as a failure rather than as empty output.
+  # with until something writes, empty standing for a key that was never
+  # written, which the real defaults reports as a failure rather than as empty
+  # output. A write lands in $PREF_FILE, so a later read sees it.
   export VIBE_ISLAND_APP="$sandbox/Vibe Island.app"
   mkdir -p "$VIBE_ISLAND_APP"
   export CURRENT_VALUE=""
+  export PREF_FILE="$sandbox/pref"
+
+  # The app is either not running, or running and willing to quit. $QUIT_REFUSED
+  # makes it ignore the quit, and $QUIT_FLAG is how the osascript stub tells the
+  # pgrep stub the process is gone.
   export APP_RUNNING=""
+  export QUIT_REFUSED=""
+  export QUIT_FLAG="$sandbox/quit"
+
+  # The app that ignores the opt-out: relaunching puts hook management back on.
+  export APP_CLOBBERS=""
 
   # printf, not a here-document: bash stages those through a temp file it picks
   # itself, which a sandbox may deny. Same reasoning as scripts/spec/spec_helper.sh.
   printf '%s\n' \
     '#!/usr/bin/env bash' \
-    'printf "%s\n" "$*" >>"$DEFAULTS_LOG"' \
-    'if [ "$1" = read ]; then' \
-    '  [ -n "$CURRENT_VALUE" ] || exit 1' \
-    '  printf "%s\n" "$CURRENT_VALUE"' \
-    'fi' \
+    'printf "%s\n" "defaults $*" >>"$ACTION_LOG"' \
+    'case "$1" in' \
+    '  read)' \
+    '    value="$CURRENT_VALUE"' \
+    '    [ -f "$PREF_FILE" ] && value=$(cat "$PREF_FILE")' \
+    '    [ -n "$value" ] || exit 1' \
+    '    printf "%s\n" "$value"' \
+    '    ;;' \
+    '  write)' \
+    '    case "${*: -1}" in' \
+    '      false) printf 0 >"$PREF_FILE" ;;' \
+    '      *)     printf 1 >"$PREF_FILE" ;;' \
+    '    esac' \
+    '    ;;' \
+    'esac' \
     'exit 0' \
     >"$stubdir/defaults"
   chmod +x "$stubdir/defaults"
 
-  printf '#!/usr/bin/env bash\n[ -n "$APP_RUNNING" ]\n' >"$stubdir/pgrep"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    '[ -f "$QUIT_FLAG" ] && exit 1' \
+    '[ -n "$APP_RUNNING" ]' \
+    >"$stubdir/pgrep"
   chmod +x "$stubdir/pgrep"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s\n" "osascript $*" >>"$ACTION_LOG"' \
+    '[ -n "$QUIT_REFUSED" ] || : >"$QUIT_FLAG"' \
+    'exit 0' \
+    >"$stubdir/osascript"
+  chmod +x "$stubdir/osascript"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s\n" "open $*" >>"$ACTION_LOG"' \
+    'rm -f "$QUIT_FLAG"' \
+    '[ -n "$APP_CLOBBERS" ] && printf 1 >"$PREF_FILE"' \
+    'exit 0' \
+    >"$stubdir/open"
+  chmod +x "$stubdir/open"
+
+  # The waits are bounded in real seconds. An example should not spend them.
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$stubdir/sleep"
+  chmod +x "$stubdir/sleep"
 
   # The real gum logs to stderr, so the warning stays off captured stdout.
   printf '#!/usr/bin/env bash\nprintf "%%s\\n" "${@: -1}" >&2\n' >"$stubdir/gum"
@@ -56,8 +106,8 @@ Describe "macos/vibe-island.sh"
   It "turns Vibe Island's Claude hook management off"
     When call run_script
     The status should be success
-    The contents of file "$DEFAULTS_LOG" should include \
-      "write app.vibeisland.macos hookAutoConfig_claude -bool false"
+    The contents of file "$ACTION_LOG" should include \
+      "defaults write app.vibeisland.macos hookAutoConfig_claude -bool false"
   End
 
   # The app owns this key too. A value of 1 means it has taken hook management
@@ -66,23 +116,24 @@ Describe "macos/vibe-island.sh"
     export CURRENT_VALUE=1
     When call run_script
     The status should be success
-    The contents of file "$DEFAULTS_LOG" should include "-bool false"
+    The contents of file "$ACTION_LOG" should include "-bool false"
   End
 
-  # The install runs nightly. Rewriting a preference already set would warn
-  # about a running app every night for a change that has already taken.
+  # The install runs nightly. Rewriting a preference already set would quit the
+  # app out from under the user every night for a change that has already taken.
   It "leaves a preference already set alone"
     export CURRENT_VALUE=0
     When call run_script
     The status should be success
-    The contents of file "$DEFAULTS_LOG" should not include "write"
+    The contents of file "$ACTION_LOG" should not include "write"
+    The contents of file "$ACTION_LOG" should not include "osascript"
   End
 
   It "does nothing on a machine without the app"
     rm -rf "$VIBE_ISLAND_APP"
     When call run_script
     The status should be success
-    The contents of file "$DEFAULTS_LOG" should equal ""
+    The contents of file "$ACTION_LOG" should equal ""
   End
 
   It "says nothing when the app is not installed but is somehow running"
@@ -93,17 +144,61 @@ Describe "macos/vibe-island.sh"
     The stderr should equal ""
   End
 
-  Describe "the running-app caveat"
+  Describe "with the app running"
+    BeforeEach 'export APP_RUNNING=1'
+
     # NSUserDefaults holds what the app read at launch, and the app can write
-    # that copy back, so the write alone is not enough to report as done.
-    It "warns to restart the app when it is running"
-      export APP_RUNNING=1
+    # that copy back, so a write under a running app is the one that gets lost.
+    It "quits the app before writing"
       When call run_script
       The status should be success
-      The stderr should include "Quit and reopen"
+      The contents of file "$ACTION_LOG" should match pattern "*osascript*quit app*defaults write*"
     End
 
-    It "stays quiet when the app is not running"
+    # Quitting takes the menu bar with it, so the script owns putting it back.
+    It "reopens the app after writing"
+      When call run_script
+      The status should be success
+      The contents of file "$ACTION_LOG" should match pattern "*defaults write*open -a*"
+    End
+
+    It "stays quiet when the quit and the write both take"
+      When call run_script
+      The status should be success
+      The stderr should equal ""
+    End
+
+    # An app that ignores the opt-out is not one a relaunch can fix. Only
+    # claude-upgrade's revert defends the config from there, so say so.
+    It "warns when hook management is back on after the relaunch"
+      export APP_CLOBBERS=1
+      When call run_script
+      The status should be success
+      The stderr should include "ignoring the opt-out"
+    End
+
+    # An app that will not quit leaves the old behavior: write anyway, and say
+    # the value may not survive. Killing it or leaving it dead would cost the
+    # user their menu bar for a preference write.
+    It "writes and warns when the app will not quit"
+      export QUIT_REFUSED=1
+      When call run_script
+      The status should be success
+      The stderr should include "would not quit"
+      The contents of file "$ACTION_LOG" should include "-bool false"
+      The contents of file "$ACTION_LOG" should not include "open -a"
+    End
+  End
+
+  Describe "with the app not running"
+    It "neither quits nor reopens"
+      When call run_script
+      The status should be success
+      The contents of file "$ACTION_LOG" should not include "osascript"
+      The contents of file "$ACTION_LOG" should not include "open -a"
+    End
+
+    It "stays quiet"
       When call run_script
       The status should be success
       The stderr should equal ""

--- a/macos/spec/vibe_island_spec.sh
+++ b/macos/spec/vibe_island_spec.sh
@@ -43,6 +43,9 @@ setup() {
   # The app that ignores the opt-out: relaunching puts hook management back on.
   export APP_CLOBBERS=""
 
+  # A reopen that fails: the app stays down, and the user's menu bar with it.
+  export OPEN_FAILS=""
+
   # printf, not a here-document: bash stages those through a temp file it picks
   # itself, which a sandbox may deny. Same reasoning as scripts/spec/spec_helper.sh.
   printf '%s\n' \
@@ -84,6 +87,7 @@ setup() {
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'printf "%s\n" "open $*" >>"$ACTION_LOG"' \
+    '[ -n "$OPEN_FAILS" ] && exit 1' \
     'rm -f "$QUIT_FLAG"' \
     '[ -n "$APP_CLOBBERS" ] && printf 1 >"$PREF_FILE"' \
     'exit 0' \
@@ -175,6 +179,16 @@ Describe "macos/vibe-island.sh"
       When call run_script
       The status should be success
       The stderr should include "ignoring the opt-out"
+    End
+
+    # Quitting the app was this script's doing, so a reopen it could not manage
+    # is its to report. Silence here costs the user their menu bar.
+    It "warns when it cannot reopen the app"
+      export OPEN_FAILS=1
+      When call run_script
+      The status should be success
+      The stderr should include "Could not reopen"
+      The contents of file "$ACTION_LOG" should include "-bool false"
     End
 
     # An app that will not quit leaves the old behavior: write anyway, and say

--- a/macos/spec/vibe_island_spec.sh
+++ b/macos/spec/vibe_island_spec.sh
@@ -46,6 +46,9 @@ setup() {
   # A reopen that fails: the app stays down, and the user's menu bar with it.
   export OPEN_FAILS=""
 
+  # A preference write that does not take, leaving the key unset behind it.
+  export WRITE_FAILS=""
+
   # printf, not a here-document: bash stages those through a temp file it picks
   # itself, which a sandbox may deny. Same reasoning as scripts/spec/spec_helper.sh.
   printf '%s\n' \
@@ -59,6 +62,7 @@ setup() {
     '    printf "%s\n" "$value"' \
     '    ;;' \
     '  write)' \
+    '    [ -n "$WRITE_FAILS" ] && exit 1' \
     '    case "${*: -1}" in' \
     '      false) printf 0 >"$PREF_FILE" ;;' \
     '      *)     printf 1 >"$PREF_FILE" ;;' \
@@ -189,6 +193,33 @@ Describe "macos/vibe-island.sh"
       The status should be success
       The stderr should include "Could not reopen"
       The contents of file "$ACTION_LOG" should include "-bool false"
+    End
+
+    # stderr on the nightly run goes to a log file nobody reads, and a missing
+    # menu bar is not something the user can trace back to this script.
+    It "notifies when it cannot reopen the app"
+      export OPEN_FAILS=1
+      When call run_script
+      The status should be success
+      The stderr should be defined
+      The contents of file "$ACTION_LOG" should include "display notification"
+    End
+
+    # A preference that could not be written is not the app overriding one.
+    It "reports a failed write as its own, not as the app ignoring the opt-out"
+      export WRITE_FAILS=1
+      When call run_script
+      The status should be success
+      The stderr should include "Could not write"
+      The stderr should not include "ignoring the opt-out"
+    End
+
+    It "says so when it cannot read the preference back"
+      export WRITE_FAILS=1
+      When call run_script
+      The status should be success
+      The stderr should include "Could not read"
+      The stderr should not include "ignoring the opt-out"
     End
 
     # An app that will not quit leaves the old behavior: write anyway, and say

--- a/macos/vibe-island.sh
+++ b/macos/vibe-island.sh
@@ -3,12 +3,23 @@
 # Vibe Island manages Claude Code's hooks by writing ~/.claude/settings.json
 # itself. It writes with an atomic rename, which replaces the dotfiles symlink
 # with a regular file, so Claude Code silently stops reading the tracked config
-# in ~/.claude-repo and every later edit there goes nowhere.
+# in ~/.claude-repo and every later edit there goes nowhere. What it writes is
+# the hook shape for a remote agent host, naming a binary that is only installed
+# on machines the app SSHes into, so every hook event in a session started
+# afterward fails.
 #
 # This preference opts out of that management, recording a standing choice so a
 # new machine does not arrive with the app owning the hook config again. Opting
 # out is not passive: the app removes its hook entries from settings.json rather
 # than leaving behind whatever it last wrote.
+#
+# A running app holds its own cached copy of the preference and can write that
+# copy back, which is how an earlier opt-out was lost while this preference
+# still read 0. So the app is quit before the write and reopened after it,
+# rather than warned about. dock.sh and clock.sh kill their process to apply a
+# change, which does not carry over: the Dock and SystemUIServer relaunch
+# themselves, while Vibe Island has to be reopened or the user loses their menu
+# bar.
 #
 # claude/install.sh restores the symlink when it finds one already replaced.
 # This is what keeps it from being replaced again.
@@ -18,19 +29,55 @@ VIBE_ISLAND_DOMAIN="app.vibeisland.macos"
 
 [ -d "$VIBE_ISLAND_APP" ] || exit 0
 
+hook_auto_config() {
+  defaults read "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude 2>/dev/null
+}
+
+app_running() {
+  pgrep -x vibe-island >/dev/null 2>&1
+}
+
+# Ask the app to quit and wait for it to go, so the write lands while nothing
+# holds a cached copy of the preference. Bounded: an app that will not quit must
+# not hang the nightly install.
+quit_app() {
+  osascript -e 'quit app "Vibe Island"' >/dev/null 2>&1
+
+  local waited=0
+  while app_running && [ "$waited" -lt 10 ]; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  ! app_running
+}
+
 # Already off. Stopping here keeps the nightly install silent rather than
-# warning about a running app on every run.
-if [ "$(defaults read "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude 2>/dev/null)" = 0 ]; then
+# quitting the app out from under the user on every run.
+if [ "$(hook_auto_config)" = 0 ]; then
   exit 0
+fi
+
+quit=""
+if app_running; then
+  if quit_app; then
+    quit=1
+  else
+    gum log --level warn "Vibe Island would not quit. It may write the old value back - quit and reopen it to apply the change."
+  fi
 fi
 
 defaults write "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude -bool false
 
-# A running app holds its own cached copy of the preference and can write that
-# copy back over this one, so the change is only reliable from the next launch.
-# dock.sh and clock.sh kill the process to apply a change, which does not carry
-# over: the Dock and SystemUIServer relaunch themselves, while quitting Vibe
-# Island would take the user's menu bar with it until they reopened it.
-if pgrep -x vibe-island >/dev/null 2>&1; then
-  gum log --level warn "Vibe Island hook management disabled for Claude. Quit and reopen Vibe Island so it does not write the old value back."
+[ -n "$quit" ] || exit 0
+
+open -a "$VIBE_ISLAND_APP"
+
+# The app reads the preference at launch, so what it reports now is what it
+# means to honor. A value that is still not 0 means it is ignoring the opt-out
+# rather than caching over it, and only claude-upgrade's revert can defend the
+# config from there.
+sleep 2
+if [ "$(hook_auto_config)" != 0 ]; then
+  gum log --level warn "Vibe Island turned Claude hook management back on after relaunching. It is ignoring the opt-out."
 fi

--- a/macos/vibe-island.sh
+++ b/macos/vibe-island.sh
@@ -71,12 +71,25 @@ defaults write "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude -bool false
 
 [ -n "$quit" ] || exit 0
 
-open -a "$VIBE_ISLAND_APP"
+# This script took the menu bar away, so it owns putting it back, and owns
+# saying when it could not.
+if ! open -a "$VIBE_ISLAND_APP"; then
+  gum log --level warn "Could not reopen Vibe Island. Open it to get the menu bar back."
+  exit 0
+fi
 
-# The app reads the preference at launch, so what it reports now is what it
-# means to honor. A value that is still not 0 means the app is ignoring the
-# opt-out, and only claude-upgrade's revert can defend the config from there.
-sleep 2
+# The app reads the preference at launch, so what it reports once it is up is
+# what it means to honor. A value that is still not 0 means the app is ignoring
+# the opt-out, and only claude-upgrade's revert can defend the config from
+# there. A best-effort signal either way: an app slow to write its own value
+# back reads as compliant here, and the revert's notification is the detector
+# that does not depend on timing.
+waited=0
+while ! app_running && [ "$waited" -lt 10 ]; do
+  sleep 1
+  waited=$((waited + 1))
+done
+
 if [ "$(hook_auto_config)" != 0 ]; then
   gum log --level warn "Vibe Island turned Claude hook management back on after relaunching. It is ignoring the opt-out."
 fi

--- a/macos/vibe-island.sh
+++ b/macos/vibe-island.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
 # Vibe Island manages Claude Code's hooks by writing ~/.claude/settings.json
-# itself. It writes with an atomic rename, which replaces the dotfiles symlink
-# with a regular file, so Claude Code silently stops reading the tracked config
-# in ~/.claude-repo and every later edit there goes nowhere. What it writes is
-# the hook shape for a remote agent host, naming a binary that is only installed
-# on machines the app SSHes into, so every hook event in a session started
-# afterward fails.
+# itself. It follows the dotfiles symlink and writes through it, so what lands
+# is a dirty user/settings.json in the tracked ~/.claude-repo checkout. What it
+# writes is the hook shape for a remote agent host, naming a binary that is only
+# installed on machines the app SSHes into, so every hook event in a session
+# started afterward fails.
+#
+# An earlier version replaced the symlink with a regular file instead, which
+# left Claude Code reading a file no longer connected to the repo. Both are
+# worth defending against, and they need different defenses: claude/install.sh
+# restores a replaced symlink, while claude-upgrade reverts a write that came
+# through one.
 #
 # This preference opts out of that management, recording a standing choice so a
 # new machine does not arrive with the app owning the hook config again. Opting
@@ -20,12 +25,10 @@
 # change, which does not carry over: the Dock and SystemUIServer relaunch
 # themselves, while Vibe Island has to be reopened or the user loses their menu
 # bar.
-#
-# claude/install.sh restores the symlink when it finds one already replaced.
-# This is what keeps it from being replaced again.
 
 VIBE_ISLAND_APP="${VIBE_ISLAND_APP:-/Applications/Vibe Island.app}"
 VIBE_ISLAND_DOMAIN="app.vibeisland.macos"
+APP_WAIT_SECONDS=10
 
 [ -d "$VIBE_ISLAND_APP" ] || exit 0
 
@@ -37,19 +40,32 @@ app_running() {
   pgrep -x vibe-island >/dev/null 2>&1
 }
 
+# Wait for the app to reach a running state, or give up. Bounded in one place,
+# so the quit and the relaunch cannot drift to different limits. Takes the
+# state to wait for, and answers whether it arrived.
+wait_for_app() {
+  local want="$1" waited=0
+
+  while [ "$waited" -lt "$APP_WAIT_SECONDS" ]; do
+    if app_running; then
+      [ "$want" = running ] && return 0
+    else
+      [ "$want" = gone ] && return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  return 1
+}
+
 # Ask the app to quit and wait for it to go, so the write lands while nothing
 # holds a cached copy of the preference. Bounded: an app that will not quit must
 # not hang the nightly install.
 quit_app() {
   osascript -e 'quit app "Vibe Island"' >/dev/null 2>&1
 
-  local waited=0
-  while app_running && [ "$waited" -lt 10 ]; do
-    sleep 1
-    waited=$((waited + 1))
-  done
-
-  ! app_running
+  wait_for_app gone
 }
 
 # Already off. Stopping here skips quitting the app on a nightly run that has
@@ -67,14 +83,22 @@ if app_running; then
   fi
 fi
 
-defaults write "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude -bool false
+wrote=1
+defaults write "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude -bool false || wrote=""
+
+if [ -z "$wrote" ]; then
+  gum log --level warn "Could not write the Vibe Island preference. The opt-out did not take."
+fi
 
 [ -n "$quit" ] || exit 0
 
 # This script took the menu bar away, so it owns putting it back, and owns
-# saying when it could not.
+# saying when it could not. A failed reopen is the one outcome the user cannot
+# discover on their own, and stderr on a nightly run goes to a log nobody reads,
+# so it also goes to Notification Center.
 if ! open -a "$VIBE_ISLAND_APP"; then
   gum log --level warn "Could not reopen Vibe Island. Open it to get the menu bar back."
+  osascript -e 'display notification "Could not reopen it after applying a preference. Open it to get the menu bar back." with title "Vibe Island"' >/dev/null 2>&1
   exit 0
 fi
 
@@ -84,12 +108,14 @@ fi
 # there. A best-effort signal either way: an app slow to write its own value
 # back reads as compliant here, and the revert's notification is the detector
 # that does not depend on timing.
-waited=0
-while ! app_running && [ "$waited" -lt 10 ]; do
-  sleep 1
-  waited=$((waited + 1))
-done
+wait_for_app running || exit 0
 
-if [ "$(hook_auto_config)" != 0 ]; then
+# An unreadable preference is not the app overriding one. Blaming it for a read
+# that never returned a value would point at the wrong defense, so the two get
+# different messages.
+current=$(hook_auto_config)
+if [ -z "$current" ]; then
+  gum log --level warn "Could not read the Vibe Island preference back after relaunching. Whether the opt-out took is unknown."
+elif [ "$current" != 0 ]; then
   gum log --level warn "Vibe Island turned Claude hook management back on after relaunching. It is ignoring the opt-out."
 fi

--- a/macos/vibe-island.sh
+++ b/macos/vibe-island.sh
@@ -52,8 +52,8 @@ quit_app() {
   ! app_running
 }
 
-# Already off. Stopping here keeps the nightly install silent rather than
-# quitting the app out from under the user on every run.
+# Already off. Stopping here skips quitting the app on a nightly run that has
+# nothing to write.
 if [ "$(hook_auto_config)" = 0 ]; then
   exit 0
 fi
@@ -74,9 +74,8 @@ defaults write "$VIBE_ISLAND_DOMAIN" hookAutoConfig_claude -bool false
 open -a "$VIBE_ISLAND_APP"
 
 # The app reads the preference at launch, so what it reports now is what it
-# means to honor. A value that is still not 0 means it is ignoring the opt-out
-# rather than caching over it, and only claude-upgrade's revert can defend the
-# config from there.
+# means to honor. A value that is still not 0 means the app is ignoring the
+# opt-out, and only claude-upgrade's revert can defend the config from there.
 sleep 2
 if [ "$(hook_auto_config)" != 0 ]; then
   gum log --level warn "Vibe Island turned Claude hook management back on after relaunching. It is ignoring the opt-out."

--- a/scripts/lib/git-diff-review.sh
+++ b/scripts/lib/git-diff-review.sh
@@ -70,7 +70,7 @@ git_review_open_pr() {
   # The repos this serves are public deploy checkouts, and what lands in them
   # without being written by hand is whatever an app decided to configure -
   # Vibe Island puts the machine's own name into a hook command. Refuse the
-  # whole sync rather than publishing it, leaving the tree for inspection.
+  # whole sync, leaving the tree for inspection.
   if diff_names_host "$repo_dir"; then
     gum log --level error "Local changes name this machine - refusing to push them to a public remote"
     notify "$title" "Skipped: local changes name this machine"

--- a/scripts/lib/git-diff-review.sh
+++ b/scripts/lib/git-diff-review.sh
@@ -12,16 +12,20 @@
 #   Print everything `git add -A` would capture: the tracked diff against HEAD,
 #   plus the name and contents of every untracked file.
 #
+# host_names
+#   Print every name this machine answers to, one per line: the `hostname`
+#   forms plus scutil's ComputerName, LocalHostName, and HostName.
+#
 # changes_name_host [repo_dir]
-#   Return 0 when capturable_content contains this machine's name, matched
-#   case-insensitively against both `hostname -s` and `hostname`.
+#   Return 0 when capturable_content contains one of host_names, matched
+#   case-insensitively on word boundaries.
 #
 # git_review_open_pr <repo_dir> <title>
 #   Capture the working-tree changes (tracked and untracked) onto a fresh branch,
 #   push it, and open a draft PR with `gh`, then return the base branch to a clean
 #   state so the caller can fast-forward it. Returns nonzero if any step fails,
 #   leaving the base branch checked out. Refuses before touching the tree when
-#   what it would capture names this machine.
+#   what it would capture names this machine, and again once it is staged.
 #
 # git_review_dirty <repo_dir> <title>
 #   If the tree is clean, return 0. Otherwise render the diff and, on a TTY,
@@ -65,22 +69,39 @@ capturable_content() {
   ) 2>/dev/null
 }
 
+# Every name this machine answers to. `hostname` covers the POSIX forms, and
+# scutil covers the ones macOS keeps separately: an app asking Cocoa for the
+# computer's name gets ComputerName, which a user can set to something the
+# POSIX hostname does not contain. Duplicates are harmless, so they are not
+# filtered.
+host_names() {
+  hostname -s 2>/dev/null
+  hostname 2>/dev/null
+
+  local key
+  for key in ComputerName LocalHostName HostName; do
+    scutil --get "$key" 2>/dev/null
+  done
+}
+
 changes_name_host() {
   local repo_dir="${1:-.}"
 
-  local content
-  content=$(capturable_content "$repo_dir")
-  [[ -z "$content" ]] && return 1
+  # grep -F reads a newline-separated argument as several patterns, so the whole
+  # set goes in one pass without an array or a temp file. Blank lines are
+  # dropped first: an empty pattern matches every line and would refuse every
+  # sync.
+  local names
+  names=$(host_names | grep -v '^[[:space:]]*$')
+  [[ -z "$names" ]] && return 1
 
-  # printf into grep, not a here-string: bash 3.2 stages those through a temp
-  # file it picks itself, and a guard that fails open is worse than no guard.
-  local name
-  for name in "$(hostname -s)" "$(hostname)"; do
-    [[ -n "$name" ]] || continue
-    printf '%s\n' "$content" | grep -qiF -- "$name" && return 0
-  done
-
-  return 1
+  # -w, so a short machine name does not match inside an unrelated word and
+  # refuse a sync over nothing. Word boundaries still catch every form the app
+  # writes, including the user@host in its hook command.
+  #
+  # Streamed into grep rather than captured first: an untracked file can be any
+  # size, and grep -q stops reading at the first match.
+  capturable_content "$repo_dir" | grep -qiwF -- "$names"
 }
 
 git_review_open_pr() {
@@ -107,8 +128,24 @@ git_review_open_pr() {
     return 1
   fi
 
-  if ! git -C "$repo_dir" add -A ||
-     ! git -C "$repo_dir" commit -m "sync: local changes captured"; then
+  if ! git -C "$repo_dir" add -A; then
+    gum log --level error "Failed to stage local changes"
+    git -C "$repo_dir" checkout "$base"
+    return 1
+  fi
+
+  # Checked again now that the tree is staged. Vibe Island writes on its own
+  # schedule, so a write that landed after the first check would otherwise ride
+  # out on this commit.
+  if changes_name_host "$repo_dir"; then
+    gum log --level error "Local changes name this machine - refusing to push them to a public remote"
+    notify "$title" "Skipped: local changes name this machine"
+    git -C "$repo_dir" reset >/dev/null 2>&1
+    git -C "$repo_dir" checkout "$base"
+    return 1
+  fi
+
+  if ! git -C "$repo_dir" commit -m "sync: local changes captured"; then
     gum log --level error "Failed to commit local changes"
     git -C "$repo_dir" checkout "$base"
     return 1

--- a/scripts/lib/git-diff-review.sh
+++ b/scripts/lib/git-diff-review.sh
@@ -8,16 +8,20 @@
 #   with `jq -S` so cosmetic key reordering doesn't show as noise; everything
 #   else falls back to plain `git diff HEAD`.
 #
-# diff_names_host [repo_dir]
-#   Return 0 when the tracked diff against HEAD contains this machine's name,
-#   matched case-insensitively against both `hostname -s` and `hostname`.
+# capturable_content [repo_dir]
+#   Print everything `git add -A` would capture: the tracked diff against HEAD,
+#   plus the name and contents of every untracked file.
+#
+# changes_name_host [repo_dir]
+#   Return 0 when capturable_content contains this machine's name, matched
+#   case-insensitively against both `hostname -s` and `hostname`.
 #
 # git_review_open_pr <repo_dir> <title>
 #   Capture the working-tree changes (tracked and untracked) onto a fresh branch,
 #   push it, and open a draft PR with `gh`, then return the base branch to a clean
 #   state so the caller can fast-forward it. Returns nonzero if any step fails,
 #   leaving the base branch checked out. Refuses before touching the tree when
-#   the diff names this machine.
+#   what it would capture names this machine.
 #
 # git_review_dirty <repo_dir> <title>
 #   If the tree is clean, return 0. Otherwise render the diff and, on a TTY,
@@ -46,19 +50,34 @@ render_diff() {
   )
 }
 
-diff_names_host() {
+capturable_content() {
+  local repo_dir="${1:-.}"
+  (
+    cd "$repo_dir" || return
+    git diff HEAD
+    # git add -A stages untracked files too, so they are as publishable as the
+    # tracked diff. Their names carry as much as their contents.
+    local f
+    git ls-files --others --exclude-standard | while IFS= read -r f; do
+      printf '%s\n' "$f"
+      [[ -f "$f" ]] && cat "$f"
+    done
+  ) 2>/dev/null
+}
+
+changes_name_host() {
   local repo_dir="${1:-.}"
 
-  local diff
-  diff=$(git -C "$repo_dir" diff HEAD 2>/dev/null)
-  [[ -z "$diff" ]] && return 1
+  local content
+  content=$(capturable_content "$repo_dir")
+  [[ -z "$content" ]] && return 1
 
   # printf into grep, not a here-string: bash 3.2 stages those through a temp
   # file it picks itself, and a guard that fails open is worse than no guard.
   local name
   for name in "$(hostname -s)" "$(hostname)"; do
     [[ -n "$name" ]] || continue
-    printf '%s\n' "$diff" | grep -qiF -- "$name" && return 0
+    printf '%s\n' "$content" | grep -qiF -- "$name" && return 0
   done
 
   return 1
@@ -71,7 +90,7 @@ git_review_open_pr() {
   # without being written by hand is whatever an app decided to configure -
   # Vibe Island puts the machine's own name into a hook command. Refuse the
   # whole sync, leaving the tree for inspection.
-  if diff_names_host "$repo_dir"; then
+  if changes_name_host "$repo_dir"; then
     gum log --level error "Local changes name this machine - refusing to push them to a public remote"
     notify "$title" "Skipped: local changes name this machine"
     return 1

--- a/scripts/lib/git-diff-review.sh
+++ b/scripts/lib/git-diff-review.sh
@@ -8,11 +8,16 @@
 #   with `jq -S` so cosmetic key reordering doesn't show as noise; everything
 #   else falls back to plain `git diff HEAD`.
 #
+# diff_names_host [repo_dir]
+#   Return 0 when the tracked diff against HEAD contains this machine's name,
+#   matched case-insensitively against both `hostname -s` and `hostname`.
+#
 # git_review_open_pr <repo_dir> <title>
 #   Capture the working-tree changes (tracked and untracked) onto a fresh branch,
 #   push it, and open a draft PR with `gh`, then return the base branch to a clean
 #   state so the caller can fast-forward it. Returns nonzero if any step fails,
-#   leaving the base branch checked out.
+#   leaving the base branch checked out. Refuses before touching the tree when
+#   the diff names this machine.
 #
 # git_review_dirty <repo_dir> <title>
 #   If the tree is clean, return 0. Otherwise render the diff and, on a TTY,
@@ -41,12 +46,39 @@ render_diff() {
   )
 }
 
+diff_names_host() {
+  local repo_dir="${1:-.}"
+
+  local diff
+  diff=$(git -C "$repo_dir" diff HEAD 2>/dev/null)
+  [[ -z "$diff" ]] && return 1
+
+  # printf into grep, not a here-string: bash 3.2 stages those through a temp
+  # file it picks itself, and a guard that fails open is worse than no guard.
+  local name
+  for name in "$(hostname -s)" "$(hostname)"; do
+    [[ -n "$name" ]] || continue
+    printf '%s\n' "$diff" | grep -qiF -- "$name" && return 0
+  done
+
+  return 1
+}
+
 git_review_open_pr() {
   local repo_dir="$1" title="$2"
 
-  local base branch host
+  # The repos this serves are public deploy checkouts, and what lands in them
+  # without being written by hand is whatever an app decided to configure -
+  # Vibe Island puts the machine's own name into a hook command. Refuse the
+  # whole sync rather than publishing it, leaving the tree for inspection.
+  if diff_names_host "$repo_dir"; then
+    gum log --level error "Local changes name this machine - refusing to push them to a public remote"
+    notify "$title" "Skipped: local changes name this machine"
+    return 1
+  fi
+
+  local base branch
   base=$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null || git_default_branch "$repo_dir")
-  host=$(hostname -s)
   branch="sync/local-changes-$(date +%Y%m%d-%H%M%S)"
 
   gum log --level info "Opening a PR for local changes on $branch..."
@@ -57,7 +89,7 @@ git_review_open_pr() {
   fi
 
   if ! git -C "$repo_dir" add -A ||
-     ! git -C "$repo_dir" commit -m "sync: local changes captured on $host"; then
+     ! git -C "$repo_dir" commit -m "sync: local changes captured"; then
     gum log --level error "Failed to commit local changes"
     git -C "$repo_dir" checkout "$base"
     return 1

--- a/scripts/spec/git_diff_review_spec.sh
+++ b/scripts/spec/git_diff_review_spec.sh
@@ -42,6 +42,19 @@ Describe "git_review_open_pr"
       >"$stubdir/hostname"
     chmod +x "$stubdir/hostname"
 
+    # macOS keeps the Cocoa-facing name separately, and a user can set it to
+    # something the POSIX hostname does not contain. HostName is commonly unset,
+    # which scutil reports as a failure with nothing on stdout.
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'case "$2" in' \
+      '  ComputerName)  printf "Spec Machine\n" ;;' \
+      '  LocalHostName) printf "spechost\n" ;;' \
+      '  *)             exit 1 ;;' \
+      'esac' \
+      >"$stubdir/scutil"
+    chmod +x "$stubdir/scutil"
+
     PATH="$stubdir:$PATH"
 
     git init -q --bare "$sandbox/origin.git"
@@ -111,6 +124,15 @@ Describe "git_review_open_pr"
       The stderr should be defined
     End
 
+    # An app asking Cocoa for the computer's name gets this one, which the
+    # POSIX hostname need not contain.
+    It "refuses the Cocoa computer name"
+      printf 'ran on Spec Machine\n' >"$repo/file.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be failure
+      The stderr should be defined
+    End
+
     It "leaves the tree and the branches untouched"
       printf 'ran on spechost\n' >"$repo/file.txt"
       When call git_review_open_pr "$repo" "Title"
@@ -121,7 +143,46 @@ Describe "git_review_open_pr"
     End
   End
 
+  # Vibe Island writes on its own schedule, so the tree can gain the machine's
+  # name after the first check has already passed. The `git` stub writes it in
+  # on the `add`, standing in for that timing.
+  Describe "a change that arrives mid-flight"
+    It "refuses once the tree is staged"
+      printf 'unremarkable\n' >"$repo/file.txt"
+      printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'for a in "$@"; do' \
+        '  [ "$a" = add ] && printf "ran on spechost\n" >>"$REPO/file.txt"' \
+        'done' \
+        'exec /usr/bin/git "$@"' \
+        >"$stubdir/git"
+      chmod +x "$stubdir/git"
+      export REPO="$repo"
+      # setup ran git before this stub existed, so bash has the real path
+      # cached and would keep using it.
+      hash -r
+
+      When call git_review_open_pr "$repo" "Title"
+      The status should be failure
+      The variable notified should include "name this machine"
+      The stderr should include "refusing to push"
+      The contents of file "$GH_LOG" should equal ""
+      The output should be defined
+    End
+  End
+
   Describe "changes that do not"
+    # The machine's name is short, so an unanchored match would find it inside
+    # unrelated words and refuse a sync over nothing.
+    It "allows a name embedded in a longer word"
+      printf 'the spechostname helper and a spechosting provider\n' >"$repo/file.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be success
+      The contents of file "$GH_LOG" should include "pr create"
+      The stderr should be defined
+      The output should be defined
+    End
+
     It "opens the PR"
       printf 'unremarkable\n' >"$repo/file.txt"
       When call git_review_open_pr "$repo" "Title"

--- a/scripts/spec/git_diff_review_spec.sh
+++ b/scripts/spec/git_diff_review_spec.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# notified is consumed by a shellspec matcher the linter cannot see, and the
+# stub functions read as unused.
+# shellcheck disable=SC2034,SC2329,SC2016
+#
+# git_review_open_pr is the one path that pushes a dirty deploy checkout to a
+# remote, and both repos it serves are public. Vibe Island writes this
+# machine's name into settings.json as part of a hook command, so the changes
+# this path captures are exactly the ones that can carry it. These lock the
+# refusal, and lock the commit message that used to publish the host by design.
+#
+# A real temp repo with a bare origin, so the branch, commit, and push are the
+# real ones. Only gum, gh, and hostname are stubbed.
+
+Describe "git_review_open_pr"
+  setup() {
+    sandbox="$SHELLSPEC_TMPBASE/git-diff-review"
+    stubdir="$sandbox/stub"
+    repo="$sandbox/repo"
+    rm -rf "$sandbox"
+    mkdir -p "$stubdir"
+
+    stub_gum "$stubdir"
+
+    export GH_LOG="$sandbox/gh.log"
+    : >"$GH_LOG"
+    # printf, not a here-document: bash stages those through a temp file it
+    # picks itself, which a sandbox may deny.
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'printf "%s\n" "$*" >>"$GH_LOG"' \
+      'printf "https://example.test/pr/1\n"' \
+      >"$stubdir/gh"
+    chmod +x "$stubdir/gh"
+
+    # `hostname -s` and `hostname` differ on a real machine, and the guard has
+    # to cover both.
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      '[ "$1" = "-s" ] && { printf "spechost\n"; exit 0; }' \
+      'printf "spechost.example.test\n"' \
+      >"$stubdir/hostname"
+    chmod +x "$stubdir/hostname"
+
+    PATH="$stubdir:$PATH"
+
+    git init -q --bare "$sandbox/origin.git"
+    git init -q -b main "$repo"
+    git -C "$repo" config user.email spec@example.test
+    git -C "$repo" config user.name Spec
+    git -C "$repo" config commit.gpgsign false
+    git -C "$repo" remote add origin "$sandbox/origin.git"
+    printf 'tracked\n' >"$repo/file.txt"
+    git -C "$repo" add -A
+    git -C "$repo" commit -q -m initial
+    git -C "$repo" push -q -u origin main
+
+    # shellcheck source=/dev/null
+    source "$SHELLSPEC_PROJECT_ROOT/lib/git-sync.sh"
+    # shellcheck source=/dev/null
+    source "$SHELLSPEC_PROJECT_ROOT/lib/git-diff-review.sh"
+    notified=""
+  }
+  BeforeEach 'setup'
+
+  # Overrides the notify sourced above, so a test reads what the caller was
+  # told without reaching osascript.
+  notify() { notified="$1: $2"; }
+
+  sync_branches() { git -C "$repo" branch --list 'sync/*'; }
+  head_subject() { git -C "$repo" log -1 --format=%s --branches='sync/*'; }
+
+  Describe "changes that name this machine"
+    It "refuses the short name"
+      printf 'ran on spechost\n' >"$repo/file.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be failure
+      The variable notified should include "name this machine"
+      The stderr should include "refusing to push"
+    End
+
+    It "refuses the fully qualified name"
+      printf 'ran on spechost.example.test\n' >"$repo/file.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be failure
+      The stderr should be defined
+    End
+
+    # Vibe Island writes the host lowercased into the hook command while the
+    # machine reports it capitalized, so an exact match would miss it.
+    It "refuses a name in another case"
+      printf 'ran on SPECHOST\n' >"$repo/file.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be failure
+      The stderr should be defined
+    End
+
+    # Nothing is committed or pushed, so the change stays where it can be
+    # looked at.
+    It "leaves the tree and the branches untouched"
+      printf 'ran on spechost\n' >"$repo/file.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be failure
+      The result of function sync_branches should equal ""
+      The contents of file "$GH_LOG" should equal ""
+      The contents of file "$repo/file.txt" should equal "ran on spechost"
+    End
+  End
+
+  Describe "changes that do not"
+    It "opens the PR"
+      printf 'unremarkable\n' >"$repo/file.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be success
+      The contents of file "$GH_LOG" should include "pr create"
+      The variable notified should include "Opened PR"
+      The stderr should be defined
+      The output should be defined
+    End
+
+    # The message used to carry `hostname -s`, publishing the host on every
+    # sync. The branch name already dates the run.
+    It "commits without naming the machine"
+      printf 'unremarkable\n' >"$repo/file.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be success
+      The result of function head_subject should equal "sync: local changes captured"
+      The stderr should be defined
+      The output should be defined
+    End
+  End
+End

--- a/scripts/spec/git_diff_review_spec.sh
+++ b/scripts/spec/git_diff_review_spec.sh
@@ -95,6 +95,22 @@ Describe "git_review_open_pr"
       The stderr should be defined
     End
 
+    # git add -A commits untracked files too, so a guard reading only the
+    # tracked diff would wave through a file an app just dropped in.
+    It "refuses an untracked file whose contents name it"
+      printf 'ran on spechost\n' >"$repo/dropped.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be failure
+      The stderr should be defined
+    End
+
+    It "refuses an untracked file whose own name names it"
+      printf 'unremarkable\n' >"$repo/spechost-diagnostics.txt"
+      When call git_review_open_pr "$repo" "Title"
+      The status should be failure
+      The stderr should be defined
+    End
+
     It "leaves the tree and the branches untouched"
       printf 'ran on spechost\n' >"$repo/file.txt"
       When call git_review_open_pr "$repo" "Title"

--- a/scripts/spec/git_diff_review_spec.sh
+++ b/scripts/spec/git_diff_review_spec.sh
@@ -95,8 +95,6 @@ Describe "git_review_open_pr"
       The stderr should be defined
     End
 
-    # Nothing is committed or pushed, so the change stays where it can be
-    # looked at.
     It "leaves the tree and the branches untouched"
       printf 'ran on spechost\n' >"$repo/file.txt"
       When call git_review_open_pr "$repo" "Title"


### PR DESCRIPTION
A Claude session failed at startup with `vibe-island-hook: No such file or directory`. Vibe Island had followed the `~/.claude/settings.json` symlink into the tracked deploy clone and replaced every guarded bridge hook with the command it runs on a remote agent host. That binary only exists on machines the app SSHes into. The dirty tracked file then stalled `claude-upgrade` behind `git_review_dirty`.

The opt-out preference already read `0`. It did not hold, because a running app keeps its own cached copy of the preference and writes that copy back over a change made while it's still running.

## Surviving a Running App

`macos/vibe-island.sh` now quits the app before writing and reopens it after. An app that refuses to quit falls back to writing anyway and warns that the value may not survive. A reopen that fails goes to Notification Center as well as stderr. The nightly run's stderr lands in a log nobody opens.

## Self-Healing the Sync

`revert_vibe_island_hook_rewrite` discards the rewrite in `claude-upgrade` before `git_review_dirty` stalls on it, but only when every hook in the file is the app's own command and the rest of the file matches HEAD. A file carrying a real edit alongside the rewrite goes to the normal prompt instead. It warns and notifies, so the app cannot take hook management back quietly.

The header comment in `vibe-island.sh` now documents both ways the app can break the tracked config:

- Replacing the symlink outright. `claude/install.sh` restores that.
- Writing through the symlink into a dirty `user/settings.json`. This revert catches that.

## Refusing to Publish the Machine Name

The rewritten hook command embeds `user@machine`, and both deploy checkouts are public. `git_review_open_pr` pushes a dirty tree to a remote, and its commit message used to include `hostname -s`. Both are gone. The sync now refuses to push when the staged changes name this machine, matched on word boundaries so a short machine name inside an unrelated word doesn't refuse a sync for nothing.

Names come from both `hostname` and `scutil`, since an app asking Cocoa for the computer name can get something the POSIX hostname never contains. The check runs again once the tree is staged, so a write landing after the first check can't ride out on the commit. It reads untracked files whole, with no size cap. Skipping a large file would let the guard fail open.

## Follow-Up

If `user/settings.json` goes dirty again while the preference reads `0`, the app is ignoring its own opt-out. The quit-and-relaunch logic in `vibe-island.sh` becomes dead weight at that point. Remove it and let the revert stand as the sole defense.
