### PR TITLE
vibe-island: stub the platform in the revert spec

### DIFF
--- a/claude/spec/claude_upgrade_spec.sh
+++ b/claude/spec/claude_upgrade_spec.sh
@@ -480,6 +480,12 @@ Describe "revert_vibe_island_hook_rewrite"
       >"$revert_stub/osascript"
     chmod +x "$revert_stub/osascript"
 
+    # notify only reaches osascript on Darwin, and the Linux leg of CI runs
+    # these specs too. Stubbing the platform keeps the notification assertion
+    # testing the revert rather than the runner.
+    printf '#!/usr/bin/env bash\nprintf "Darwin\\n"\n' >"$revert_stub/uname"
+    chmod +x "$revert_stub/uname"
+
     printf '#!/usr/bin/env bash\n[ "$1" = log ] && printf "%%s\\n" "${@: -1}" >&2\nexit 0\n' \
       >"$revert_stub/gum"
     chmod +x "$revert_stub/gum"


### PR DESCRIPTION
The Linux leg of CI fails on `revert_vibe_island_hook_rewrite discards the rewrite and says so`. `notify` returns early off Darwin, so the `osascript` stub never runs and the assertion reads an empty log. The test was checking which runner it was on.

Stubs `uname` in the revert setup, matching what `scripts/spec/install_cask_variants_spec.sh` already does. Forcing the stub to report `Linux` reproduces the CI failure exactly, so the assertion now depends on the revert rather than the platform.

Follows #676, which merged before this fix reached it.
