### PR TITLE
herdr: make remote mirroring opt-in

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -127,12 +127,35 @@ description = "worktree: switch / create (current branch)"
 
 # herdr-mirror mirrors a remote herdr server's workspaces and agents into the
 # local sidebar. Its hosts live in ~/.config/herdr-mirror/hosts.toml, untracked
-# because every entry is an ssh target. The daemon autostarts on workspace
-# focus, and the lifecycle actions (start, pause, teardown, status) are the same
-# subcommands of the herdr-mirror the install links into ~/.local/bin, so a key
-# buys them nothing. These four have no CLI equivalent worth typing: each takes
-# its host and cwd from the mirror it's invoked from, and degrades to the plain
-# local action outside one. Native key plus alt, so both sets stay reachable.
+# because every entry is an ssh target.
+#
+# That file also carries `autostart = false`, so focusing a workspace no longer
+# pulls the remote in. One sidebar holding both machines loses the separation
+# that makes the second machine useful: which agents are here and which are over
+# there stops being answerable at a glance, and the rows that scroll past are
+# mostly not the ones being worked on. Mirroring is per-sitting instead of
+# ambient, which is what the two keys below are for.
+#
+# teardown closes the local mirrors and nothing else. The remote panes and their
+# agents keep running, and start re-mirrors them from scratch. The rest of the
+# lifecycle (pause, status, once, restore) stays on the herdr-mirror the install
+# links into ~/.local/bin, where it reads fine as a typed command.
+[[keys.command]]
+key = "prefix+shift+m"
+type = "plugin_action"
+command = "mirror.start"
+description = "remote: mirror hosts into the sidebar"
+
+[[keys.command]]
+key = "prefix+alt+d"
+type = "plugin_action"
+command = "mirror.teardown"
+description = "remote: stop mirroring, close every mirror"
+
+# Creating objects on the remote. These four have no CLI equivalent worth
+# typing: each takes its host and cwd from the mirror it's invoked from, and
+# degrades to the plain local action outside one. Native key plus alt, so both
+# sets stay reachable.
 [[keys.command]]
 key = "prefix+alt+n"
 type = "plugin_action"


### PR DESCRIPTION
Mirroring a remote herdr server merged both machines' agents into one sidebar, and keeping the hosts separate turns out to be worth more than seeing everything at once. Which agents are here and which are over there stopped being answerable at a glance, and most of the rows that scrolled past were not the ones being worked on. herdr-mirror's `workspace.focused` hook runs `mirror ensure`, so the remote arrived without being asked for.

The switch that turns it off is `autostart = false` in `~/.config/herdr-mirror/hosts.toml`, which stays untracked because every host entry is an ssh target. Nothing in this diff changes behavior on a machine that has not set it, and a machine with no `hosts.toml` at all was never mirroring anyway.

What this adds is the way back in. `prefix+shift+m` starts the daemon and `prefix+alt+d` tears it down, both the keys the plugin's own README suggests. Teardown closes the local mirrors and leaves the remote alone: it wipes the host id map before closing any windows, so `close_remote_on_local_close` has nothing to attribute those closes to and the remote panes and their agents keep running. `start` re-mirrors from scratch.

`pause` stays off the keymap because it halts syncing while leaving the mirror rows in the sidebar, which is the thing being avoided here. `status`, `once`, and `restore` stay on the `herdr-mirror` the install links into `~/.local/bin`, where they read fine as typed commands.

Confirmed the flag against a throwaway `HOME`: with `autostart = false`, `ensure` starts nothing, and flipping it to `true` spawns the daemon.
