### PR TITLE
herdr: add terminal-code and terminal-browser

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -157,6 +157,29 @@ type = "plugin_action"
 command = "mirror.remote-split-down"
 description = "remote: split down"
 
+# terminal-code (tode) and terminal-browser — a VS Code and a browser, each in
+# a right-hand split. Both ship a CLI on PATH (~/.local/bin, zsh/.zshenv) whose
+# `--split right` is what the plugin action shells out to, so these keys buy
+# reaching them without a shell prompt. prefix+b and prefix+c are herdr's
+# toggle_sidebar and new_tab, so both take the shift variant the same way the
+# file viewer and nvim do above.
+#
+# terminal-browser overlaps ogulcancelik/herdr-browser, which stays: that one
+# owns the link handler that opens a localhost URL from a pane, and this one
+# has the `terminal-browser action` CLI an agent drives. Nothing is bound to
+# herdr-browser, so they don't contend for a key.
+[[keys.command]]
+key = "prefix+shift+c"
+type = "plugin_action"
+command = "zenbu-labs.tode.open-split"
+description = "terminal-code (right split)"
+
+[[keys.command]]
+key = "prefix+shift+b"
+type = "plugin_action"
+command = "zenbu-labs.terminal-browser.open-split"
+description = "terminal-browser (right split)"
+
 [ui]
 agent_panel_sort = "priority"
 

--- a/herdr/plugins.list
+++ b/herdr/plugins.list
@@ -10,3 +10,12 @@ nikok6/herdr-mirror
 ogulcancelik/herdr-browser
 persiyanov/herdr-reviewr
 smarzban/herdr-file-viewer
+
+# The two zenbu-labs entries build by piping a vendor install script to bash,
+# which fetches a ~130MB tarball of a vendored Electron rather than compiling.
+# `update` reinstalls unpinned entries unconditionally, so each nightly upgrade
+# re-downloads both and takes about 35s. They stay unpinned anyway: the pin
+# would freeze the herdr manifest while the binary version comes from the
+# install endpoint, so pinning buys a stale plugin and no stable binary.
+zenbu-labs/terminal-browser/herdr-plugin
+zenbu-labs/terminal-code/herdr-plugin


### PR DESCRIPTION
Adds both zenbu-labs plugins to the declared set and binds each to a key:

- `prefix+shift+c` opens terminal-code in a right split
- `prefix+shift+b` opens terminal-browser

herdr's own `toggle_sidebar` and `new_tab` hold the unshifted keys. Both take the shift variant the file viewer and nvim bindings already use.

Both entries stay unpinned, which costs more here than elsewhere in the list. Each builds by piping a vendor install script to bash, pulling a ~130MB tarball of a vendored Electron. `herdr-lazy update` reinstalls unpinned entries unconditionally, and a reinstall measured at about 17s. The nightly upgrade grows by roughly 35s.

Pinning would not buy stability in exchange. A ref freezes the herdr manifest, while the binary version still comes from whatever `tode.sh/install` serves. That yields a stale plugin while the binary keeps moving.

`ogulcancelik/herdr-browser` stays alongside terminal-browser. It owns the link handler that opens a localhost URL from a pane. terminal-browser carries the `terminal-browser action` CLI an agent drives. Nothing is bound to herdr-browser, so the two never contend for a key.

Verified by loading the config into the running herdr server, which applied it with no diagnostics. Both actions register with `herdr plugin action list`, and both CLIs answer on `$PATH`. Their installers write to `~/.local/bin`, which `zsh/.zshenv` already puts there.

herdr's config parser accepts a plugin action it cannot resolve and refuses it at the keypress instead. So the action strings rest on the same `<plugin_id>.<action_id>` form as the working `chmarax.herdr-nvim.toggle` binding.

Installing terminal-browser has one effect outside this repo. Its installer symlinks a Claude Code skill into `~/.claude/skills`, leaving an untracked entry in the claude config repo.

https://claude.ai/code/session_01MoC5o3575jpiWazTw5Lpmn
